### PR TITLE
feat: runtime feature flags with admin UI (fixes #188)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -31,12 +31,11 @@ NEO4J_DATABASE=neo4j
 # Zettelkasten Authentication
 ADMIN_PASSKEY=  # Set this to enable persistent note creation (admin only)
 
-# LLM Feature Flag (master switch for all AI/LLM features)
-# Default: false (off to save resources in production)
-# Set to true for local development with AI features
+# LLM feature flag SEED DEFAULT only. Runtime control lives in the admin UI
+# (/admin) and is persisted in Neo4j - once toggled there, this env var is ignored.
 LLM_FEATURES_ENABLED=true
 
-# Ollama Configuration (for AI features, only used when LLM_FEATURES_ENABLED=true)
+# Ollama Configuration (for AI features, only used when LLM features are enabled)
 OLLAMA_HOST=http://localhost:11434
 OLLAMA_MODEL=llama3.2:latest
 OLLAMA_ENABLED=true

--- a/backend/adapters/neo4j.py
+++ b/backend/adapters/neo4j.py
@@ -777,6 +777,43 @@ class Neo4jAdapter:
             record = result.single()
             return record["count"] if record else 0
 
+    def get_feature_flags(self) -> dict[str, bool]:
+        """Get all persisted feature flags.
+
+        Returns:
+            Mapping of flag name to enabled state (empty if unavailable)
+        """
+        if not self._available or not self.driver:
+            return {}
+
+        with self.driver.session(database=self.database) as session:
+            result = session.run("MATCH (f:FeatureFlag) RETURN f.name AS name, f.enabled AS enabled")
+            return {record["name"]: bool(record["enabled"]) for record in result}
+
+    def set_feature_flag(self, name: str, enabled: bool) -> bool:
+        """Persist a feature flag value (upsert).
+
+        Args:
+            name: Flag name
+            enabled: Whether the flag is enabled
+
+        Returns:
+            True if persisted, False if Neo4j unavailable
+        """
+        if not self._available or not self.driver:
+            return False
+
+        with self.driver.session(database=self.database) as session:
+            session.run(
+                """
+                MERGE (f:FeatureFlag {name: $name})
+                SET f.enabled = $enabled, f.updated_at = datetime()
+                """,
+                name=name,
+                enabled=enabled,
+            )
+            return True
+
     def get_all_note_ids(self) -> set[str]:
         """Get all note IDs (for collision detection).
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -50,7 +50,9 @@ class Settings(BaseSettings):
     static_articles_s3_bucket: str | None = None
     static_articles_s3_prefix: str = "articles/"
 
-    # LLM feature flag (master switch for all AI/LLM features)
+    # LLM feature flag seed default. Only used when the flag has never been
+    # toggled via the admin UI (/api/admin/feature-flags) - the persisted
+    # value in Neo4j always wins over this setting.
     llm_features_enabled: bool = False  # Default off to save resources in production
 
     # Ollama settings

--- a/backend/feature_flags.py
+++ b/backend/feature_flags.py
@@ -6,6 +6,7 @@ provide the default when a flag has never been set.
 """
 
 import logging
+import time
 from dataclasses import dataclass
 
 from fastapi import HTTPException
@@ -39,21 +40,25 @@ def _flag_definitions() -> dict[str, FlagDefinition]:
 
 
 class FeatureFlagService:
-    """Read/write feature flags with an in-memory cache over Neo4j.
+    """Read/write feature flags with a TTL cache over Neo4j.
 
-    The cache is loaded lazily on first read and kept authoritative for the
-    process lifetime (only the admin API mutates flags, and this is a
-    single-process app).
+    Production runs multiple uvicorn workers, each with its own service
+    instance. A toggle lands on one worker; the others pick up the new
+    value from Neo4j when their cache expires (within CACHE_TTL_SECONDS).
     """
+
+    CACHE_TTL_SECONDS = 15.0
 
     def __init__(self, neo4j: Neo4jAdapter) -> None:
         self.neo4j = neo4j
         self.definitions = _flag_definitions()
         self._cache: dict[str, bool] | None = None
+        self._loaded_at: float = 0.0
 
     def _load(self) -> dict[str, bool]:
-        """Load flags: persisted values override defaults."""
-        if self._cache is None:
+        """Load flags: persisted values override defaults. Reloads after TTL."""
+        now = time.monotonic()
+        if self._cache is None or now - self._loaded_at >= self.CACHE_TTL_SECONDS:
             flags = {name: d.default for name, d in self.definitions.items()}
             try:
                 persisted = self.neo4j.get_feature_flags()
@@ -64,6 +69,7 @@ class FeatureFlagService:
                 if name in flags:
                     flags[name] = enabled
             self._cache = flags
+            self._loaded_at = now
         return self._cache
 
     def is_enabled(self, name: str) -> bool:
@@ -90,12 +96,16 @@ class FeatureFlagService:
         """
         if name not in self.definitions:
             raise KeyError(name)
-        persisted = self.neo4j.set_feature_flag(name, enabled)
+        try:
+            persisted = self.neo4j.set_feature_flag(name, enabled)
+        except Exception as e:
+            logger.error("Failed to persist feature flag '%s' to Neo4j: %s", name, e)
+            persisted = False
         self._load()[name] = enabled
         if not persisted:
             logger.warning(
                 "Feature flag '%s' set in memory only - Neo4j unavailable, "
-                "value will reset on restart",
+                "value will revert when the cache expires or the app restarts",
                 name,
             )
         return persisted
@@ -103,6 +113,7 @@ class FeatureFlagService:
     def reset_cache(self) -> None:
         """Clear the in-memory cache (reloads from Neo4j on next read)."""
         self._cache = None
+        self._loaded_at = 0.0
 
 
 _service: FeatureFlagService | None = None

--- a/backend/feature_flags.py
+++ b/backend/feature_flags.py
@@ -1,0 +1,125 @@
+"""Runtime feature flags backed by Neo4j.
+
+Flags are toggled at runtime via the admin API (/api/admin/feature-flags)
+and persisted as FeatureFlag nodes in Neo4j. Environment settings only
+provide the default when a flag has never been set.
+"""
+
+import logging
+from dataclasses import dataclass
+
+from fastapi import HTTPException
+
+from adapters.neo4j import Neo4jAdapter, get_neo4j_adapter
+from config import get_settings
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class FlagDefinition:
+    """A known feature flag with its metadata and default value."""
+
+    name: str
+    description: str
+    default: bool
+
+
+def _flag_definitions() -> dict[str, FlagDefinition]:
+    """Build the registry of known flags (defaults come from settings)."""
+    settings = get_settings()
+    definitions = [
+        FlagDefinition(
+            name="llm_features",
+            description="AI/LLM features: semantic search, Q&A, summaries, link suggestions",
+            default=settings.llm_features_enabled,
+        ),
+    ]
+    return {d.name: d for d in definitions}
+
+
+class FeatureFlagService:
+    """Read/write feature flags with an in-memory cache over Neo4j.
+
+    The cache is loaded lazily on first read and kept authoritative for the
+    process lifetime (only the admin API mutates flags, and this is a
+    single-process app).
+    """
+
+    def __init__(self, neo4j: Neo4jAdapter) -> None:
+        self.neo4j = neo4j
+        self.definitions = _flag_definitions()
+        self._cache: dict[str, bool] | None = None
+
+    def _load(self) -> dict[str, bool]:
+        """Load flags: persisted values override defaults."""
+        if self._cache is None:
+            flags = {name: d.default for name, d in self.definitions.items()}
+            try:
+                persisted = self.neo4j.get_feature_flags()
+            except Exception as e:
+                logger.warning("Failed to load feature flags from Neo4j: %s", e)
+                persisted = {}
+            for name, enabled in persisted.items():
+                if name in flags:
+                    flags[name] = enabled
+            self._cache = flags
+        return self._cache
+
+    def is_enabled(self, name: str) -> bool:
+        """Check whether a flag is enabled (defaults win if never persisted)."""
+        return self._load().get(name, False)
+
+    def all_flags(self) -> dict[str, bool]:
+        """Get all known flags and their current values."""
+        return dict(self._load())
+
+    def set_flag(self, name: str, enabled: bool) -> bool:
+        """Set a flag value, persisting to Neo4j.
+
+        Args:
+            name: Flag name (must be a known flag)
+            enabled: New value
+
+        Returns:
+            True if persisted to Neo4j, False if only set in memory
+            (Neo4j unavailable - value is lost on restart)
+
+        Raises:
+            KeyError: If the flag name is not a known flag
+        """
+        if name not in self.definitions:
+            raise KeyError(name)
+        persisted = self.neo4j.set_feature_flag(name, enabled)
+        self._load()[name] = enabled
+        if not persisted:
+            logger.warning(
+                "Feature flag '%s' set in memory only - Neo4j unavailable, "
+                "value will reset on restart",
+                name,
+            )
+        return persisted
+
+    def reset_cache(self) -> None:
+        """Clear the in-memory cache (reloads from Neo4j on next read)."""
+        self._cache = None
+
+
+_service: FeatureFlagService | None = None
+
+
+def get_feature_flags() -> FeatureFlagService:
+    """Get the global feature flag service (dependency-injectable in tests)."""
+    global _service
+    if _service is None:
+        _service = FeatureFlagService(get_neo4j_adapter())
+    return _service
+
+
+def require_llm_features() -> None:
+    """FastAPI dependency: reject the request when LLM features are disabled."""
+    if not get_feature_flags().is_enabled("llm_features"):
+        raise HTTPException(
+            status_code=503,
+            detail="LLM features are disabled. An admin can enable them at /api/admin/feature-flags.",
+        )

--- a/backend/main.py
+++ b/backend/main.py
@@ -21,6 +21,7 @@ from adapters.neo4j import get_neo4j_adapter
 from auth import verify_admin
 from config import SecretManager, Settings, get_secret_manager, get_settings
 from dependencies import get_neo4j, get_ollama, set_static_articles, set_user_resources
+from feature_flags import get_feature_flags, require_llm_features
 from image_optimizer import optimize_image_to_webp
 from logging_config import setup_logging
 from models import (
@@ -33,6 +34,7 @@ from models import (
 from notes_service import get_notes_service
 from rate_limiter import RATE_LIMITS, limiter
 from routers.admin import create_admin_router
+from routers.ai import router as ai_router
 from routers.articles import router as articles_router
 from routers.inspire import router as inspire_router
 from routers.notes import router as notes_router
@@ -49,16 +51,8 @@ secret_manager: SecretManager = get_secret_manager()
 neo4j_adapter = get_neo4j_adapter()
 notes_service = get_notes_service()
 
-# Only initialize Ollama when LLM features are enabled
-if settings.llm_features_enabled:
-    from embedding_sync import sync_embeddings_on_startup
-    from ollama_client import get_ollama_client
-    from routers.ai import router as ai_router
-
-    ollama_client = get_ollama_client()
-else:
-    ollama_client = None
-    logger.info("LLM features disabled (LLM_FEATURES_ENABLED=false)")
+# LLM features are gated at runtime via feature flags (see feature_flags.py).
+# The Ollama client is created lazily on first use (dependencies.get_ollama).
 
 # Static articles (loaded from files/S3, read-only)
 static_articles: list[dict[str, Any]] = []
@@ -76,10 +70,12 @@ async def _sync_embeddings_background() -> None:
     global _embedding_sync_ready
 
     try:
+        from embedding_sync import sync_embeddings_on_startup
+
         # Run the sync in a thread pool (it's blocking I/O)
         loop = asyncio.get_event_loop()
         await loop.run_in_executor(
-            None, sync_embeddings_on_startup, static_articles, ollama_client, neo4j_adapter
+            None, sync_embeddings_on_startup, static_articles, get_ollama(), neo4j_adapter
         )
         _embedding_sync_ready = True
         logger.info("Background embedding sync completed - app is fully ready")
@@ -135,8 +131,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     _auto_seed_notes_if_empty()
 
     # Conditionally start embedding sync in background (non-blocking)
-    if not settings.llm_features_enabled:
-        logger.info("Skipping embedding sync (LLM_FEATURES_ENABLED=false)")
+    if not get_feature_flags().is_enabled("llm_features"):
+        logger.info("Skipping embedding sync (llm_features flag disabled)")
         _embedding_sync_ready = True
     elif settings.sync_embeddings_on_startup:
         logger.info("Starting background embedding sync (SYNC_EMBEDDINGS_ON_STARTUP=true)...")
@@ -287,8 +283,8 @@ app.add_middleware(CacheControlMiddleware)
 
 # Create and include domain routers
 # AI, Notes, Search, and Articles routers use FastAPI Depends() - no factory needed
-if settings.llm_features_enabled:
-    app.include_router(ai_router)
+# AI endpoints return 503 when the llm_features flag is disabled
+app.include_router(ai_router, dependencies=[Depends(require_llm_features)])
 app.include_router(inspire_router)
 app.include_router(notes_router)
 app.include_router(search_router)
@@ -332,7 +328,7 @@ def read_root() -> StatusResponse:
         message=settings.app_name,
         version=settings.app_version,
         onepassword_enabled=secret_manager.is_available(),
-        llm_features_enabled=settings.llm_features_enabled,
+        llm_features_enabled=get_feature_flags().is_enabled("llm_features"),
     )
 
 
@@ -523,9 +519,11 @@ def trigger_embedding_sync(
 
     Requires authentication via Bearer token in Authorization header.
     """
-    if not settings.llm_features_enabled:
+    if not get_feature_flags().is_enabled("llm_features"):
         return EmbeddingSyncResponse(
-            success=False, message="LLM features are disabled (LLM_FEATURES_ENABLED=false)", stats=None
+            success=False,
+            message="LLM features are disabled (enable via /api/admin/feature-flags)",
+            stats=None,
         )
 
     if not neo4j.is_available():

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -5,6 +5,10 @@ from models.admin import (
     BackupInfo,
     BackupListResponse,
     DatabaseHealthResponse,
+    FeatureFlagInfo,
+    FeatureFlagsResponse,
+    FeatureFlagUpdateRequest,
+    FeatureFlagUpdateResponse,
     RestoreRequest,
     RestoreResponse,
 )
@@ -50,6 +54,10 @@ __all__ = [
     "BackupInfo",
     "BackupListResponse",
     "DatabaseHealthResponse",
+    "FeatureFlagInfo",
+    "FeatureFlagsResponse",
+    "FeatureFlagUpdateRequest",
+    "FeatureFlagUpdateResponse",
     "RestoreRequest",
     "RestoreResponse",
     # AI models

--- a/backend/models/admin.py
+++ b/backend/models/admin.py
@@ -82,6 +82,35 @@ class RestoreResponse(BaseModel):
     notes_after: int | None = Field(None, description="Note count after restore")
 
 
+class FeatureFlagInfo(BaseModel):
+    """A single feature flag with its current state."""
+
+    name: str = Field(..., description="Flag name (e.g., 'llm_features')")
+    enabled: bool = Field(..., description="Whether the flag is currently enabled")
+    description: str = Field(..., description="What the flag controls")
+
+
+class FeatureFlagsResponse(BaseModel):
+    """Response listing all feature flags."""
+
+    flags: list[FeatureFlagInfo] = Field(..., description="All known feature flags")
+
+
+class FeatureFlagUpdateRequest(BaseModel):
+    """Request to update a feature flag."""
+
+    enabled: bool = Field(..., description="New value for the flag")
+
+
+class FeatureFlagUpdateResponse(BaseModel):
+    """Response after updating a feature flag."""
+
+    flag: FeatureFlagInfo = Field(..., description="The updated flag")
+    persisted: bool = Field(
+        ..., description="False if Neo4j was unavailable (value resets on restart)"
+    )
+
+
 class DatabaseHealthResponse(BaseModel):
     """Response for database health check."""
 

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -7,14 +7,19 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Response
 
 from auth import AdminUser
+from feature_flags import get_feature_flags
 from models import (
     BackupCreateResponse,
     BackupInfo,
     BackupListResponse,
     DatabaseHealthResponse,
+    FeatureFlagInfo,
+    FeatureFlagsResponse,
+    FeatureFlagUpdateRequest,
+    FeatureFlagUpdateResponse,
     RestoreRequest,
     RestoreResponse,
 )
@@ -320,6 +325,64 @@ def create_admin_router(neo4j_adapter: Any) -> APIRouter:
                 status_code=500,
                 detail=f"Restore failed: {str(e)}",
             ) from e
+
+    @router.get("/feature-flags", response_model=FeatureFlagsResponse)
+    async def list_feature_flags(_admin: AdminUser, response: Response) -> FeatureFlagsResponse:
+        """List all feature flags and their current values.
+
+        Requires admin authentication.
+        """
+        # Flags change at runtime - never let the browser cache this
+        response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
+        service = get_feature_flags()
+        current = service.all_flags()
+        flags = [
+            FeatureFlagInfo(
+                name=name,
+                enabled=current.get(name, definition.default),
+                description=definition.description,
+            )
+            for name, definition in service.definitions.items()
+        ]
+        return FeatureFlagsResponse(flags=flags)
+
+    @router.put("/feature-flags/{flag_name}", response_model=FeatureFlagUpdateResponse)
+    async def update_feature_flag(
+        flag_name: str,
+        update: FeatureFlagUpdateRequest,
+        _admin: AdminUser,
+    ) -> FeatureFlagUpdateResponse:
+        """Enable or disable a feature flag at runtime.
+
+        The value is persisted in Neo4j and takes effect immediately -
+        no restart or redeploy required.
+
+        Requires admin authentication.
+        """
+        service = get_feature_flags()
+        try:
+            persisted = service.set_flag(flag_name, update.enabled)
+        except KeyError:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Unknown feature flag: {flag_name}. "
+                f"Known flags: {', '.join(service.definitions)}",
+            ) from None
+
+        logger.info(
+            "Admin set feature flag '%s' to %s (persisted=%s)",
+            flag_name,
+            update.enabled,
+            persisted,
+        )
+        return FeatureFlagUpdateResponse(
+            flag=FeatureFlagInfo(
+                name=flag_name,
+                enabled=update.enabled,
+                description=service.definitions[flag_name].description,
+            ),
+            persisted=persisted,
+        )
 
     @router.get("/health/database", response_model=DatabaseHealthResponse)
     async def database_health() -> DatabaseHealthResponse:

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -5,12 +5,12 @@ import logging
 import os
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
-from fastapi import APIRouter, HTTPException, Response
+from fastapi import APIRouter, Depends, HTTPException, Response
 
 from auth import AdminUser
-from feature_flags import get_feature_flags
+from feature_flags import FeatureFlagService, get_feature_flags
 from models import (
     BackupCreateResponse,
     BackupInfo,
@@ -327,19 +327,22 @@ def create_admin_router(neo4j_adapter: Any) -> APIRouter:
             ) from e
 
     @router.get("/feature-flags", response_model=FeatureFlagsResponse)
-    async def list_feature_flags(_admin: AdminUser, response: Response) -> FeatureFlagsResponse:
+    async def list_feature_flags(
+        _admin: AdminUser,
+        response: Response,
+        service: Annotated[FeatureFlagService, Depends(get_feature_flags)],
+    ) -> FeatureFlagsResponse:
         """List all feature flags and their current values.
 
         Requires admin authentication.
         """
         # Flags change at runtime - never let the browser cache this
         response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
-        service = get_feature_flags()
         current = service.all_flags()
         flags = [
             FeatureFlagInfo(
                 name=name,
-                enabled=current.get(name, definition.default),
+                enabled=current[name],
                 description=definition.description,
             )
             for name, definition in service.definitions.items()
@@ -351,6 +354,7 @@ def create_admin_router(neo4j_adapter: Any) -> APIRouter:
         flag_name: str,
         update: FeatureFlagUpdateRequest,
         _admin: AdminUser,
+        service: Annotated[FeatureFlagService, Depends(get_feature_flags)],
     ) -> FeatureFlagUpdateResponse:
         """Enable or disable a feature flag at runtime.
 
@@ -359,7 +363,6 @@ def create_admin_router(neo4j_adapter: Any) -> APIRouter:
 
         Requires admin authentication.
         """
-        service = get_feature_flags()
         try:
             persisted = service.set_flag(flag_name, update.enabled)
         except KeyError:

--- a/backend/routers/search.py
+++ b/backend/routers/search.py
@@ -11,9 +11,9 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, Request
 from rapidfuzz import fuzz
 
-from config import get_settings
 from core.search import extract_snippet
 from dependencies import get_neo4j, get_notes, get_ollama, get_static_articles, get_user_resources
+from feature_flags import get_feature_flags
 from models import SearchRequest, SearchResponse, SearchResult
 from rate_limiter import RATE_LIMITS, limiter
 
@@ -157,7 +157,7 @@ def search_resources(
     all_resources = _get_all_resources(static_articles, user_resources, notes_service)
 
     # Force text search if LLM features are disabled
-    if not get_settings().llm_features_enabled and search_request.semantic:
+    if not get_feature_flags().is_enabled("llm_features") and search_request.semantic:
         logger.info("Semantic search requested but LLM features are disabled, using text search")
         search_request.semantic = False
 

--- a/backend/routers/search.py
+++ b/backend/routers/search.py
@@ -13,7 +13,7 @@ from rapidfuzz import fuzz
 
 from core.search import extract_snippet
 from dependencies import get_neo4j, get_notes, get_ollama, get_static_articles, get_user_resources
-from feature_flags import get_feature_flags
+from feature_flags import FeatureFlagService, get_feature_flags
 from models import SearchRequest, SearchResponse, SearchResult
 from rate_limiter import RATE_LIMITS, limiter
 
@@ -27,6 +27,7 @@ NotesDep = Annotated[Any, Depends(get_notes)]
 Neo4jDep = Annotated[Any, Depends(get_neo4j)]
 ArticlesDep = Annotated[list[dict[str, Any]], Depends(get_static_articles)]
 UserResourcesDep = Annotated[list[dict[str, Any]], Depends(get_user_resources)]
+FeatureFlagsDep = Annotated[FeatureFlagService, Depends(get_feature_flags)]
 
 
 def _fuzzy_match_text(query: str, text: str, threshold: int = 80) -> float:
@@ -129,6 +130,7 @@ def search_resources(
     notes_service: NotesDep,
     ollama: OllamaDep,
     neo4j: Neo4jDep,
+    feature_flags: FeatureFlagsDep,
 ) -> SearchResponse:
     """
     Search across all resources (articles + notes).
@@ -157,7 +159,7 @@ def search_resources(
     all_resources = _get_all_resources(static_articles, user_resources, notes_service)
 
     # Force text search if LLM features are disabled
-    if not get_feature_flags().is_enabled("llm_features") and search_request.semantic:
+    if not feature_flags.is_enabled("llm_features") and search_request.semantic:
         logger.info("Semantic search requested but LLM features are disabled, using text search")
         search_request.semantic = False
 
@@ -295,7 +297,9 @@ def search_resources(
 
     # Fallback: Generate embeddings on-demand (slow but works without Neo4j)
     logger.info("Using on-demand embedding generation (slower)")
-    semantic_results = ollama.semantic_search(search_request.query, all_resources, search_request.top_k)
+    semantic_results = ollama.semantic_search(
+        search_request.query, all_resources, search_request.top_k
+    )
     results = [
         _normalize_search_result(doc, search_request.query, score=doc.get("score", 0.0))
         for doc in semantic_results

--- a/backend/tests/unit/test_feature_flags.py
+++ b/backend/tests/unit/test_feature_flags.py
@@ -1,0 +1,226 @@
+"""Unit tests for runtime feature flags (service + admin API + gating)."""
+
+import os
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Set testing mode before importing app modules
+os.environ["TESTING"] = "1"
+
+import feature_flags as feature_flags_module
+from config import get_settings
+from feature_flags import FeatureFlagService
+from main import app
+
+TEST_ADMIN_TOKEN = "test-admin-token-for-ci"
+
+
+class MockNeo4jFlags:
+    """Mock Neo4j adapter exposing only the feature-flag methods."""
+
+    def __init__(self, available: bool = True) -> None:
+        self.available = available
+        self.stored: dict[str, bool] = {}
+
+    def get_feature_flags(self) -> dict[str, bool]:
+        return dict(self.stored) if self.available else {}
+
+    def set_feature_flag(self, name: str, enabled: bool) -> bool:
+        if not self.available:
+            return False
+        self.stored[name] = enabled
+        return True
+
+
+@pytest.fixture
+def mock_neo4j() -> MockNeo4jFlags:
+    """Mock Neo4j adapter for flag persistence."""
+    return MockNeo4jFlags()
+
+
+@pytest.fixture
+def flag_service(
+    mock_neo4j: MockNeo4jFlags, monkeypatch: pytest.MonkeyPatch
+) -> Generator[FeatureFlagService]:
+    """Install a fresh flag service backed by the mock adapter as the global."""
+    service = FeatureFlagService(mock_neo4j)  # type: ignore[arg-type]
+    monkeypatch.setattr(feature_flags_module, "_service", service)
+    yield service
+
+
+@pytest.fixture
+def client(flag_service: FeatureFlagService) -> TestClient:
+    """Test client with the mock-backed flag service installed."""
+    return TestClient(app)
+
+
+@pytest.fixture
+def admin_headers() -> dict[str, str]:
+    """Admin authentication headers."""
+    settings = get_settings()
+    token = settings.admin_token or TEST_ADMIN_TOKEN
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestFeatureFlagService:
+    """Tests for the FeatureFlagService (pure-ish logic over a mock adapter)."""
+
+    def test_defaults_used_when_nothing_persisted(
+        self, flag_service: FeatureFlagService
+    ) -> None:
+        # conftest sets LLM_FEATURES_ENABLED=true, so the seed default is True
+        assert flag_service.is_enabled("llm_features") is True
+
+    def test_persisted_value_overrides_default(
+        self, flag_service: FeatureFlagService, mock_neo4j: MockNeo4jFlags
+    ) -> None:
+        mock_neo4j.stored["llm_features"] = False
+        flag_service.reset_cache()
+        assert flag_service.is_enabled("llm_features") is False
+
+    def test_unknown_flag_is_disabled(self, flag_service: FeatureFlagService) -> None:
+        assert flag_service.is_enabled("nonexistent_flag") is False
+
+    def test_set_flag_persists_and_updates_cache(
+        self, flag_service: FeatureFlagService, mock_neo4j: MockNeo4jFlags
+    ) -> None:
+        persisted = flag_service.set_flag("llm_features", False)
+        assert persisted is True
+        assert mock_neo4j.stored["llm_features"] is False
+        assert flag_service.is_enabled("llm_features") is False
+
+    def test_set_unknown_flag_raises(self, flag_service: FeatureFlagService) -> None:
+        with pytest.raises(KeyError):
+            flag_service.set_flag("nonexistent_flag", True)
+
+    def test_set_flag_without_neo4j_is_memory_only(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        unavailable = MockNeo4jFlags(available=False)
+        service = FeatureFlagService(unavailable)  # type: ignore[arg-type]
+        persisted = service.set_flag("llm_features", False)
+        assert persisted is False
+        assert service.is_enabled("llm_features") is False
+
+    def test_ignores_persisted_unknown_flags(
+        self, flag_service: FeatureFlagService, mock_neo4j: MockNeo4jFlags
+    ) -> None:
+        mock_neo4j.stored["removed_old_flag"] = True
+        flag_service.reset_cache()
+        assert "removed_old_flag" not in flag_service.all_flags()
+
+
+class TestFeatureFlagsAPI:
+    """Tests for GET/PUT /api/admin/feature-flags."""
+
+    def test_list_requires_auth(self, client: TestClient) -> None:
+        response = client.get("/api/admin/feature-flags")
+        assert response.status_code == 401
+
+    def test_update_requires_auth(self, client: TestClient) -> None:
+        response = client.put("/api/admin/feature-flags/llm_features", json={"enabled": True})
+        assert response.status_code == 401
+
+    def test_list_flags(self, client: TestClient, admin_headers: dict[str, str]) -> None:
+        response = client.get("/api/admin/feature-flags", headers=admin_headers)
+        assert response.status_code == 200
+        flags = {f["name"]: f for f in response.json()["flags"]}
+        assert "llm_features" in flags
+        assert flags["llm_features"]["enabled"] is True
+        assert flags["llm_features"]["description"]
+
+    def test_list_flags_not_cached(
+        self, client: TestClient, admin_headers: dict[str, str]
+    ) -> None:
+        response = client.get("/api/admin/feature-flags", headers=admin_headers)
+        assert "no-store" in response.headers["Cache-Control"]
+
+    def test_update_flag(
+        self,
+        client: TestClient,
+        admin_headers: dict[str, str],
+        mock_neo4j: MockNeo4jFlags,
+    ) -> None:
+        response = client.put(
+            "/api/admin/feature-flags/llm_features",
+            json={"enabled": False},
+            headers=admin_headers,
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["flag"]["enabled"] is False
+        assert body["persisted"] is True
+        assert mock_neo4j.stored["llm_features"] is False
+
+        # Reflected in subsequent list and public status
+        response = client.get("/api/admin/feature-flags", headers=admin_headers)
+        flags = {f["name"]: f for f in response.json()["flags"]}
+        assert flags["llm_features"]["enabled"] is False
+
+    def test_update_unknown_flag_404(
+        self, client: TestClient, admin_headers: dict[str, str]
+    ) -> None:
+        response = client.put(
+            "/api/admin/feature-flags/nonexistent",
+            json={"enabled": True},
+            headers=admin_headers,
+        )
+        assert response.status_code == 404
+
+
+class TestRuntimeGating:
+    """Tests that toggling the flag gates features without a restart."""
+
+    def _disable_llm(self, flag_service: FeatureFlagService) -> None:
+        flag_service.set_flag("llm_features", False)
+
+    def test_status_reflects_flag(
+        self, client: TestClient, flag_service: FeatureFlagService
+    ) -> None:
+        assert client.get("/").json()["llm_features_enabled"] is True
+        self._disable_llm(flag_service)
+        assert client.get("/").json()["llm_features_enabled"] is False
+
+    def test_ai_endpoints_return_503_when_disabled(
+        self, client: TestClient, flag_service: FeatureFlagService
+    ) -> None:
+        self._disable_llm(flag_service)
+        response = client.post("/api/ask", json={"question": "What is SRE?"})
+        assert response.status_code == 503
+        assert "disabled" in response.json()["detail"]
+
+    def test_semantic_search_falls_back_to_text_when_disabled(
+        self,
+        flag_service: FeatureFlagService,
+        mock_ollama_available: Any,
+        mock_notes_service: Any,
+    ) -> None:
+        from dependencies import get_notes, get_ollama
+
+        self._disable_llm(flag_service)
+        app.dependency_overrides[get_ollama] = lambda: mock_ollama_available
+        app.dependency_overrides[get_notes] = lambda: mock_notes_service
+        try:
+            with TestClient(app) as client:
+                response = client.post(
+                    "/api/search", json={"query": "test", "semantic": True}
+                )
+                assert response.status_code == 200
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_admin_sync_embeddings_blocked_when_disabled(
+        self,
+        client: TestClient,
+        flag_service: FeatureFlagService,
+        admin_headers: dict[str, str],
+    ) -> None:
+        self._disable_llm(flag_service)
+        response = client.post("/api/admin/sync-embeddings", headers=admin_headers)
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is False
+        assert "disabled" in body["message"]

--- a/backend/tests/unit/test_feature_flags.py
+++ b/backend/tests/unit/test_feature_flags.py
@@ -68,9 +68,7 @@ def admin_headers() -> dict[str, str]:
 class TestFeatureFlagService:
     """Tests for the FeatureFlagService (pure-ish logic over a mock adapter)."""
 
-    def test_defaults_used_when_nothing_persisted(
-        self, flag_service: FeatureFlagService
-    ) -> None:
+    def test_defaults_used_when_nothing_persisted(self, flag_service: FeatureFlagService) -> None:
         # conftest sets LLM_FEATURES_ENABLED=true, so the seed default is True
         assert flag_service.is_enabled("llm_features") is True
 
@@ -96,14 +94,51 @@ class TestFeatureFlagService:
         with pytest.raises(KeyError):
             flag_service.set_flag("nonexistent_flag", True)
 
-    def test_set_flag_without_neo4j_is_memory_only(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_set_flag_without_neo4j_is_memory_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
         unavailable = MockNeo4jFlags(available=False)
         service = FeatureFlagService(unavailable)  # type: ignore[arg-type]
         persisted = service.set_flag("llm_features", False)
         assert persisted is False
         assert service.is_enabled("llm_features") is False
+
+    def test_other_workers_pick_up_changes_after_ttl(
+        self, mock_neo4j: MockNeo4jFlags, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Simulate two uvicorn workers sharing Neo4j but not memory."""
+        worker_a = FeatureFlagService(mock_neo4j)  # type: ignore[arg-type]
+        worker_b = FeatureFlagService(mock_neo4j)  # type: ignore[arg-type]
+
+        # Both workers warm their caches with the default (True)
+        assert worker_a.is_enabled("llm_features") is True
+        assert worker_b.is_enabled("llm_features") is True
+
+        # Admin toggle lands on worker A only
+        worker_a.set_flag("llm_features", False)
+        assert worker_a.is_enabled("llm_features") is False
+        # Worker B still serves its cache within the TTL
+        assert worker_b.is_enabled("llm_features") is True
+
+        # After the TTL expires, worker B reloads from Neo4j
+        import feature_flags as ff
+
+        real_monotonic = ff.time.monotonic
+        monkeypatch.setattr(
+            ff.time,
+            "monotonic",
+            lambda: real_monotonic() + FeatureFlagService.CACHE_TTL_SECONDS + 1,
+        )
+        assert worker_b.is_enabled("llm_features") is False
+
+    def test_set_flag_survives_neo4j_write_error(
+        self, flag_service: FeatureFlagService, mock_neo4j: MockNeo4jFlags
+    ) -> None:
+        def boom(name: str, enabled: bool) -> bool:
+            raise RuntimeError("transient write failure")
+
+        mock_neo4j.set_feature_flag = boom  # type: ignore[method-assign]
+        persisted = flag_service.set_flag("llm_features", False)
+        assert persisted is False
+        assert flag_service.is_enabled("llm_features") is False
 
     def test_ignores_persisted_unknown_flags(
         self, flag_service: FeatureFlagService, mock_neo4j: MockNeo4jFlags
@@ -132,9 +167,7 @@ class TestFeatureFlagsAPI:
         assert flags["llm_features"]["enabled"] is True
         assert flags["llm_features"]["description"]
 
-    def test_list_flags_not_cached(
-        self, client: TestClient, admin_headers: dict[str, str]
-    ) -> None:
+    def test_list_flags_not_cached(self, client: TestClient, admin_headers: dict[str, str]) -> None:
         response = client.get("/api/admin/feature-flags", headers=admin_headers)
         assert "no-store" in response.headers["Cache-Control"]
 
@@ -205,9 +238,7 @@ class TestRuntimeGating:
         app.dependency_overrides[get_notes] = lambda: mock_notes_service
         try:
             with TestClient(app) as client:
-                response = client.post(
-                    "/api/search", json={"query": "test", "semantic": True}
-                )
+                response = client.post("/api/search", json={"query": "test", "semantic": True})
                 assert response.status_code == 200
         finally:
             app.dependency_overrides.clear()

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -102,7 +102,6 @@ services:
     environment:
       - NODE_ENV=production
       - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://localhost:8000}
-      - NEXT_PUBLIC_LLM_FEATURES_ENABLED=false
     depends_on:
       backend:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,6 @@ services:
       - /app/.next
     environment:
       - NEXT_PUBLIC_API_URL=http://localhost:8000
-      - NEXT_PUBLIC_LLM_FEATURES_ENABLED=true
       # NODE_ENV is automatically set by Next.js commands:
       # - 'npm run dev' sets NODE_ENV=development
       # - 'npm run build' sets NODE_ENV=production

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -2,11 +2,6 @@
 # Default: http://localhost:8000
 NEXT_PUBLIC_API_URL=http://localhost:8000
 
-# LLM Feature Flag (master switch for all AI/LLM features)
-# Default: false (off to save resources in production)
-# Set to "true" to enable AI features (Q&A, semantic search, suggestions)
-NEXT_PUBLIC_LLM_FEATURES_ENABLED=true
-
 # Allow unauthenticated users to use AI features
 # Default: true (allows visitors to try AI suggestions)
 # Set to "false" to restrict AI features to authenticated users only

--- a/frontend/src/__tests__/useFeatureFlags.test.tsx
+++ b/frontend/src/__tests__/useFeatureFlags.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * Tests for useFeatureFlags hook
+ *
+ * Tests cover:
+ * - Fetching runtime flags from the backend status endpoint
+ * - Defaulting to disabled on fetch failure
+ * - Sharing one fetch across consumers (module-level store)
+ * - applyFeatureFlag updating the store directly
+ */
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// The hook keeps module-level state, so re-import a fresh copy per test
+async function freshHook() {
+  vi.resetModules();
+  return import("../hooks/useFeatureFlags");
+}
+
+describe("useFeatureFlags", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("loads flags from the backend status endpoint", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ llm_features_enabled: true }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { useFeatureFlags } = await freshHook();
+    const { result } = renderHook(() => useFeatureFlags());
+
+    expect(result.current.loaded).toBe(false);
+    expect(result.current.llmFeaturesEnabled).toBe(false);
+
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+    expect(result.current.llmFeaturesEnabled).toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringMatching(/\/$/),
+      expect.objectContaining({ cache: "no-store" })
+    );
+  });
+
+  it("defaults to disabled when the fetch fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+
+    const { useFeatureFlags } = await freshHook();
+    const { result } = renderHook(() => useFeatureFlags());
+
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+    expect(result.current.llmFeaturesEnabled).toBe(false);
+  });
+
+  it("shares a single fetch across multiple consumers", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ llm_features_enabled: true }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { useFeatureFlags } = await freshHook();
+    const first = renderHook(() => useFeatureFlags());
+    const second = renderHook(() => useFeatureFlags());
+
+    await waitFor(() => expect(first.result.current.loaded).toBe(true));
+    await waitFor(() => expect(second.result.current.loaded).toBe(true));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(second.result.current.llmFeaturesEnabled).toBe(true);
+  });
+
+  it("applyFeatureFlag updates subscribed components without a fetch", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ llm_features_enabled: false }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { useFeatureFlags, applyFeatureFlag } = await freshHook();
+    const { result } = renderHook(() => useFeatureFlags());
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+    expect(result.current.llmFeaturesEnabled).toBe(false);
+
+    applyFeatureFlag("llm_features", true);
+    await waitFor(() => expect(result.current.llmFeaturesEnabled).toBe(true));
+
+    // Unknown flag names are ignored
+    applyFeatureFlag("nonexistent_flag", false);
+    expect(result.current.llmFeaturesEnabled).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/app/admin/page.module.scss
+++ b/frontend/src/app/admin/page.module.scss
@@ -1,0 +1,164 @@
+/**
+ * Admin Settings Page Styles
+ * Minimal layout matching the login page's header/card pattern
+ */
+
+@use '@/styles/design-tokens' as *;
+@use '@/styles/mixins' as *;
+
+.container {
+  min-height: 100vh;
+  background: linear-gradient(to bottom right, $color-page-bg-gradient-start, $color-page-bg-gradient-end);
+}
+
+.header {
+  background: linear-gradient(
+    to bottom,
+    $slate-blue-200 0%,
+    $slate-blue-100 50%,
+    rgba($slate-blue-50, 0.7) 100%
+  );
+  border-bottom: 1px solid $slate-blue-300;
+  box-shadow: $shadow-card-sm;
+  padding-top: $spacing-3;
+  padding-bottom: $spacing-3;
+
+  @media (min-width: 640px) {
+    padding-top: $spacing-6;
+    padding-bottom: $spacing-6;
+  }
+
+  .headerContent {
+    max-width: 42rem;
+    margin: 0 auto;
+    padding: 0 $spacing-4;
+
+    @media (min-width: 640px) {
+      padding: 0 $spacing-6;
+    }
+
+    .title {
+      @include heading-h1;
+      margin: 0 0 $spacing-2 0;
+      font-size: $font-size-2xl;
+
+      @media (min-width: 640px) {
+        font-size: $font-size-3xl;
+      }
+    }
+
+    .subtitle {
+      @include text-secondary;
+      color: $color-text-secondary;
+      margin: 0;
+    }
+  }
+}
+
+.main {
+  max-width: 42rem;
+  margin: 0 auto;
+  padding: $spacing-8 $spacing-4;
+}
+
+.card {
+  @include card-elevated;
+  padding: $spacing-6;
+}
+
+.status {
+  @include text-secondary;
+  margin: 0;
+}
+
+.error {
+  margin: 0 0 $spacing-4 0;
+  padding: $spacing-3 $spacing-4;
+  background-color: rgba(254, 226, 226, 0.8);
+  border: $border-width-thin solid rgba(220, 38, 38, 0.3);
+  border-radius: $border-radius-md;
+  color: $color-error-text;
+  font-weight: $font-weight-medium;
+}
+
+.warning {
+  margin: 0 0 $spacing-4 0;
+  padding: $spacing-3 $spacing-4;
+  background-color: rgba(254, 243, 199, 0.8);
+  border: $border-width-thin solid rgba(217, 119, 6, 0.3);
+  border-radius: $border-radius-md;
+  color: $color-text-primary;
+}
+
+.flagRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $spacing-4;
+  padding: $spacing-4 0;
+
+  &:not(:last-child) {
+    border-bottom: $border-default;
+  }
+}
+
+.flagInfo {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-1;
+}
+
+.flagName {
+  font-family: $font-family-mono;
+  font-size: $font-size-base;
+  font-weight: $font-weight-medium;
+  color: $color-text-primary;
+}
+
+.flagDescription {
+  @include text-secondary;
+  font-size: $font-size-sm;
+  color: $color-text-secondary;
+}
+
+.toggle {
+  position: relative;
+  flex-shrink: 0;
+  width: 2.75rem;
+  height: 1.5rem;
+  padding: 0;
+  background-color: $neutral-400;
+  border: none;
+  border-radius: 9999px;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px rgba($blue-500, 0.3);
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: wait;
+  }
+
+  .toggleKnob {
+    position: absolute;
+    top: 0.125rem;
+    left: 0.125rem;
+    width: 1.25rem;
+    height: 1.25rem;
+    background-color: $white;
+    border-radius: 9999px;
+    transition: transform 0.2s ease;
+  }
+}
+
+.toggleOn {
+  background-color: $blue-600;
+
+  .toggleKnob {
+    transform: translateX(1.25rem);
+  }
+}

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -67,7 +67,9 @@ export default function AdminPage() {
         <header className={styles.header}>
           <div className={styles.headerContent}>
             <h1 className={styles.title}>Admin Settings</h1>
-            <p className={styles.subtitle}>Runtime feature flags - changes take effect immediately</p>
+            <p className={styles.subtitle}>
+              Runtime feature flags - changes take effect immediately
+            </p>
           </div>
         </header>
 

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import TopNavigation from "@/components/TopNavigation";
 import { isAuthenticated } from "@/lib/api/client";
 import { getFeatureFlags, updateFeatureFlag, type FeatureFlag } from "@/lib/api/admin";
-import { refreshFeatureFlags } from "@/hooks/useFeatureFlags";
+import { applyFeatureFlag } from "@/hooks/useFeatureFlags";
 import { logger } from "@/lib/logger";
 import styles from "./page.module.scss";
 
@@ -47,11 +47,11 @@ export default function AdminPage() {
       );
       if (!result.persisted) {
         setWarning(
-          "Saved in memory only - the database is unavailable, so this value will reset when the backend restarts."
+          "Saved in memory only - the database is unavailable, so this value may revert shortly."
         );
       }
-      // Update the rest of the app immediately
-      await refreshFeatureFlags();
+      // Update the rest of the app immediately from the authoritative response
+      applyFeatureFlag(result.flag.name, result.flag.enabled);
     } catch (err) {
       adminLogger.error("Failed to update feature flag:", err);
       setError(`Failed to update "${flag.name}". Try again.`);

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import TopNavigation from "@/components/TopNavigation";
+import { isAuthenticated } from "@/lib/api/client";
+import { getFeatureFlags, updateFeatureFlag, type FeatureFlag } from "@/lib/api/admin";
+import { refreshFeatureFlags } from "@/hooks/useFeatureFlags";
+import { logger } from "@/lib/logger";
+import styles from "./page.module.scss";
+
+const adminLogger = logger.withContext("AdminSettings");
+
+export default function AdminPage() {
+  const router = useRouter();
+  const [flags, setFlags] = useState<FeatureFlag[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [warning, setWarning] = useState<string | null>(null);
+  const [saving, setSaving] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isAuthenticated()) {
+      router.replace("/login");
+      return;
+    }
+
+    getFeatureFlags()
+      .then(setFlags)
+      .catch((err) => {
+        adminLogger.error("Failed to load feature flags:", err);
+        setError("Failed to load feature flags. Is your admin session still valid?");
+      })
+      .finally(() => setLoading(false));
+  }, [router]);
+
+  const handleToggle = async (flag: FeatureFlag) => {
+    const newValue = !flag.enabled;
+    setSaving(flag.name);
+    setError(null);
+    setWarning(null);
+
+    try {
+      const result = await updateFeatureFlag(flag.name, newValue);
+      setFlags((current) =>
+        current.map((f) => (f.name === flag.name ? { ...f, enabled: result.flag.enabled } : f))
+      );
+      if (!result.persisted) {
+        setWarning(
+          "Saved in memory only - the database is unavailable, so this value will reset when the backend restarts."
+        );
+      }
+      // Update the rest of the app immediately
+      await refreshFeatureFlags();
+    } catch (err) {
+      adminLogger.error("Failed to update feature flag:", err);
+      setError(`Failed to update "${flag.name}". Try again.`);
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  return (
+    <>
+      <TopNavigation />
+      <div className={styles.container}>
+        <header className={styles.header}>
+          <div className={styles.headerContent}>
+            <h1 className={styles.title}>Admin Settings</h1>
+            <p className={styles.subtitle}>Runtime feature flags - changes take effect immediately</p>
+          </div>
+        </header>
+
+        <main className={styles.main}>
+          <div className={styles.card}>
+            {loading && <p className={styles.status}>Loading feature flags...</p>}
+
+            {error && <p className={styles.error}>{error}</p>}
+            {warning && <p className={styles.warning}>{warning}</p>}
+
+            {!loading && !error && flags.length === 0 && (
+              <p className={styles.status}>No feature flags defined.</p>
+            )}
+
+            {flags.map((flag) => (
+              <div key={flag.name} className={styles.flagRow}>
+                <div className={styles.flagInfo}>
+                  <span className={styles.flagName}>{flag.name}</span>
+                  <span className={styles.flagDescription}>{flag.description}</span>
+                </div>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={flag.enabled}
+                  aria-label={`Toggle ${flag.name}`}
+                  className={`${styles.toggle} ${flag.enabled ? styles.toggleOn : ""}`}
+                  disabled={saving === flag.name}
+                  onClick={() => handleToggle(flag)}
+                >
+                  <span className={styles.toggleKnob} />
+                </button>
+              </div>
+            ))}
+          </div>
+        </main>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/app/knowledge-base/articles/[id]/page.tsx
+++ b/frontend/src/app/knowledge-base/articles/[id]/page.tsx
@@ -11,7 +11,7 @@ import Breadcrumb from "@/components/Breadcrumb";
 import Badge from "@/components/Badge";
 import { TagPillList } from "@/components/TagPill";
 import { logger } from "@/lib/logger";
-import { config } from "@/lib/config";
+import { useFeatureFlags } from "@/hooks/useFeatureFlags";
 import { sanitizeHtml } from "@/lib/sanitize";
 import styles from "./page.module.scss";
 
@@ -37,6 +37,7 @@ interface RelatedNote {
 }
 
 export default function ArticleDetailPage() {
+  const { llmFeaturesEnabled } = useFeatureFlags();
   const params = useParams();
   const router = useRouter();
   const articleId = parseInt(params.id as string);
@@ -136,12 +137,12 @@ export default function ArticleDetailPage() {
   return (
     <div className={styles.container}>
       {/* AI Panel (only when LLM features enabled) */}
-      {config.llmFeaturesEnabled && (
+      {llmFeaturesEnabled && (
         <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
       )}
 
       {/* AI Button (only when LLM features enabled) */}
-      {config.llmFeaturesEnabled && !aiPanelOpen && (
+      {llmFeaturesEnabled && !aiPanelOpen && (
         <AIButton onClick={() => setAiPanelOpen(true)} />
       )}
 

--- a/frontend/src/app/knowledge-base/articles/[id]/page.tsx
+++ b/frontend/src/app/knowledge-base/articles/[id]/page.tsx
@@ -137,14 +137,10 @@ export default function ArticleDetailPage() {
   return (
     <div className={styles.container}>
       {/* AI Panel (only when LLM features enabled) */}
-      {llmFeaturesEnabled && (
-        <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
-      )}
+      {llmFeaturesEnabled && <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />}
 
       {/* AI Button (only when LLM features enabled) */}
-      {llmFeaturesEnabled && !aiPanelOpen && (
-        <AIButton onClick={() => setAiPanelOpen(true)} />
-      )}
+      {llmFeaturesEnabled && !aiPanelOpen && <AIButton onClick={() => setAiPanelOpen(true)} />}
 
       {/* Header */}
       <header className={styles.header}>

--- a/frontend/src/app/knowledge-base/articles/page.tsx
+++ b/frontend/src/app/knowledge-base/articles/page.tsx
@@ -157,14 +157,10 @@ function ArticlesContent() {
   return (
     <div className={styles.container}>
       {/* AI Panel (only when LLM features enabled) */}
-      {llmFeaturesEnabled && (
-        <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
-      )}
+      {llmFeaturesEnabled && <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />}
 
       {/* AI Button (only when LLM features enabled) */}
-      {llmFeaturesEnabled && !aiPanelOpen && (
-        <AIButton onClick={() => setAiPanelOpen(true)} />
-      )}
+      {llmFeaturesEnabled && !aiPanelOpen && <AIButton onClick={() => setAiPanelOpen(true)} />}
 
       {/* Header */}
       <header className={styles.header}>

--- a/frontend/src/app/knowledge-base/articles/page.tsx
+++ b/frontend/src/app/knowledge-base/articles/page.tsx
@@ -10,7 +10,7 @@ import AIPanel from "@/components/AIPanel";
 import AIButton from "@/components/AIButton";
 import Breadcrumb from "@/components/Breadcrumb";
 import { TagPillList } from "@/components/TagPill";
-import { config } from "@/lib/config";
+import { useFeatureFlags } from "@/hooks/useFeatureFlags";
 import styles from "./page.module.scss";
 
 interface ArticleMetadata {
@@ -28,6 +28,7 @@ interface ArticleMetadata {
 type SortOption = "newest" | "oldest" | "recently-updated" | "alphabetical";
 
 function ArticlesContent() {
+  const { llmFeaturesEnabled } = useFeatureFlags();
   const router = useRouter();
   const searchParams = useSearchParams();
   const tagsParam = searchParams.get("tags");
@@ -156,12 +157,12 @@ function ArticlesContent() {
   return (
     <div className={styles.container}>
       {/* AI Panel (only when LLM features enabled) */}
-      {config.llmFeaturesEnabled && (
+      {llmFeaturesEnabled && (
         <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
       )}
 
       {/* AI Button (only when LLM features enabled) */}
-      {config.llmFeaturesEnabled && !aiPanelOpen && (
+      {llmFeaturesEnabled && !aiPanelOpen && (
         <AIButton onClick={() => setAiPanelOpen(true)} />
       )}
 

--- a/frontend/src/app/knowledge-base/notes/[id]/page.tsx
+++ b/frontend/src/app/knowledge-base/notes/[id]/page.tsx
@@ -38,8 +38,7 @@ export default function NoteDetailPage() {
 
   // Check if AI features should be available
   // AI is available if: LLM features enabled AND (user is authenticated OR unauthenticated AI is allowed)
-  const aiAvailable =
-    llmFeaturesEnabled && (isAuthenticated() || config.allowUnauthenticatedAI);
+  const aiAvailable = llmFeaturesEnabled && (isAuthenticated() || config.allowUnauthenticatedAI);
 
   const [note, setNote] = useState<Note | null>(null);
   const [backlinks, setBacklinks] = useState<Note[]>([]);
@@ -366,14 +365,10 @@ export default function NoteDetailPage() {
   return (
     <div className={styles.container}>
       {/* AI Panel (only when LLM features enabled) */}
-      {llmFeaturesEnabled && (
-        <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
-      )}
+      {llmFeaturesEnabled && <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />}
 
       {/* AI Button (only when LLM features enabled) */}
-      {llmFeaturesEnabled && !aiPanelOpen && (
-        <AIButton onClick={() => setAiPanelOpen(true)} />
-      )}
+      {llmFeaturesEnabled && !aiPanelOpen && <AIButton onClick={() => setAiPanelOpen(true)} />}
 
       <div className={styles.main}>
         <div className={styles.contentGrid}>

--- a/frontend/src/app/knowledge-base/notes/[id]/page.tsx
+++ b/frontend/src/app/knowledge-base/notes/[id]/page.tsx
@@ -26,9 +26,11 @@ import { logger } from "@/lib/logger";
 import { useSettings } from "@/hooks/useSettings";
 import { isAuthenticated } from "@/lib/api/client";
 import { config } from "@/lib/config";
+import { useFeatureFlags } from "@/hooks/useFeatureFlags";
 import styles from "./page.module.scss";
 
 export default function NoteDetailPage() {
+  const { llmFeaturesEnabled } = useFeatureFlags();
   const params = useParams();
   const router = useRouter();
   const noteId = params.id as string;
@@ -37,7 +39,7 @@ export default function NoteDetailPage() {
   // Check if AI features should be available
   // AI is available if: LLM features enabled AND (user is authenticated OR unauthenticated AI is allowed)
   const aiAvailable =
-    config.llmFeaturesEnabled && (isAuthenticated() || config.allowUnauthenticatedAI);
+    llmFeaturesEnabled && (isAuthenticated() || config.allowUnauthenticatedAI);
 
   const [note, setNote] = useState<Note | null>(null);
   const [backlinks, setBacklinks] = useState<Note[]>([]);
@@ -364,12 +366,12 @@ export default function NoteDetailPage() {
   return (
     <div className={styles.container}>
       {/* AI Panel (only when LLM features enabled) */}
-      {config.llmFeaturesEnabled && (
+      {llmFeaturesEnabled && (
         <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
       )}
 
       {/* AI Button (only when LLM features enabled) */}
-      {config.llmFeaturesEnabled && !aiPanelOpen && (
+      {llmFeaturesEnabled && !aiPanelOpen && (
         <AIButton onClick={() => setAiPanelOpen(true)} />
       )}
 
@@ -677,7 +679,7 @@ export default function NoteDetailPage() {
       )}
 
       {/* Post-Save AI Suggestions Modal (only when LLM features enabled) */}
-      {config.llmFeaturesEnabled && (
+      {llmFeaturesEnabled && (
         <PostSaveAISuggestions
           noteId={noteId}
           isOpen={showPostSaveSuggestions}

--- a/frontend/src/app/knowledge-base/notes/new/page.tsx
+++ b/frontend/src/app/knowledge-base/notes/new/page.tsx
@@ -59,9 +59,7 @@ function NewNoteContent() {
 
   // Check authentication status after hydration (client-side only)
   useEffect(() => {
-    setAiAvailable(
-      llmFeaturesEnabled && (isAuthenticated() || config.allowUnauthenticatedAI)
-    );
+    setAiAvailable(llmFeaturesEnabled && (isAuthenticated() || config.allowUnauthenticatedAI));
   }, [llmFeaturesEnabled]);
 
   // Load draft from localStorage on mount, or pre-fill from URL params (e.g., from article)
@@ -348,14 +346,10 @@ function NewNoteContent() {
   return (
     <div className={styles.container}>
       {/* AI Panel (only when LLM features enabled) */}
-      {llmFeaturesEnabled && (
-        <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
-      )}
+      {llmFeaturesEnabled && <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />}
 
       {/* AI Button (only when LLM features enabled) */}
-      {llmFeaturesEnabled && !aiPanelOpen && (
-        <AIButton onClick={() => setAiPanelOpen(true)} />
-      )}
+      {llmFeaturesEnabled && !aiPanelOpen && <AIButton onClick={() => setAiPanelOpen(true)} />}
 
       <div className={styles.main}>
         {/* Header */}

--- a/frontend/src/app/knowledge-base/notes/new/page.tsx
+++ b/frontend/src/app/knowledge-base/notes/new/page.tsx
@@ -15,10 +15,12 @@ import AISuggestionsPanel from "@/components/AISuggestionsPanel";
 import { useSettings } from "@/hooks/useSettings";
 import { isAuthenticated } from "@/lib/api/client";
 import { config } from "@/lib/config";
+import { useFeatureFlags } from "@/hooks/useFeatureFlags";
 import { saveDraft, loadDraft, clearDraft } from "@/lib/draft";
 import styles from "./page.module.scss";
 
 function NewNoteContent() {
+  const { llmFeaturesEnabled } = useFeatureFlags();
   const router = useRouter();
   const searchParams = useSearchParams();
   const { settings } = useSettings();
@@ -58,9 +60,9 @@ function NewNoteContent() {
   // Check authentication status after hydration (client-side only)
   useEffect(() => {
     setAiAvailable(
-      config.llmFeaturesEnabled && (isAuthenticated() || config.allowUnauthenticatedAI)
+      llmFeaturesEnabled && (isAuthenticated() || config.allowUnauthenticatedAI)
     );
-  }, []);
+  }, [llmFeaturesEnabled]);
 
   // Load draft from localStorage on mount, or pre-fill from URL params (e.g., from article)
   useEffect(() => {
@@ -346,12 +348,12 @@ function NewNoteContent() {
   return (
     <div className={styles.container}>
       {/* AI Panel (only when LLM features enabled) */}
-      {config.llmFeaturesEnabled && (
+      {llmFeaturesEnabled && (
         <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
       )}
 
       {/* AI Button (only when LLM features enabled) */}
-      {config.llmFeaturesEnabled && !aiPanelOpen && (
+      {llmFeaturesEnabled && !aiPanelOpen && (
         <AIButton onClick={() => setAiPanelOpen(true)} />
       )}
 
@@ -673,7 +675,7 @@ function NewNoteContent() {
       )}
 
       {/* Post-Save AI Suggestions Modal (only when LLM features enabled) */}
-      {config.llmFeaturesEnabled && savedNoteId && (
+      {llmFeaturesEnabled && savedNoteId && (
         <PostSaveAISuggestions
           noteId={savedNoteId}
           isOpen={showPostSaveSuggestions}

--- a/frontend/src/app/knowledge-base/notes/page.tsx
+++ b/frontend/src/app/knowledge-base/notes/page.tsx
@@ -222,14 +222,10 @@ function NotesContent() {
   return (
     <div className={styles.container}>
       {/* AI Panel (only when LLM features enabled) */}
-      {llmFeaturesEnabled && (
-        <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
-      )}
+      {llmFeaturesEnabled && <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />}
 
       {/* AI Button (only when LLM features enabled) */}
-      {llmFeaturesEnabled && !aiPanelOpen && (
-        <AIButton onClick={() => setAiPanelOpen(true)} />
-      )}
+      {llmFeaturesEnabled && !aiPanelOpen && <AIButton onClick={() => setAiPanelOpen(true)} />}
 
       {/* Header */}
       <div className={styles.header}>

--- a/frontend/src/app/knowledge-base/notes/page.tsx
+++ b/frontend/src/app/knowledge-base/notes/page.tsx
@@ -12,12 +12,13 @@ import Breadcrumb from "@/components/Breadcrumb";
 import { TagPillList } from "@/components/TagPill";
 import QuickLists from "@/components/QuickLists/QuickLists";
 import NoteOfDay from "@/components/NoteOfDay/NoteOfDay";
-import { config } from "@/lib/config";
+import { useFeatureFlags } from "@/hooks/useFeatureFlags";
 import styles from "./page.module.scss";
 
 type SortOption = "newest" | "oldest" | "alphabetical";
 
 function NotesContent() {
+  const { llmFeaturesEnabled } = useFeatureFlags();
   const router = useRouter();
   const searchParams = useSearchParams();
   const tagsParam = searchParams.get("tags");
@@ -221,12 +222,12 @@ function NotesContent() {
   return (
     <div className={styles.container}>
       {/* AI Panel (only when LLM features enabled) */}
-      {config.llmFeaturesEnabled && (
+      {llmFeaturesEnabled && (
         <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
       )}
 
       {/* AI Button (only when LLM features enabled) */}
-      {config.llmFeaturesEnabled && !aiPanelOpen && (
+      {llmFeaturesEnabled && !aiPanelOpen && (
         <AIButton onClick={() => setAiPanelOpen(true)} />
       )}
 

--- a/frontend/src/app/knowledge-base/page.tsx
+++ b/frontend/src/app/knowledge-base/page.tsx
@@ -6,7 +6,7 @@ import AIPanel from "@/components/AIPanel";
 import AIButton from "@/components/AIButton";
 import Badge from "@/components/Badge";
 import { logger } from "@/lib/logger";
-import { config } from "@/lib/config";
+import { useFeatureFlags } from "@/hooks/useFeatureFlags";
 import styles from "./page.module.scss";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -40,6 +40,7 @@ function highlightText(text: string, query: string): React.ReactNode {
 }
 
 export default function KnowledgeBasePage() {
+  const { llmFeaturesEnabled } = useFeatureFlags();
   const [aiPanelOpen, setAiPanelOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
@@ -130,12 +131,12 @@ export default function KnowledgeBasePage() {
   return (
     <div className={styles.container}>
       {/* AI Panel (only when LLM features enabled) */}
-      {config.llmFeaturesEnabled && (
+      {llmFeaturesEnabled && (
         <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
       )}
 
       {/* AI Button (only when LLM features enabled) */}
-      {config.llmFeaturesEnabled && !aiPanelOpen && (
+      {llmFeaturesEnabled && !aiPanelOpen && (
         <AIButton onClick={() => setAiPanelOpen(true)} />
       )}
 
@@ -176,7 +177,7 @@ export default function KnowledgeBasePage() {
           </form>
           <p className={styles.searchHint}>
             Live search enabled - results appear as you type.
-            {config.llmFeaturesEnabled && " For AI-powered semantic search, use the AI Assistant."}
+            {llmFeaturesEnabled && " For AI-powered semantic search, use the AI Assistant."}
           </p>
 
           {/* Search Error */}

--- a/frontend/src/app/knowledge-base/page.tsx
+++ b/frontend/src/app/knowledge-base/page.tsx
@@ -131,14 +131,10 @@ export default function KnowledgeBasePage() {
   return (
     <div className={styles.container}>
       {/* AI Panel (only when LLM features enabled) */}
-      {llmFeaturesEnabled && (
-        <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
-      )}
+      {llmFeaturesEnabled && <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />}
 
       {/* AI Button (only when LLM features enabled) */}
-      {llmFeaturesEnabled && !aiPanelOpen && (
-        <AIButton onClick={() => setAiPanelOpen(true)} />
-      )}
+      {llmFeaturesEnabled && !aiPanelOpen && <AIButton onClick={() => setAiPanelOpen(true)} />}
 
       {/* Header */}
       <header className={styles.header}>

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -21,7 +21,7 @@ import styles from "./Settings.module.scss";
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
 export default function Settings() {
-  const { llmFeaturesEnabled } = useFeatureFlags();
+  const { llmFeaturesEnabled, loaded: flagsLoaded } = useFeatureFlags();
   const { preferences, updatePreferences } = useUserPreferences();
   const [isOpen, setIsOpen] = useState(false);
   const [isWarmingUp, setIsWarmingUp] = useState(false);
@@ -90,7 +90,7 @@ export default function Settings() {
           <div className={styles.dropdownContent}>
             {/* AI Assistance Section */}
             <div className={styles.section}>
-              {llmFeaturesEnabled ? (
+              {!flagsLoaded ? null : llmFeaturesEnabled ? (
                 <>
                   {isWarmingUp && <div className={styles.warmupIndicator}>Warming up...</div>}
 

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -15,12 +15,13 @@ import { useState, useRef, useEffect } from "react";
 import { useUserPreferences } from "@/hooks/useUserPreferences";
 import type { AiMode } from "@/lib/settings";
 import { logger } from "@/lib/logger";
-import { config } from "@/lib/config";
+import { useFeatureFlags } from "@/hooks/useFeatureFlags";
 import styles from "./Settings.module.scss";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
 export default function Settings() {
+  const { llmFeaturesEnabled } = useFeatureFlags();
   const { preferences, updatePreferences } = useUserPreferences();
   const [isOpen, setIsOpen] = useState(false);
   const [isWarmingUp, setIsWarmingUp] = useState(false);
@@ -89,7 +90,7 @@ export default function Settings() {
           <div className={styles.dropdownContent}>
             {/* AI Assistance Section */}
             <div className={styles.section}>
-              {config.llmFeaturesEnabled ? (
+              {llmFeaturesEnabled ? (
                 <>
                   {isWarmingUp && <div className={styles.warmupIndicator}>Warming up...</div>}
 

--- a/frontend/src/components/SettingsDropdown.module.scss
+++ b/frontend/src/components/SettingsDropdown.module.scss
@@ -166,3 +166,20 @@
     background-color: $red-50;
   }
 }
+
+.adminLink {
+  display: block;
+  width: 100%;
+  padding: $spacing-2 $spacing-3;
+  margin-bottom: $spacing-1;
+  border-radius: $border-radius-sm;
+  @include text-secondary;
+  font-weight: $font-weight-medium;
+  color: $color-text-primary;
+  text-decoration: none;
+  @include transition-colors;
+
+  &:hover {
+    background-color: $neutral-100;
+  }
+}

--- a/frontend/src/components/SettingsDropdown.tsx
+++ b/frontend/src/components/SettingsDropdown.tsx
@@ -6,13 +6,14 @@ import Link from "next/link";
 import { useSettings } from "@/hooks/useSettings";
 import type { AiMode } from "@/lib/settings";
 import { logger } from "@/lib/logger";
-import { config } from "@/lib/config";
+import { useFeatureFlags } from "@/hooks/useFeatureFlags";
 import { isAuthenticated, clearAdminToken } from "@/lib/api/client";
 import styles from "./SettingsDropdown.module.scss";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
 export default function SettingsDropdown() {
+  const { llmFeaturesEnabled } = useFeatureFlags();
   const { settings, updateSettings } = useSettings();
   const [isOpen, setIsOpen] = useState(false);
   const [isWarmingUp, setIsWarmingUp] = useState(false);
@@ -107,7 +108,7 @@ export default function SettingsDropdown() {
         {isOpen && (
           <div className={styles.dropdown}>
             <div className={styles.dropdownContent}>
-              {config.llmFeaturesEnabled ? (
+              {llmFeaturesEnabled ? (
                 <>
                   <div className={styles.header}>
                     <h3 className={styles.title}>AI Suggestions</h3>
@@ -163,9 +164,12 @@ export default function SettingsDropdown() {
                 </div>
               )}
 
-              {/* Logout section */}
+              {/* Admin section */}
               {isUserAuthenticated && (
                 <div className={styles.logoutSection}>
+                  <Link href="/admin" className={styles.adminLink} onClick={() => setIsOpen(false)}>
+                    Admin Settings
+                  </Link>
                   <button onClick={handleLogout} className={styles.logoutButton}>
                     Sign Out
                   </button>

--- a/frontend/src/components/SettingsDropdown.tsx
+++ b/frontend/src/components/SettingsDropdown.tsx
@@ -13,7 +13,7 @@ import styles from "./SettingsDropdown.module.scss";
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
 export default function SettingsDropdown() {
-  const { llmFeaturesEnabled } = useFeatureFlags();
+  const { llmFeaturesEnabled, loaded: flagsLoaded } = useFeatureFlags();
   const { settings, updateSettings } = useSettings();
   const [isOpen, setIsOpen] = useState(false);
   const [isWarmingUp, setIsWarmingUp] = useState(false);
@@ -108,7 +108,7 @@ export default function SettingsDropdown() {
         {isOpen && (
           <div className={styles.dropdown}>
             <div className={styles.dropdownContent}>
-              {llmFeaturesEnabled ? (
+              {!flagsLoaded ? null : llmFeaturesEnabled ? (
                 <>
                   <div className={styles.header}>
                     <h3 className={styles.title}>AI Suggestions</h3>

--- a/frontend/src/hooks/useFeatureFlags.ts
+++ b/frontend/src/hooks/useFeatureFlags.ts
@@ -29,10 +29,6 @@ function getSnapshot(): FeatureFlags {
   return flags;
 }
 
-function getServerSnapshot(): FeatureFlags {
-  return flags;
-}
-
 function setFlags(next: FeatureFlags): void {
   flags = next;
   listeners.forEach((listener) => listener());
@@ -56,11 +52,13 @@ async function fetchFlags(): Promise<void> {
 }
 
 /**
- * Re-fetch flags from the backend (e.g., after an admin toggles a flag).
+ * Apply a flag value directly to the store (from an authoritative source,
+ * e.g. the response of an admin PUT). Backend flag names map to store fields.
  */
-export function refreshFeatureFlags(): Promise<void> {
-  fetchStarted = true;
-  return fetchFlags();
+export function applyFeatureFlag(name: string, enabled: boolean): void {
+  if (name === "llm_features") {
+    setFlags({ ...flags, llmFeaturesEnabled: enabled, loaded: true });
+  }
 }
 
 /**
@@ -74,5 +72,5 @@ export function useFeatureFlags(): FeatureFlags {
     fetchStarted = true;
     void fetchFlags();
   }
-  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }

--- a/frontend/src/hooks/useFeatureFlags.ts
+++ b/frontend/src/hooks/useFeatureFlags.ts
@@ -1,0 +1,78 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { config } from "@/lib/config";
+import { logger } from "@/lib/logger";
+
+const flagsLogger = logger.withContext("FeatureFlags");
+
+export interface FeatureFlags {
+  llmFeaturesEnabled: boolean;
+  loaded: boolean;
+}
+
+/**
+ * Module-level store so all components share one fetch of the runtime
+ * feature flags (from the backend status endpoint). Flags are controlled
+ * at runtime via the /admin page, not build-time env vars.
+ */
+let flags: FeatureFlags = { llmFeaturesEnabled: false, loaded: false };
+let fetchStarted = false;
+const listeners = new Set<() => void>();
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function getSnapshot(): FeatureFlags {
+  return flags;
+}
+
+function getServerSnapshot(): FeatureFlags {
+  return flags;
+}
+
+function setFlags(next: FeatureFlags): void {
+  flags = next;
+  listeners.forEach((listener) => listener());
+}
+
+async function fetchFlags(): Promise<void> {
+  try {
+    const response = await fetch(`${config.apiUrl}/`, { cache: "no-store" });
+    if (!response.ok) {
+      throw new Error(`Status endpoint returned ${response.status}`);
+    }
+    const status = await response.json();
+    setFlags({
+      llmFeaturesEnabled: status.llm_features_enabled === true,
+      loaded: true,
+    });
+  } catch (error) {
+    flagsLogger.error("Failed to fetch feature flags, defaulting to disabled:", error);
+    setFlags({ llmFeaturesEnabled: false, loaded: true });
+  }
+}
+
+/**
+ * Re-fetch flags from the backend (e.g., after an admin toggles a flag).
+ */
+export function refreshFeatureFlags(): Promise<void> {
+  fetchStarted = true;
+  return fetchFlags();
+}
+
+/**
+ * React hook exposing runtime feature flags.
+ *
+ * Flags default to disabled until the first fetch resolves; check `loaded`
+ * to distinguish "disabled" from "still loading" when needed.
+ */
+export function useFeatureFlags(): FeatureFlags {
+  if (typeof window !== "undefined" && !fetchStarted) {
+    fetchStarted = true;
+    void fetchFlags();
+  }
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/frontend/src/lib/api/admin.ts
+++ b/frontend/src/lib/api/admin.ts
@@ -1,0 +1,32 @@
+/**
+ * Admin API - feature flag management (requires admin token)
+ */
+
+import { apiGet, apiPut } from "./client";
+
+export interface FeatureFlag {
+  name: string;
+  enabled: boolean;
+  description: string;
+}
+
+interface FeatureFlagsResponse {
+  flags: FeatureFlag[];
+}
+
+export interface FeatureFlagUpdateResponse {
+  flag: FeatureFlag;
+  persisted: boolean;
+}
+
+export async function getFeatureFlags(): Promise<FeatureFlag[]> {
+  const response = await apiGet<FeatureFlagsResponse>("/api/admin/feature-flags");
+  return response.flags;
+}
+
+export async function updateFeatureFlag(
+  name: string,
+  enabled: boolean
+): Promise<FeatureFlagUpdateResponse> {
+  return apiPut<FeatureFlagUpdateResponse>(`/api/admin/feature-flags/${name}`, { enabled });
+}

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -10,13 +10,6 @@ export const config = {
   apiUrl: process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000",
 
   /**
-   * Master switch for LLM/AI features
-   * Default: false (off to save resources in production)
-   * Set to "true" to enable AI features (Q&A, semantic search, suggestions)
-   */
-  llmFeaturesEnabled: process.env.NEXT_PUBLIC_LLM_FEATURES_ENABLED === "true",
-
-  /**
    * Allow unauthenticated users to use AI features
    * Default: true (allows visitors to try AI suggestions)
    * Set to "false" to restrict AI features to authenticated users only


### PR DESCRIPTION
## Summary

Replaces the deploy-time `LLM_FEATURES_ENABLED` gating (#185/#186) with runtime feature flags an admin can toggle from a minimal `/admin` page — no restart or redeploy required.

## Backend

- **`feature_flags.py`**: `FeatureFlagService` persists flags as `FeatureFlag` nodes in Neo4j with a 15s TTL cache. Production runs 4 uvicorn workers; a toggle lands on one worker and the others converge via Neo4j within the TTL.
- **`GET/PUT /api/admin/feature-flags`** (admin bearer auth), injected via `Depends()` like the rest of the routers.
- AI router is always registered but gated per-request — returns 503 with a clear message when `llm_features` is off. Semantic search falls back to text search; embedding sync and the status endpoint read the runtime flag.
- `LLM_FEATURES_ENABLED` env var is now only the **seed default** for a flag that has never been toggled; once set in the UI, the Neo4j value wins (and survives restarts).

## Frontend

- **`useFeatureFlags()`** hook fetches runtime flags from the backend status endpoint (module-level shared store), replacing the build-time `NEXT_PUBLIC_LLM_FEATURES_ENABLED` var (removed).
- **`/admin`** page with toggle switches; redirects to `/login` when unauthenticated; linked as “Admin Settings” in the settings dropdown. Toggles update the app immediately from the authoritative PUT response.
- Settings components use the hook's `loaded` state so they don't flash “AI features are not available” while flags load.

## Testing

- 19 new backend unit tests (service semantics, admin API auth/caching, runtime gating incl. multi-worker TTL convergence and Neo4j write-error handling)
- 4 new frontend Vitest tests for the hook
- Verified live in dev: toggle → status flips → AI endpoints 503 → re-enable, all without restart; value persisted in Neo4j

## Deploy notes

- The Ollama container still runs in prod (infra); the flag controls whether the backend uses it. With `OLLAMA_KEEP_ALIVE=0` idle RAM cost is small.
- After deploy, prod seeds to **disabled** (env default) until you enable it once at `/admin`.

## Known trade-offs (noted, not blocking)

- First paint renders without AI UI until the flag fetch resolves (inherent to runtime flags; `loaded` gate covers the worst case in Settings).
- Admin/login page headers share ~70 lines of similar SCSS that could be extracted later.

Fixes #188