### PR TITLE
feat: put LLM features behind LLM_FEATURES_ENABLED env var (fixes #185)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -31,7 +31,12 @@ NEO4J_DATABASE=neo4j
 # Zettelkasten Authentication
 ADMIN_PASSKEY=  # Set this to enable persistent note creation (admin only)
 
-# Ollama Configuration (for AI features)
+# LLM Feature Flag (master switch for all AI/LLM features)
+# Default: false (off to save resources in production)
+# Set to true for local development with AI features
+LLM_FEATURES_ENABLED=true
+
+# Ollama Configuration (for AI features, only used when LLM_FEATURES_ENABLED=true)
 OLLAMA_HOST=http://localhost:11434
 OLLAMA_MODEL=llama3.2:latest
 OLLAMA_ENABLED=true

--- a/backend/config.py
+++ b/backend/config.py
@@ -50,6 +50,9 @@ class Settings(BaseSettings):
     static_articles_s3_bucket: str | None = None
     static_articles_s3_prefix: str = "articles/"
 
+    # LLM feature flag (master switch for all AI/LLM features)
+    llm_features_enabled: bool = False  # Default off to save resources in production
+
     # Ollama settings
     ollama_host: str = "http://localhost:11434"  # Default Ollama endpoint
     ollama_embed_model: str = "nomic-embed-text"  # Embedding model (small, fast, optimized)

--- a/backend/models/resource.py
+++ b/backend/models/resource.py
@@ -61,6 +61,7 @@ class StatusResponse(BaseModel):
     message: str
     version: str
     onepassword_enabled: bool  # Changed from "1password_enabled" for valid Python identifier
+    llm_features_enabled: bool = False  # Whether LLM/AI features are active
 
 
 class HealthResponse(BaseModel):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -7,6 +7,8 @@ from unittest.mock import MagicMock
 
 # Set TESTING environment variable BEFORE any imports
 os.environ["TESTING"] = "1"
+# Enable LLM features in tests so AI endpoints are registered
+os.environ["LLM_FEATURES_ENABLED"] = "true"
 
 import pytest
 from fastapi.testclient import TestClient

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -68,6 +68,7 @@ services:
       - NEO4J_PASSWORD=${NEO4J_PASSWORD:?NEO4J_PASSWORD must be set in production}
       - OLLAMA_HOST=http://ollama:11434
       - OLLAMA_ENABLED=true
+      - LLM_FEATURES_ENABLED=false
       - COMPOSE_FILE=docker-compose.prod.yml  # Enable prod backup path detection
     env_file:
       - ./backend/.env
@@ -101,6 +102,7 @@ services:
     environment:
       - NODE_ENV=production
       - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://localhost:8000}
+      - NEXT_PUBLIC_LLM_FEATURES_ENABLED=false
     depends_on:
       backend:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,7 @@ services:
       - NEO4J_PASSWORD=mongado-dev-password
       - OLLAMA_HOST=http://ollama:11434
       - OLLAMA_ENABLED=true
+      - LLM_FEATURES_ENABLED=true
     env_file:
       - ./backend/.env
     networks:
@@ -96,6 +97,7 @@ services:
       - /app/.next
     environment:
       - NEXT_PUBLIC_API_URL=http://localhost:8000
+      - NEXT_PUBLIC_LLM_FEATURES_ENABLED=true
       # NODE_ENV is automatically set by Next.js commands:
       # - 'npm run dev' sets NODE_ENV=development
       # - 'npm run build' sets NODE_ENV=production

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -2,6 +2,11 @@
 # Default: http://localhost:8000
 NEXT_PUBLIC_API_URL=http://localhost:8000
 
+# LLM Feature Flag (master switch for all AI/LLM features)
+# Default: false (off to save resources in production)
+# Set to "true" to enable AI features (Q&A, semantic search, suggestions)
+NEXT_PUBLIC_LLM_FEATURES_ENABLED=true
+
 # Allow unauthenticated users to use AI features
 # Default: true (allows visitors to try AI suggestions)
 # Set to "false" to restrict AI features to authenticated users only

--- a/frontend/src/app/knowledge-base/articles/[id]/page.tsx
+++ b/frontend/src/app/knowledge-base/articles/[id]/page.tsx
@@ -11,6 +11,7 @@ import Breadcrumb from "@/components/Breadcrumb";
 import Badge from "@/components/Badge";
 import { TagPillList } from "@/components/TagPill";
 import { logger } from "@/lib/logger";
+import { config } from "@/lib/config";
 import { sanitizeHtml } from "@/lib/sanitize";
 import styles from "./page.module.scss";
 
@@ -134,11 +135,15 @@ export default function ArticleDetailPage() {
 
   return (
     <div className={styles.container}>
-      {/* AI Panel */}
-      <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
+      {/* AI Panel (only when LLM features enabled) */}
+      {config.llmFeaturesEnabled && (
+        <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
+      )}
 
-      {/* AI Button */}
-      {!aiPanelOpen && <AIButton onClick={() => setAiPanelOpen(true)} />}
+      {/* AI Button (only when LLM features enabled) */}
+      {config.llmFeaturesEnabled && !aiPanelOpen && (
+        <AIButton onClick={() => setAiPanelOpen(true)} />
+      )}
 
       {/* Header */}
       <header className={styles.header}>

--- a/frontend/src/app/knowledge-base/articles/page.tsx
+++ b/frontend/src/app/knowledge-base/articles/page.tsx
@@ -10,6 +10,7 @@ import AIPanel from "@/components/AIPanel";
 import AIButton from "@/components/AIButton";
 import Breadcrumb from "@/components/Breadcrumb";
 import { TagPillList } from "@/components/TagPill";
+import { config } from "@/lib/config";
 import styles from "./page.module.scss";
 
 interface ArticleMetadata {
@@ -154,11 +155,15 @@ function ArticlesContent() {
 
   return (
     <div className={styles.container}>
-      {/* AI Panel */}
-      <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
+      {/* AI Panel (only when LLM features enabled) */}
+      {config.llmFeaturesEnabled && (
+        <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
+      )}
 
-      {/* AI Button */}
-      {!aiPanelOpen && <AIButton onClick={() => setAiPanelOpen(true)} />}
+      {/* AI Button (only when LLM features enabled) */}
+      {config.llmFeaturesEnabled && !aiPanelOpen && (
+        <AIButton onClick={() => setAiPanelOpen(true)} />
+      )}
 
       {/* Header */}
       <header className={styles.header}>

--- a/frontend/src/app/knowledge-base/notes/[id]/page.tsx
+++ b/frontend/src/app/knowledge-base/notes/[id]/page.tsx
@@ -35,8 +35,9 @@ export default function NoteDetailPage() {
   const { settings } = useSettings();
 
   // Check if AI features should be available
-  // AI is available if: user is authenticated OR unauthenticated AI is allowed
-  const aiAvailable = isAuthenticated() || config.allowUnauthenticatedAI;
+  // AI is available if: LLM features enabled AND (user is authenticated OR unauthenticated AI is allowed)
+  const aiAvailable =
+    config.llmFeaturesEnabled && (isAuthenticated() || config.allowUnauthenticatedAI);
 
   const [note, setNote] = useState<Note | null>(null);
   const [backlinks, setBacklinks] = useState<Note[]>([]);
@@ -362,11 +363,15 @@ export default function NoteDetailPage() {
 
   return (
     <div className={styles.container}>
-      {/* AI Panel */}
-      <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
+      {/* AI Panel (only when LLM features enabled) */}
+      {config.llmFeaturesEnabled && (
+        <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
+      )}
 
-      {/* AI Button */}
-      {!aiPanelOpen && <AIButton onClick={() => setAiPanelOpen(true)} />}
+      {/* AI Button (only when LLM features enabled) */}
+      {config.llmFeaturesEnabled && !aiPanelOpen && (
+        <AIButton onClick={() => setAiPanelOpen(true)} />
+      )}
 
       <div className={styles.main}>
         <div className={styles.contentGrid}>
@@ -671,13 +676,15 @@ export default function NoteDetailPage() {
         </div>
       )}
 
-      {/* Post-Save AI Suggestions Modal */}
-      <PostSaveAISuggestions
-        noteId={noteId}
-        isOpen={showPostSaveSuggestions}
-        onClose={handleCloseSuggestions}
-        onInsertLink={handleInsertLinkFromSuggestion}
-      />
+      {/* Post-Save AI Suggestions Modal (only when LLM features enabled) */}
+      {config.llmFeaturesEnabled && (
+        <PostSaveAISuggestions
+          noteId={noteId}
+          isOpen={showPostSaveSuggestions}
+          onClose={handleCloseSuggestions}
+          onInsertLink={handleInsertLinkFromSuggestion}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/app/knowledge-base/notes/new/page.tsx
+++ b/frontend/src/app/knowledge-base/notes/new/page.tsx
@@ -57,7 +57,9 @@ function NewNoteContent() {
 
   // Check authentication status after hydration (client-side only)
   useEffect(() => {
-    setAiAvailable(isAuthenticated() || config.allowUnauthenticatedAI);
+    setAiAvailable(
+      config.llmFeaturesEnabled && (isAuthenticated() || config.allowUnauthenticatedAI)
+    );
   }, []);
 
   // Load draft from localStorage on mount, or pre-fill from URL params (e.g., from article)
@@ -343,11 +345,15 @@ function NewNoteContent() {
 
   return (
     <div className={styles.container}>
-      {/* AI Panel */}
-      <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
+      {/* AI Panel (only when LLM features enabled) */}
+      {config.llmFeaturesEnabled && (
+        <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
+      )}
 
-      {/* AI Button */}
-      {!aiPanelOpen && <AIButton onClick={() => setAiPanelOpen(true)} />}
+      {/* AI Button (only when LLM features enabled) */}
+      {config.llmFeaturesEnabled && !aiPanelOpen && (
+        <AIButton onClick={() => setAiPanelOpen(true)} />
+      )}
 
       <div className={styles.main}>
         {/* Header */}
@@ -666,8 +672,8 @@ function NewNoteContent() {
         </div>
       )}
 
-      {/* Post-Save AI Suggestions Modal */}
-      {savedNoteId && (
+      {/* Post-Save AI Suggestions Modal (only when LLM features enabled) */}
+      {config.llmFeaturesEnabled && savedNoteId && (
         <PostSaveAISuggestions
           noteId={savedNoteId}
           isOpen={showPostSaveSuggestions}

--- a/frontend/src/app/knowledge-base/notes/page.tsx
+++ b/frontend/src/app/knowledge-base/notes/page.tsx
@@ -12,6 +12,7 @@ import Breadcrumb from "@/components/Breadcrumb";
 import { TagPillList } from "@/components/TagPill";
 import QuickLists from "@/components/QuickLists/QuickLists";
 import NoteOfDay from "@/components/NoteOfDay/NoteOfDay";
+import { config } from "@/lib/config";
 import styles from "./page.module.scss";
 
 type SortOption = "newest" | "oldest" | "alphabetical";
@@ -219,11 +220,15 @@ function NotesContent() {
 
   return (
     <div className={styles.container}>
-      {/* AI Panel */}
-      <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
+      {/* AI Panel (only when LLM features enabled) */}
+      {config.llmFeaturesEnabled && (
+        <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
+      )}
 
-      {/* AI Button */}
-      {!aiPanelOpen && <AIButton onClick={() => setAiPanelOpen(true)} />}
+      {/* AI Button (only when LLM features enabled) */}
+      {config.llmFeaturesEnabled && !aiPanelOpen && (
+        <AIButton onClick={() => setAiPanelOpen(true)} />
+      )}
 
       {/* Header */}
       <div className={styles.header}>

--- a/frontend/src/app/knowledge-base/page.tsx
+++ b/frontend/src/app/knowledge-base/page.tsx
@@ -6,6 +6,7 @@ import AIPanel from "@/components/AIPanel";
 import AIButton from "@/components/AIButton";
 import Badge from "@/components/Badge";
 import { logger } from "@/lib/logger";
+import { config } from "@/lib/config";
 import styles from "./page.module.scss";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -128,11 +129,15 @@ export default function KnowledgeBasePage() {
 
   return (
     <div className={styles.container}>
-      {/* AI Panel */}
-      <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
+      {/* AI Panel (only when LLM features enabled) */}
+      {config.llmFeaturesEnabled && (
+        <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
+      )}
 
-      {/* AI Button */}
-      {!aiPanelOpen && <AIButton onClick={() => setAiPanelOpen(true)} />}
+      {/* AI Button (only when LLM features enabled) */}
+      {config.llmFeaturesEnabled && !aiPanelOpen && (
+        <AIButton onClick={() => setAiPanelOpen(true)} />
+      )}
 
       {/* Header */}
       <header className={styles.header}>
@@ -170,8 +175,9 @@ export default function KnowledgeBasePage() {
             </div>
           </form>
           <p className={styles.searchHint}>
-            Live search enabled - results appear as you type. For AI-powered semantic search, use
-            the AI Assistant.
+            Live search enabled - results appear as you type.
+            {config.llmFeaturesEnabled &&
+              " For AI-powered semantic search, use the AI Assistant."}
           </p>
 
           {/* Search Error */}

--- a/frontend/src/app/knowledge-base/page.tsx
+++ b/frontend/src/app/knowledge-base/page.tsx
@@ -176,8 +176,7 @@ export default function KnowledgeBasePage() {
           </form>
           <p className={styles.searchHint}>
             Live search enabled - results appear as you type.
-            {config.llmFeaturesEnabled &&
-              " For AI-powered semantic search, use the AI Assistant."}
+            {config.llmFeaturesEnabled && " For AI-powered semantic search, use the AI Assistant."}
           </p>
 
           {/* Search Error */}

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -15,6 +15,7 @@ import { useState, useRef, useEffect } from "react";
 import { useUserPreferences } from "@/hooks/useUserPreferences";
 import type { AiMode } from "@/lib/settings";
 import { logger } from "@/lib/logger";
+import { config } from "@/lib/config";
 import styles from "./Settings.module.scss";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -88,51 +89,59 @@ export default function Settings() {
           <div className={styles.dropdownContent}>
             {/* AI Assistance Section */}
             <div className={styles.section}>
-              {isWarmingUp && <div className={styles.warmupIndicator}>Warming up...</div>}
+              {config.llmFeaturesEnabled ? (
+                <>
+                  {isWarmingUp && <div className={styles.warmupIndicator}>Warming up...</div>}
 
-              {/* Segmented Control */}
-              <div className={styles.segmentedControl}>
-                <button
-                  onClick={() => handleModeChange("off")}
-                  className={`${styles.segmentButton} ${preferences.aiMode === "off" ? styles.active : styles.inactive}`}
-                  title="No AI suggestions"
-                >
-                  Off
-                </button>
-                <button
-                  onClick={() => handleModeChange("on-demand")}
-                  className={`${styles.segmentButton} ${preferences.aiMode === "on-demand" ? styles.active : styles.inactive}`}
-                  title="Click to get AI suggestions"
-                >
-                  On-demand
-                </button>
-                <button
-                  onClick={() => handleModeChange("real-time")}
-                  className={`${styles.segmentButton} ${preferences.aiMode === "real-time" ? styles.active : styles.inactive}`}
-                  title="Automatic AI suggestions"
-                >
-                  Automatic
-                </button>
-              </div>
+                  {/* Segmented Control */}
+                  <div className={styles.segmentedControl}>
+                    <button
+                      onClick={() => handleModeChange("off")}
+                      className={`${styles.segmentButton} ${preferences.aiMode === "off" ? styles.active : styles.inactive}`}
+                      title="No AI suggestions"
+                    >
+                      Off
+                    </button>
+                    <button
+                      onClick={() => handleModeChange("on-demand")}
+                      className={`${styles.segmentButton} ${preferences.aiMode === "on-demand" ? styles.active : styles.inactive}`}
+                      title="Click to get AI suggestions"
+                    >
+                      On-demand
+                    </button>
+                    <button
+                      onClick={() => handleModeChange("real-time")}
+                      className={`${styles.segmentButton} ${preferences.aiMode === "real-time" ? styles.active : styles.inactive}`}
+                      title="Automatic AI suggestions"
+                    >
+                      Automatic
+                    </button>
+                  </div>
 
-              {/* Mode descriptions */}
-              <div className={styles.modeDescription}>
-                {preferences.aiMode === "off" && (
-                  <p>No AI suggestions. Fast, minimal overhead. Pure Zettelkasten experience.</p>
-                )}
-                {preferences.aiMode === "on-demand" && (
-                  <p>
-                    Click &quot;Get Suggestions&quot; when you want AI help. Balanced approach with
-                    no overhead while writing.
-                  </p>
-                )}
-                {preferences.aiMode === "real-time" && (
-                  <p>
-                    Automatically generate suggestions in the background as you type. Panel stays
-                    collapsed until you open it.
-                  </p>
-                )}
-              </div>
+                  {/* Mode descriptions */}
+                  <div className={styles.modeDescription}>
+                    {preferences.aiMode === "off" && (
+                      <p>No AI suggestions. Fast, minimal overhead. Pure Zettelkasten experience.</p>
+                    )}
+                    {preferences.aiMode === "on-demand" && (
+                      <p>
+                        Click &quot;Get Suggestions&quot; when you want AI help. Balanced approach with
+                        no overhead while writing.
+                      </p>
+                    )}
+                    {preferences.aiMode === "real-time" && (
+                      <p>
+                        Automatically generate suggestions in the background as you type. Panel stays
+                        collapsed until you open it.
+                      </p>
+                    )}
+                  </div>
+                </>
+              ) : (
+                <div className={styles.modeDescription}>
+                  <p>AI features are not available in this environment.</p>
+                </div>
+              )}
             </div>
 
             {/* Future sections can be added here:

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -121,18 +121,20 @@ export default function Settings() {
                   {/* Mode descriptions */}
                   <div className={styles.modeDescription}>
                     {preferences.aiMode === "off" && (
-                      <p>No AI suggestions. Fast, minimal overhead. Pure Zettelkasten experience.</p>
+                      <p>
+                        No AI suggestions. Fast, minimal overhead. Pure Zettelkasten experience.
+                      </p>
                     )}
                     {preferences.aiMode === "on-demand" && (
                       <p>
-                        Click &quot;Get Suggestions&quot; when you want AI help. Balanced approach with
-                        no overhead while writing.
+                        Click &quot;Get Suggestions&quot; when you want AI help. Balanced approach
+                        with no overhead while writing.
                       </p>
                     )}
                     {preferences.aiMode === "real-time" && (
                       <p>
-                        Automatically generate suggestions in the background as you type. Panel stays
-                        collapsed until you open it.
+                        Automatically generate suggestions in the background as you type. Panel
+                        stays collapsed until you open it.
                       </p>
                     )}
                   </div>

--- a/frontend/src/components/SettingsDropdown.tsx
+++ b/frontend/src/components/SettingsDropdown.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { useSettings } from "@/hooks/useSettings";
 import type { AiMode } from "@/lib/settings";
 import { logger } from "@/lib/logger";
+import { config } from "@/lib/config";
 import { isAuthenticated, clearAdminToken } from "@/lib/api/client";
 import styles from "./SettingsDropdown.module.scss";
 
@@ -106,51 +107,59 @@ export default function SettingsDropdown() {
         {isOpen && (
           <div className={styles.dropdown}>
             <div className={styles.dropdownContent}>
-              <div className={styles.header}>
-                <h3 className={styles.title}>AI Suggestions</h3>
-                {isWarmingUp && <span className={styles.warmupIndicator}>Warming up...</span>}
-              </div>
+              {config.llmFeaturesEnabled ? (
+                <>
+                  <div className={styles.header}>
+                    <h3 className={styles.title}>AI Suggestions</h3>
+                    {isWarmingUp && <span className={styles.warmupIndicator}>Warming up...</span>}
+                  </div>
 
-              {/* Segmented Control */}
-              <div className={styles.segmentedControl}>
-                <button
-                  onClick={() => handleModeChange("off")}
-                  className={`${styles.segmentButton} ${settings.aiMode === "off" ? styles.active : styles.inactive}`}
-                >
-                  Off
-                </button>
-                <button
-                  onClick={() => handleModeChange("on-demand")}
-                  className={`${styles.segmentButton} ${settings.aiMode === "on-demand" ? styles.active : styles.inactive}`}
-                >
-                  On-demand
-                </button>
-                <button
-                  onClick={() => handleModeChange("real-time")}
-                  className={`${styles.segmentButton} ${settings.aiMode === "real-time" ? styles.active : styles.inactive}`}
-                >
-                  Automatic
-                </button>
-              </div>
+                  {/* Segmented Control */}
+                  <div className={styles.segmentedControl}>
+                    <button
+                      onClick={() => handleModeChange("off")}
+                      className={`${styles.segmentButton} ${settings.aiMode === "off" ? styles.active : styles.inactive}`}
+                    >
+                      Off
+                    </button>
+                    <button
+                      onClick={() => handleModeChange("on-demand")}
+                      className={`${styles.segmentButton} ${settings.aiMode === "on-demand" ? styles.active : styles.inactive}`}
+                    >
+                      On-demand
+                    </button>
+                    <button
+                      onClick={() => handleModeChange("real-time")}
+                      className={`${styles.segmentButton} ${settings.aiMode === "real-time" ? styles.active : styles.inactive}`}
+                    >
+                      Automatic
+                    </button>
+                  </div>
 
-              {/* Mode descriptions */}
-              <div className={styles.modeDescription}>
-                {settings.aiMode === "off" && (
-                  <p>No AI suggestions. Fast, minimal overhead. Pure Zettelkasten experience.</p>
-                )}
-                {settings.aiMode === "on-demand" && (
-                  <p>
-                    Click &quot;Get Suggestions&quot; when you want AI help. Balanced approach with
-                    no overhead while writing.
-                  </p>
-                )}
-                {settings.aiMode === "real-time" && (
-                  <p>
-                    Automatically generate suggestions in the background as you type. Panel stays
-                    collapsed until you open it.
-                  </p>
-                )}
-              </div>
+                  {/* Mode descriptions */}
+                  <div className={styles.modeDescription}>
+                    {settings.aiMode === "off" && (
+                      <p>No AI suggestions. Fast, minimal overhead. Pure Zettelkasten experience.</p>
+                    )}
+                    {settings.aiMode === "on-demand" && (
+                      <p>
+                        Click &quot;Get Suggestions&quot; when you want AI help. Balanced approach with
+                        no overhead while writing.
+                      </p>
+                    )}
+                    {settings.aiMode === "real-time" && (
+                      <p>
+                        Automatically generate suggestions in the background as you type. Panel stays
+                        collapsed until you open it.
+                      </p>
+                    )}
+                  </div>
+                </>
+              ) : (
+                <div className={styles.modeDescription}>
+                  <p>AI features are not available in this environment.</p>
+                </div>
+              )}
 
               {/* Logout section */}
               {isUserAuthenticated && (

--- a/frontend/src/components/SettingsDropdown.tsx
+++ b/frontend/src/components/SettingsDropdown.tsx
@@ -139,18 +139,20 @@ export default function SettingsDropdown() {
                   {/* Mode descriptions */}
                   <div className={styles.modeDescription}>
                     {settings.aiMode === "off" && (
-                      <p>No AI suggestions. Fast, minimal overhead. Pure Zettelkasten experience.</p>
+                      <p>
+                        No AI suggestions. Fast, minimal overhead. Pure Zettelkasten experience.
+                      </p>
                     )}
                     {settings.aiMode === "on-demand" && (
                       <p>
-                        Click &quot;Get Suggestions&quot; when you want AI help. Balanced approach with
-                        no overhead while writing.
+                        Click &quot;Get Suggestions&quot; when you want AI help. Balanced approach
+                        with no overhead while writing.
                       </p>
                     )}
                     {settings.aiMode === "real-time" && (
                       <p>
-                        Automatically generate suggestions in the background as you type. Panel stays
-                        collapsed until you open it.
+                        Automatically generate suggestions in the background as you type. Panel
+                        stays collapsed until you open it.
                       </p>
                     )}
                   </div>

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -10,6 +10,13 @@ export const config = {
   apiUrl: process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000",
 
   /**
+   * Master switch for LLM/AI features
+   * Default: false (off to save resources in production)
+   * Set to "true" to enable AI features (Q&A, semantic search, suggestions)
+   */
+  llmFeaturesEnabled: process.env.NEXT_PUBLIC_LLM_FEATURES_ENABLED === "true",
+
+  /**
    * Allow unauthenticated users to use AI features
    * Default: true (allows visitors to try AI suggestions)
    * Set to "false" to restrict AI features to authenticated users only


### PR DESCRIPTION
Add master switch for all AI/LLM features that defaults to off, allowing
production to run without Ollama overhead on a smaller droplet while
keeping AI features available in local dev.

Backend:
- Add LLM_FEATURES_ENABLED setting (default: false) to config.py
- Conditionally import/register AI router only when enabled
- Skip Ollama client initialization when disabled
- Skip embedding sync when disabled
- Guard admin sync-embeddings endpoint
- Force text search when semantic requested but LLM disabled
- Expose llm_features_enabled in status response for frontend
- Set LLM_FEATURES_ENABLED=true in test conftest

Frontend:
- Add NEXT_PUBLIC_LLM_FEATURES_ENABLED to config.ts (default: false)
- Gate AIPanel, AIButton, AISuggestionsPanel, PostSaveAISuggestions
  behind the feature flag across all pages
- Hide AI mode selector in Settings/SettingsDropdown when disabled
- Hide semantic search hint when disabled
- Include llmFeaturesEnabled in aiAvailable check

Docker:
- Set LLM_FEATURES_ENABLED=true in docker-compose.yml (dev)
- Set LLM_FEATURES_ENABLED=false in docker-compose.prod.yml
- Set NEXT_PUBLIC_LLM_FEATURES_ENABLED for frontend in both

https://claude.ai/code/session_01ESoAAm5YbRk8oLyenTrXBF