### PR TITLE
feat: LLM provider abstraction with hosted API routing (Groq/Gemini)

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -14,11 +14,19 @@ This configures git to use the `.githooks` directory for all hooks.
 
 ## Available Hooks
 
+### commit-msg
+
+Appends a DCO `Signed-off-by:` trailer to every commit automatically (CI
+enforces DCO on all commits). Equivalent to always passing `git commit -s`.
+
 ### pre-push
 
 Runs before `git push` to catch issues before they reach CI.
 
 **Checks performed:**
+
+- ✓ DCO sign-off on every commit being pushed (backstop for commits made
+  before the commit-msg hook was installed; fix with `git rebase --signoff origin/main`)
 
 Backend:
 - ✓ Linting (ruff)

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,19 @@
+#!/bin/bash
+# commit-msg hook: append a DCO Signed-off-by trailer if missing.
+# CI enforces DCO on all commits; this makes every local commit compliant
+# without having to remember `git commit -s`.
+
+MSG_FILE="$1"
+NAME=$(git config user.name)
+EMAIL=$(git config user.email)
+
+if [ -z "$NAME" ] || [ -z "$EMAIL" ]; then
+    echo "commit-msg hook: git user.name/user.email not set; cannot add Signed-off-by" >&2
+    exit 1
+fi
+
+SOB="Signed-off-by: $NAME <$EMAIL>"
+
+if ! grep -qs "^$SOB" "$MSG_FILE"; then
+    printf '\n%s\n' "$SOB" >> "$MSG_FILE"
+fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -16,6 +16,43 @@ NC='\033[0m' # No Color
 # Track if any checks fail
 FAILED=0
 
+# DCO sign-off check (CI enforces this on every commit)
+# Reads the refs being pushed from stdin - must run before anything else
+# consumes stdin.
+echo "✍️  DCO Sign-off Check"
+echo "====================="
+ZERO_SHA="0000000000000000000000000000000000000000"
+UNSIGNED=""
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+    # Branch deletion - nothing to check
+    [ "$local_sha" = "$ZERO_SHA" ] && continue
+    if [ "$remote_sha" = "$ZERO_SHA" ]; then
+        # New remote branch - check commits not already on origin/main
+        range="origin/main..$local_sha"
+    else
+        range="$remote_sha..$local_sha"
+    fi
+    for commit in $(git rev-list --no-merges "$range" 2>/dev/null); do
+        if ! git show -s --format=%B "$commit" | grep -q "^Signed-off-by:"; then
+            UNSIGNED="$UNSIGNED $commit"
+        fi
+    done
+done
+
+if [ -n "$UNSIGNED" ]; then
+    echo -e "  ${RED}✗ Commits missing Signed-off-by:${NC}"
+    for commit in $UNSIGNED; do
+        echo "    $(git log -1 --format='%h %s' "$commit")"
+    done
+    echo -e "${RED}  Fix with: git rebase --signoff origin/main${NC}"
+    echo "  (The commit-msg hook adds sign-offs automatically - run ./setup-hooks.sh if commits are missing them)"
+    FAILED=1
+else
+    echo -e "  Sign-offs... ${GREEN}✓${NC}"
+fi
+
+echo ""
+
 # Backend checks
 echo "📦 Backend Quality Checks"
 echo "========================="

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,6 +75,8 @@ jobs:
           NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL }}
           CORS_ORIGINS: ${{ secrets.CORS_ORIGINS }}
           NEO4J_PASSWORD: ${{ secrets.NEO4J_PASSWORD }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |
           # Pass secrets to remote server via SSH command arguments
           ssh $DO_USER@$DO_HOST "bash -s" \
@@ -82,7 +84,9 @@ jobs:
             "$OP_SERVICE_ACCOUNT_TOKEN" \
             "$ADMIN_PASSKEY" \
             "$NEXT_PUBLIC_API_URL" \
-            "$NEO4J_PASSWORD" << 'EOF'
+            "$NEO4J_PASSWORD" \
+            "$GROQ_API_KEY" \
+            "$GEMINI_API_KEY" << 'EOF'
             set -e
 
             # Receive arguments
@@ -91,6 +95,8 @@ jobs:
             ADMIN_PASSKEY="$3"
             NEXT_PUBLIC_API_URL="$4"
             NEO4J_PASSWORD="$5"
+            GROQ_API_KEY="$6"
+            GEMINI_API_KEY="$7"
 
             echo "📦 Deploying Mongado to production..."
 
@@ -115,6 +121,9 @@ jobs:
             echo "CORS_ORIGINS=$CORS_ORIGINS" >> backend/.env
             echo "OP_MONGADO_SERVICE_ACCOUNT_TOKEN=$OP_SERVICE_ACCOUNT_TOKEN" >> backend/.env
             echo "ADMIN_TOKEN=$ADMIN_PASSKEY" >> backend/.env
+            # Hosted LLM API keys (empty until the GitHub secrets are set - see issue #190)
+            echo "GROQ_API_KEY=$GROQ_API_KEY" >> backend/.env
+            echo "GEMINI_API_KEY=$GEMINI_API_KEY" >> backend/.env
 
             # Root .env file for docker-compose (so env vars persist across manual runs)
             echo "NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL" > .env

--- a/backend/config.py
+++ b/backend/config.py
@@ -55,6 +55,22 @@ class Settings(BaseSettings):
     # value in Neo4j always wins over this setting.
     llm_features_enabled: bool = False  # Default off to save resources in production
 
+    # LLM API provider seed default for the "llm_use_api" feature flag.
+    # When enabled (via admin UI), AI generation (Q&A, summaries, suggestions)
+    # is routed to hosted APIs (Groq primary, Gemini fallback) instead of
+    # local Ollama. Embeddings always stay on Ollama regardless of this flag.
+    llm_use_api: bool = False
+
+    # Hosted API providers (OpenAI-compatible chat completions)
+    groq_api_key: str | None = None
+    groq_base_url: str = "https://api.groq.com/openai/v1"
+    groq_model: str = "llama-3.1-8b-instant"  # Free tier: 14,400 req/day
+    gemini_api_key: str | None = None
+    gemini_base_url: str = "https://generativelanguage.googleapis.com/v1beta/openai"
+    gemini_model: str = "gemini-flash-latest"  # Free tier: 1,500 req/day
+    llm_api_timeout: float = 30.0  # Per-provider request timeout (seconds)
+    llm_api_max_tokens: int = 1024  # Default response cap for API generation
+
     # Ollama settings
     ollama_host: str = "http://localhost:11434"  # Default Ollama endpoint
     ollama_embed_model: str = "nomic-embed-text"  # Embedding model (small, fast, optimized)

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -22,27 +22,31 @@ Usage in tests:
 from typing import Any
 
 from adapters.neo4j import Neo4jAdapter, get_neo4j_adapter
+from llm_client import RoutingLLMClient, get_llm_client
 from notes_service import NotesService
 from notes_service import get_notes_service as _get_notes_service
-from ollama_client import OllamaClient, get_ollama_client
 
 # Module-level instances (created once at import)
 # These are the "real" instances used in production
-_ollama_client: OllamaClient | None = None
+_llm: RoutingLLMClient | None = None
 _neo4j_adapter: Neo4jAdapter | None = None
 _notes_service: NotesService | None = None
 
 
-def get_ollama() -> OllamaClient:
-    """Get the Ollama client instance.
+def get_llm() -> RoutingLLMClient:
+    """Get the LLM client (routes between Ollama and hosted APIs).
 
     This dependency can be overridden in tests:
-        app.dependency_overrides[get_ollama] = lambda: mock_client
+        app.dependency_overrides[get_llm] = lambda: mock_client
     """
-    global _ollama_client
-    if _ollama_client is None:
-        _ollama_client = get_ollama_client()
-    return _ollama_client
+    global _llm
+    if _llm is None:
+        _llm = get_llm_client()
+    return _llm
+
+
+# Backwards-compatible alias (pre-API-provider name)
+get_ollama = get_llm
 
 
 def get_neo4j() -> Neo4jAdapter:
@@ -110,9 +114,9 @@ def reset_dependencies() -> None:
 
     Call this in test fixtures to ensure clean state between tests.
     """
-    global _ollama_client, _neo4j_adapter, _notes_service
+    global _llm, _neo4j_adapter, _notes_service
     global _static_articles, _user_resources
-    _ollama_client = None
+    _llm = None
     _neo4j_adapter = None
     _notes_service = None
     _static_articles = []

--- a/backend/feature_flags.py
+++ b/backend/feature_flags.py
@@ -35,6 +35,15 @@ def _flag_definitions() -> dict[str, FlagDefinition]:
             description="AI/LLM features: semantic search, Q&A, summaries, link suggestions",
             default=settings.llm_features_enabled,
         ),
+        FlagDefinition(
+            name="llm_use_api",
+            description=(
+                "Route AI generation to hosted APIs (Groq primary, Gemini fallback) "
+                "instead of local Ollama. Requires GROQ_API_KEY/GEMINI_API_KEY; "
+                "without keys this flag has no effect. Embeddings stay on Ollama."
+            ),
+            default=settings.llm_use_api,
+        ),
     ]
     return {d.name: d for d in definitions}
 

--- a/backend/llm_client.py
+++ b/backend/llm_client.py
@@ -1,0 +1,327 @@
+"""LLM client abstraction: local Ollama or hosted APIs (Groq/Gemini).
+
+Provides a single client surface for all AI generation and embedding calls.
+Which backend handles *generation* is decided per-call by the "llm_use_api"
+runtime feature flag (admin UI). Embeddings and semantic search always use
+Ollama so stored embeddings in Neo4j stay consistent with query embeddings.
+
+Architecture:
+- ApiLLMClient: OpenAI-compatible chat completions with a provider fallback
+  chain (Groq primary, Gemini fallback). Configured via GROQ_API_KEY /
+  GEMINI_API_KEY; a provider without a key is simply skipped.
+- RoutingLLMClient: delegates each call to Ollama or the API chain based on
+  the feature flag. This is what routers receive via dependencies.get_llm().
+"""
+
+import json
+import logging
+from collections.abc import Generator
+from dataclasses import dataclass
+from typing import Any
+
+from config import get_settings
+from core import ai as ai_core
+from ollama_client import OllamaClient, get_ollama_client
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ApiProvider:
+    """A hosted OpenAI-compatible inference provider."""
+
+    name: str
+    base_url: str
+    api_key: str
+    model: str
+
+
+def _build_providers() -> list[ApiProvider]:
+    """Build the provider chain from settings (order = fallback priority)."""
+    settings = get_settings()
+    providers = []
+    if settings.groq_api_key:
+        providers.append(
+            ApiProvider(
+                name="groq",
+                base_url=settings.groq_base_url,
+                api_key=settings.groq_api_key,
+                model=settings.groq_model,
+            )
+        )
+    if settings.gemini_api_key:
+        providers.append(
+            ApiProvider(
+                name="gemini",
+                base_url=settings.gemini_base_url,
+                api_key=settings.gemini_api_key,
+                model=settings.gemini_model,
+            )
+        )
+    return providers
+
+
+class ApiLLMClient:
+    """LLM generation via hosted OpenAI-compatible APIs with fallback chain."""
+
+    def __init__(self, providers: list[ApiProvider] | None = None) -> None:
+        settings = get_settings()
+        self.providers = _build_providers() if providers is None else providers
+        self.timeout = settings.llm_api_timeout
+        self.default_max_tokens = settings.llm_api_max_tokens
+        if self.providers:
+            logger.info(
+                "API LLM client configured with providers: %s",
+                ", ".join(f"{p.name} ({p.model})" for p in self.providers),
+            )
+
+    def is_available(self) -> bool:
+        """Check if at least one API provider is configured."""
+        return bool(self.providers)
+
+    def _request_body(
+        self, provider: ApiProvider, prompt: str, max_tokens: int | None, stream: bool
+    ) -> dict[str, Any]:
+        return {
+            "model": provider.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": max_tokens or self.default_max_tokens,
+            "stream": stream,
+        }
+
+    def generate(
+        self,
+        prompt: str,
+        *,
+        role: str = "chat",
+        num_ctx: int | None = None,
+        max_tokens: int | None = None,
+    ) -> str | None:
+        """Generate a completion, trying each provider in order.
+
+        Args:
+            prompt: The full prompt text
+            role: "chat" or "structured" (accepted for interface parity with
+                OllamaClient; hosted models handle both with one model)
+            num_ctx: Ignored for API providers (hosted context windows are large)
+            max_tokens: Response length cap (defaults to settings)
+
+        Returns:
+            Generated text, or None if all providers failed
+        """
+        import httpx
+
+        for provider in self.providers:
+            try:
+                response = httpx.post(
+                    f"{provider.base_url}/chat/completions",
+                    headers={"Authorization": f"Bearer {provider.api_key}"},
+                    json=self._request_body(provider, prompt, max_tokens, stream=False),
+                    timeout=self.timeout,
+                )
+                response.raise_for_status()
+                data = response.json()
+                content: str | None = data["choices"][0]["message"]["content"]
+                if content:
+                    logger.debug("Generated %d chars via %s", len(content), provider.name)
+                    return content
+                logger.warning("Empty completion from %s, trying next provider", provider.name)
+            except Exception as e:
+                logger.warning("Provider %s failed (%s), trying next provider", provider.name, e)
+        logger.error("All API providers failed for generation")
+        return None
+
+    def generate_stream(
+        self,
+        prompt: str,
+        *,
+        role: str = "chat",
+        num_ctx: int | None = None,
+        max_tokens: int | None = None,
+    ) -> Generator[str]:
+        """Stream a completion as text chunks, with provider fallback.
+
+        Falls back to the next provider only if the current one fails before
+        yielding any content (a mid-stream failure ends the stream).
+        """
+        import httpx
+
+        for provider in self.providers:
+            yielded = False
+            try:
+                with httpx.stream(
+                    "POST",
+                    f"{provider.base_url}/chat/completions",
+                    headers={"Authorization": f"Bearer {provider.api_key}"},
+                    json=self._request_body(provider, prompt, max_tokens, stream=True),
+                    timeout=self.timeout,
+                ) as response:
+                    response.raise_for_status()
+                    for line in response.iter_lines():
+                        if not line.startswith("data: "):
+                            continue
+                        payload = line[len("data: ") :].strip()
+                        if payload == "[DONE]":
+                            return
+                        try:
+                            chunk = json.loads(payload)
+                        except json.JSONDecodeError:
+                            continue
+                        choices = chunk.get("choices") or []
+                        delta = choices[0].get("delta", {}) if choices else {}
+                        content = delta.get("content")
+                        if content:
+                            yielded = True
+                            yield content
+                return
+            except Exception as e:
+                if yielded:
+                    logger.error("Provider %s failed mid-stream: %s", provider.name, e)
+                    return
+                logger.warning("Provider %s failed (%s), trying next provider", provider.name, e)
+        logger.error("All API providers failed for streaming generation")
+
+    def ask_question(
+        self,
+        question: str,
+        context_documents: list[dict[str, Any]],
+        allow_general_knowledge: bool = True,
+    ) -> str | None:
+        """Answer a question with document context (RAG)."""
+        prompt = ai_core.build_qa_prompt(question, context_documents, allow_general_knowledge)
+        return self.generate(prompt, role="chat")
+
+    def summarize_article(self, content: str) -> str | None:
+        """Generate a 2-3 sentence summary of article content."""
+        prompt = ai_core.build_summary_prompt(content, content_type="article")
+        return self.generate(prompt, role="chat", max_tokens=256)
+
+    def warmup(self, context: str = "chat") -> tuple[bool, str]:
+        """No-op: hosted APIs need no warmup."""
+        model = self.providers[0].model if self.providers else ""
+        return self.is_available(), model
+
+
+class RoutingLLMClient:
+    """Routes LLM calls to Ollama or hosted APIs based on the runtime flag.
+
+    - Generation (generate, ask_question, summarize, streaming): API chain
+      when the "llm_use_api" flag is on and providers are configured,
+      otherwise Ollama.
+    - Embeddings and semantic search: always Ollama, so query embeddings
+      match the precomputed embeddings stored in Neo4j.
+    """
+
+    def __init__(self, ollama: OllamaClient, api: ApiLLMClient) -> None:
+        self.ollama = ollama
+        self.api = api
+
+    # --- routing -----------------------------------------------------------
+
+    def _use_api(self) -> bool:
+        if not self.api.is_available():
+            return False
+        # Imported here to avoid a circular import at module load time
+        from feature_flags import get_feature_flags
+
+        return get_feature_flags().is_enabled("llm_use_api")
+
+    def _generation_backend(self) -> Any:
+        return self.api if self._use_api() else self.ollama
+
+    @property
+    def active_provider(self) -> str:
+        """Name of the backend currently serving generation requests."""
+        if self._use_api():
+            return " -> ".join(p.name for p in self.api.providers)
+        return "ollama"
+
+    # --- generation (routed) ----------------------------------------------
+
+    def generate(self, prompt: str, **kwargs: Any) -> str | None:
+        result: str | None = self._generation_backend().generate(prompt, **kwargs)
+        return result
+
+    def generate_stream(self, prompt: str, **kwargs: Any) -> Generator[str]:
+        yield from self._generation_backend().generate_stream(prompt, **kwargs)
+
+    def ask_question(
+        self,
+        question: str,
+        context_documents: list[dict[str, Any]],
+        allow_general_knowledge: bool = True,
+    ) -> str | None:
+        result: str | None = self._generation_backend().ask_question(
+            question, context_documents, allow_general_knowledge
+        )
+        return result
+
+    def summarize_article(self, content: str) -> str | None:
+        result: str | None = self._generation_backend().summarize_article(content)
+        return result
+
+    def is_available(self) -> bool:
+        """Whether generation is currently possible."""
+        available: bool = self._generation_backend().is_available()
+        return available
+
+    def has_gpu(self) -> bool:
+        """Hosted APIs are treated as accelerated; Ollama reports its own state."""
+        if self._use_api():
+            return True
+        return self.ollama.has_gpu()
+
+    def warmup(self, context: str = "chat") -> tuple[bool, str]:
+        """Warm up the backend that will serve the given context."""
+        if context == "embedding":
+            return self.ollama.warmup(context=context)
+        result: tuple[bool, str] = self._generation_backend().warmup(context=context)
+        return result
+
+    # --- embeddings / search (always Ollama) --------------------------------
+
+    @property
+    def model(self) -> str:
+        """Embedding model tag used when storing embeddings (Ollama's)."""
+        return self.ollama.model
+
+    @property
+    def chat_model(self) -> str:
+        if self._use_api():
+            return self.api.providers[0].model
+        return self.ollama.chat_model
+
+    @property
+    def structured_model(self) -> str:
+        if self._use_api():
+            return self.api.providers[0].model
+        return self.ollama.structured_model
+
+    def generate_embedding(self, text: str, use_cache: bool = True) -> list[float] | None:
+        return self.ollama.generate_embedding(text, use_cache=use_cache)
+
+    def semantic_search(
+        self, query: str, documents: list[dict[str, Any]], top_k: int = 5
+    ) -> list[dict[str, Any]]:
+        return self.ollama.semantic_search(query, documents, top_k)
+
+    def semantic_search_with_precomputed_embeddings(
+        self, query: str, documents_with_embeddings: list[dict[str, Any]], top_k: int = 5
+    ) -> list[dict[str, Any]]:
+        return self.ollama.semantic_search_with_precomputed_embeddings(
+            query, documents_with_embeddings, top_k
+        )
+
+    def clear_cache(self) -> int:
+        return self.ollama.clear_cache()
+
+
+_llm_client: RoutingLLMClient | None = None
+
+
+def get_llm_client() -> RoutingLLMClient:
+    """Get the global routing LLM client instance."""
+    global _llm_client
+    if _llm_client is None:
+        _llm_client = RoutingLLMClient(get_ollama_client(), ApiLLMClient())
+    return _llm_client

--- a/backend/llm_client.py
+++ b/backend/llm_client.py
@@ -121,11 +121,19 @@ class ApiLLMClient:
                 )
                 response.raise_for_status()
                 data = response.json()
-                content: str | None = data["choices"][0]["message"]["content"]
+                choices = data.get("choices") or []
+                message = choices[0].get("message", {}) if choices else {}
+                content: str | None = message.get("content")
                 if content:
                     logger.debug("Generated %d chars via %s", len(content), provider.name)
                     return content
-                logger.warning("Empty completion from %s, trying next provider", provider.name)
+                # e.g. Gemini spends the whole max_tokens budget on internal
+                # reasoning and returns finish_reason=length with no content
+                logger.warning(
+                    "Empty completion from %s (finish_reason=%s), trying next provider",
+                    provider.name,
+                    choices[0].get("finish_reason") if choices else "n/a",
+                )
             except Exception as e:
                 logger.warning("Provider %s failed (%s), trying next provider", provider.name, e)
         logger.error("All API providers failed for generation")

--- a/backend/notes_service.py
+++ b/backend/notes_service.py
@@ -6,8 +6,8 @@ from typing import Any
 from adapters.neo4j import get_neo4j_adapter
 from core import ai as ai_core
 from embedding_sync import EMBEDDING_VERSION
+from llm_client import get_llm_client
 from note_id_generator import get_id_generator
-from ollama_client import get_ollama_client
 from wikilink_parser import get_wikilink_parser
 
 logger = logging.getLogger(__name__)
@@ -24,7 +24,7 @@ class NotesService:
         self.neo4j = get_neo4j_adapter()
         self.id_generator = get_id_generator()
         self.wikilink_parser = get_wikilink_parser()
-        self.ollama = get_ollama_client()
+        self.ollama = get_llm_client()
 
         if self.neo4j.is_available():
             logger.info("NotesService initialized with Neo4j")
@@ -411,20 +411,13 @@ class NotesService:
             logger.debug("Skipping AI content generation for %s (Ollama unavailable)", note_id)
             return
 
-        if not self.ollama.client:
-            return
-
         # Generate summary
         summary = None
         try:
             logger.debug("Generating AI summary for note: %s", note_id)
             prompt = ai_core.build_summary_prompt(content, content_type="note")
-            response = self.ollama.client.generate(
-                model=self.ollama.chat_model,
-                prompt=prompt,
-                options={"num_ctx": 2048, "num_predict": 256},
-            )
-            summary = response.get("response", "").strip()
+            response = self.ollama.generate(prompt, role="chat", num_ctx=2048, max_tokens=256)
+            summary = (response or "").strip()
             if summary:
                 logger.info("Generated AI summary for note: %s", note_id)
         except Exception as e:
@@ -457,13 +450,9 @@ class NotesService:
                     max_candidates=50,
                 )
 
-                response = self.ollama.client.generate(
-                    model=self.ollama.structured_model,
-                    prompt=prompt,
-                    options={"num_ctx": 8192},
+                response_text = (
+                    self.ollama.generate(prompt, role="structured", num_ctx=8192) or ""
                 )
-
-                response_text = response.get("response", "")
                 suggestions_data = ai_core.parse_json_response(response_text, expected_type="array")
 
                 if suggestions_data and isinstance(suggestions_data, list):

--- a/backend/ollama_client.py
+++ b/backend/ollama_client.py
@@ -1,6 +1,7 @@
 """Ollama integration for AI-powered features."""
 
 import logging
+from collections.abc import Generator
 from typing import Any
 
 from config import get_settings
@@ -135,6 +136,71 @@ class OllamaClient:
         except Exception as e:
             logger.error("Failed to generate embedding: %s", e)
             return None
+
+    def _model_for_role(self, role: str) -> str:
+        """Map a generation role to the configured Ollama model."""
+        return self.structured_model if role == "structured" else self.chat_model
+
+    def generate(
+        self,
+        prompt: str,
+        *,
+        role: str = "chat",
+        num_ctx: int | None = None,
+        max_tokens: int | None = None,
+    ) -> str | None:
+        """Generate a completion using the model configured for the role.
+
+        Args:
+            prompt: The full prompt text
+            role: "chat" (llama) or "structured" (qwen, reliable JSON)
+            num_ctx: Context window size (defaults to configured num_ctx)
+            max_tokens: Response length cap (Ollama num_predict)
+
+        Returns:
+            Generated text, or None if unavailable or failed
+        """
+        if not self.is_available() or self.client is None:
+            logger.debug("Ollama not available, cannot generate")
+            return None
+
+        options: dict[str, int] = {"num_ctx": num_ctx or self.num_ctx}
+        if max_tokens is not None:
+            options["num_predict"] = max_tokens
+
+        try:
+            response = self.client.generate(
+                model=self._model_for_role(role), prompt=prompt, options=options
+            )
+            text: str = response.get("response", "")
+            return text
+        except Exception as e:
+            logger.error("Failed to generate completion: %s", e)
+            return None
+
+    def generate_stream(
+        self,
+        prompt: str,
+        *,
+        role: str = "chat",
+        num_ctx: int | None = None,
+        max_tokens: int | None = None,
+    ) -> Generator[str]:
+        """Stream a completion as text chunks (see generate for args)."""
+        if not self.is_available() or self.client is None:
+            logger.debug("Ollama not available, cannot stream")
+            return
+
+        options: dict[str, int] = {"num_ctx": num_ctx or self.num_ctx}
+        if max_tokens is not None:
+            options["num_predict"] = max_tokens
+
+        for chunk in self.client.generate(
+            model=self._model_for_role(role), prompt=prompt, options=options, stream=True
+        ):
+            text = chunk.get("response")
+            if text:
+                yield text
 
     def semantic_search_with_precomputed_embeddings(
         self, query: str, documents_with_embeddings: list[dict[str, Any]], top_k: int = 5

--- a/backend/requirements-base.txt
+++ b/backend/requirements-base.txt
@@ -8,6 +8,7 @@ onepassword-sdk==0.3.1  # Official 1Password SDK for service accounts
 python-frontmatter==1.1.0  # Parse markdown with YAML frontmatter
 boto3==1.40.50  # AWS S3 client (optional, for production)
 ollama==0.6.0  # Ollama Python client for AI features
+httpx==0.28.1  # HTTP client for hosted LLM APIs (Groq/Gemini)
 neo4j==6.0.2  # Neo4j driver for graph database (notes)
 slowapi==0.1.9  # Rate limiting for FastAPI
 rapidfuzz==3.10.1  # Fuzzy string matching for search

--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -13,7 +13,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
 from core import ai as ai_core
-from dependencies import get_neo4j, get_notes, get_ollama, get_static_articles, get_user_resources
+from dependencies import get_llm, get_neo4j, get_notes, get_static_articles, get_user_resources
 from models import (
     GPUStatusResponse,
     LinkSuggestion,
@@ -57,7 +57,7 @@ def _get_all_resources(
 
 
 # Type aliases for cleaner signatures
-OllamaDep = Annotated[Any, Depends(get_ollama)]
+OllamaDep = Annotated[Any, Depends(get_llm)]
 NotesDep = Annotated[Any, Depends(get_notes)]
 Neo4jDep = Annotated[Any, Depends(get_neo4j)]
 ArticlesDep = Annotated[list[dict[str, Any]], Depends(get_static_articles)]
@@ -135,9 +135,13 @@ def get_gpu_status(ollama: OllamaDep) -> GPUStatusResponse:
 
     has_gpu = ollama.has_gpu()
     if has_gpu:
-        return GPUStatusResponse(
-            has_gpu=True, message="GPU acceleration is available. AI features will be fast."
+        provider = getattr(ollama, "active_provider", "ollama")
+        message = (
+            f"AI generation served by hosted API ({provider}). AI features will be fast."
+            if provider != "ollama"
+            else "GPU acceleration is available. AI features will be fast."
         )
+        return GPUStatusResponse(has_gpu=True, message=message)
     else:
         return GPUStatusResponse(
             has_gpu=False,
@@ -273,14 +277,10 @@ def suggest_tags(
     )
 
     try:
-        # Use structured output model (qwen2.5:1.5b) for reliable JSON
-        response_data = ollama.client.generate(
-            model=ollama.structured_model, prompt=prompt, options={"num_ctx": 4096}
-        )
-
-        response = response_data.get("response", "")
+        # Use the structured-output role (Ollama: qwen2.5:1.5b; API: hosted model)
+        response = ollama.generate(prompt, role="structured", num_ctx=4096)
         if not response:
-            logger.error("Empty response from Ollama for tag suggestions")
+            logger.error("Empty response from LLM for tag suggestions")
             return TagSuggestionsResponse(suggestions=[], count=0)
 
         # Parse JSON response using pure function
@@ -406,16 +406,10 @@ def suggest_links(
     )
 
     try:
-        # Use structured output model (qwen2.5:1.5b) for reliable JSON
-        response_data = ollama.client.generate(
-            model=ollama.structured_model,
-            prompt=prompt,
-            options={"num_ctx": 8192},  # Larger context for multiple notes
-        )
-
-        response = response_data.get("response", "")
+        # Use the structured-output role; larger context for multiple notes
+        response = ollama.generate(prompt, role="structured", num_ctx=8192)
         if not response:
-            logger.error("Empty response from Ollama for link suggestions")
+            logger.error("Empty response from LLM for link suggestions")
             return LinkSuggestionsResponse(suggestions=[], count=0)
 
         # Parse JSON response using pure function
@@ -518,20 +512,14 @@ def suggest_stream(
             # Generate tags with token streaming for real-time progress
             tag_text = ""
             token_count = 0
-            for chunk in _ollama.client.generate(
-                model=_ollama.structured_model,
-                prompt=tag_prompt,
-                options={"num_ctx": 4096},
-                stream=True,
-            ):
-                if chunk.get("response"):
-                    tag_text += chunk["response"]
-                    token_count += 1
-                    # Send heartbeat every 10 tokens to show activity
-                    if token_count % 10 == 0:
-                        yield format_sse(
-                            {"type": "generating", "phase": "tags", "tokens": token_count}
-                        )
+            for text in _ollama.generate_stream(tag_prompt, role="structured", num_ctx=4096):
+                tag_text += text
+                token_count += 1
+                # Send heartbeat every 10 tokens to show activity
+                if token_count % 10 == 0:
+                    yield format_sse(
+                        {"type": "generating", "phase": "tags", "tokens": token_count}
+                    )
 
             if tag_text:
                 tags_data = ai_core.parse_json_response(tag_text, expected_type="array")
@@ -573,20 +561,16 @@ def suggest_stream(
                 # Generate links with token streaming for real-time progress
                 link_text = ""
                 token_count = 0
-                for chunk in _ollama.client.generate(
-                    model=_ollama.structured_model,
-                    prompt=link_prompt,
-                    options={"num_ctx": 8192},
-                    stream=True,
+                for text in _ollama.generate_stream(
+                    link_prompt, role="structured", num_ctx=8192
                 ):
-                    if chunk.get("response"):
-                        link_text += chunk["response"]
-                        token_count += 1
-                        # Send heartbeat every 10 tokens to show activity
-                        if token_count % 10 == 0:
-                            yield format_sse(
-                                {"type": "generating", "phase": "links", "tokens": token_count}
-                            )
+                    link_text += text
+                    token_count += 1
+                    # Send heartbeat every 10 tokens to show activity
+                    if token_count % 10 == 0:
+                        yield format_sse(
+                            {"type": "generating", "phase": "links", "tokens": token_count}
+                        )
 
                 if link_text:
                     links_data = ai_core.parse_json_response(link_text, expected_type="array")

--- a/backend/routers/articles.py
+++ b/backend/routers/articles.py
@@ -272,14 +272,10 @@ Example: [{{"concept": "DORA metrics", "excerpt": "Four key metrics...", "confid
 JSON:"""
 
     try:
-        # Use qwen2.5:1.5b for structured output
-        response_data = ollama.client.generate(
-            model="qwen2.5:1.5b", prompt=prompt, options={"num_ctx": 8192}
-        )
-
-        response = response_data.get("response", "")
+        # Use the structured-output role for reliable JSON
+        response = ollama.generate(prompt, role="structured", num_ctx=8192)
         if not response:
-            logger.error("Empty response from Ollama for concept extraction")
+            logger.error("Empty response from LLM for concept extraction")
             return ConceptExtractionResponse(concepts=[], count=0)
 
         # Defensive JSON parsing (same pattern as other endpoints)

--- a/backend/routers/inspire.py
+++ b/backend/routers/inspire.py
@@ -73,7 +73,7 @@ def get_suggestions(
     suggestions: list[dict[str, Any]] = []
     has_llm = False
 
-    if ollama.is_available() and ollama.client and (gap_notes or connection_opportunities):
+    if ollama.is_available() and (gap_notes or connection_opportunities):
         try:
             # Build prompt for LLM
             prompt = inspire_core.build_inspiration_prompt(
@@ -82,13 +82,10 @@ def get_suggestions(
             )
 
             # Generate suggestions
-            response_data = ollama.client.generate(
-                model=ollama.structured_model,
-                prompt=prompt,
-                options={"num_ctx": 4096, "num_predict": 1024},
+            response_text = ollama.generate(
+                prompt, role="structured", num_ctx=4096, max_tokens=1024
             )
 
-            response_text = response_data.get("response", "")
             if response_text:
                 parsed = inspire_core.parse_inspiration_response(response_text)
                 if parsed:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -130,6 +130,33 @@ class MockOllamaClient:
         preview = content[:100] + "..." if len(content) > 100 else content
         return f"This is a mock summary of the article: {preview}"
 
+    def generate(
+        self,
+        prompt: str,
+        *,
+        role: str = "chat",
+        num_ctx: int | None = None,
+        max_tokens: int | None = None,
+    ) -> str | None:
+        """Mock generation (same JSON payload as the raw client mock)."""
+        if not self._available:
+            return None
+        return '[{"tag": "mock-tag", "confidence": 0.8, "reason": "mock reason"}]'
+
+    def generate_stream(
+        self,
+        prompt: str,
+        *,
+        role: str = "chat",
+        num_ctx: int | None = None,
+        max_tokens: int | None = None,
+    ) -> Generator[str]:
+        """Mock streaming generation yielding text chunks."""
+        if not self._available:
+            return
+        response = self.generate(prompt, role=role) or ""
+        yield from response
+
     def warmup(self, context: str = "chat") -> tuple[bool, str]:
         """Mock model warmup."""
         if not self._available:

--- a/backend/tests/unit/test_llm_client.py
+++ b/backend/tests/unit/test_llm_client.py
@@ -1,0 +1,281 @@
+"""Unit tests for the LLM client abstraction (API providers + routing)."""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+import llm_client as llm_module
+from llm_client import ApiLLMClient, ApiProvider, RoutingLLMClient
+
+GROQ = ApiProvider(
+    name="groq",
+    base_url="https://api.groq.com/openai/v1",
+    api_key="test-groq-key",
+    model="llama-3.1-8b-instant",
+)
+GEMINI = ApiProvider(
+    name="gemini",
+    base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+    api_key="test-gemini-key",
+    model="gemini-flash-latest",
+)
+
+
+def _completion_response(content: str) -> MagicMock:
+    """Build a mock httpx response with an OpenAI-compatible completion."""
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = {"choices": [{"message": {"content": content}}]}
+    return response
+
+
+# ============================================================================
+# ApiLLMClient
+# ============================================================================
+
+
+class TestApiLLMClient:
+    def test_not_available_without_providers(self) -> None:
+        client = ApiLLMClient(providers=[])
+        assert client.is_available() is False
+
+    def test_available_with_providers(self) -> None:
+        client = ApiLLMClient(providers=[GROQ])
+        assert client.is_available() is True
+
+    def test_generate_returns_none_without_providers(self) -> None:
+        client = ApiLLMClient(providers=[])
+        assert client.generate("hello") is None
+
+    def test_generate_uses_first_provider(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list[dict[str, Any]] = []
+
+        def mock_post(url: str, **kwargs: Any) -> MagicMock:
+            calls.append({"url": url, **kwargs})
+            return _completion_response("hello from groq")
+
+        monkeypatch.setattr("httpx.post", mock_post)
+        client = ApiLLMClient(providers=[GROQ, GEMINI])
+
+        assert client.generate("test prompt") == "hello from groq"
+        assert len(calls) == 1
+        assert calls[0]["url"].startswith(GROQ.base_url)
+        assert calls[0]["headers"]["Authorization"] == "Bearer test-groq-key"
+        assert calls[0]["json"]["model"] == GROQ.model
+        assert calls[0]["json"]["messages"] == [{"role": "user", "content": "test prompt"}]
+
+    def test_generate_falls_back_to_next_provider(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def mock_post(url: str, **kwargs: Any) -> MagicMock:
+            if GROQ.base_url in url:
+                raise ConnectionError("groq down")
+            return _completion_response("hello from gemini")
+
+        monkeypatch.setattr("httpx.post", mock_post)
+        client = ApiLLMClient(providers=[GROQ, GEMINI])
+
+        assert client.generate("test prompt") == "hello from gemini"
+
+    def test_generate_returns_none_when_all_providers_fail(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def mock_post(url: str, **kwargs: Any) -> MagicMock:
+            raise ConnectionError("all down")
+
+        monkeypatch.setattr("httpx.post", mock_post)
+        client = ApiLLMClient(providers=[GROQ, GEMINI])
+
+        assert client.generate("test prompt") is None
+
+    def test_generate_stream_parses_sse(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sse_lines = [
+            'data: {"choices": [{"delta": {"content": "Hel"}}]}',
+            "",
+            'data: {"choices": [{"delta": {"content": "lo"}}]}',
+            "data: [DONE]",
+        ]
+
+        stream_response = MagicMock()
+        stream_response.raise_for_status.return_value = None
+        stream_response.iter_lines.return_value = iter(sse_lines)
+        stream_cm = MagicMock()
+        stream_cm.__enter__.return_value = stream_response
+        stream_cm.__exit__.return_value = False
+
+        monkeypatch.setattr("httpx.stream", lambda *a, **kw: stream_cm)
+        client = ApiLLMClient(providers=[GROQ])
+
+        assert list(client.generate_stream("test prompt")) == ["Hel", "lo"]
+
+    def test_warmup_is_noop(self) -> None:
+        client = ApiLLMClient(providers=[GROQ])
+        success, model = client.warmup()
+        assert success is True
+        assert model == GROQ.model
+
+
+# ============================================================================
+# RoutingLLMClient
+# ============================================================================
+
+
+class MockBackend:
+    """Minimal generation backend recording which methods were called."""
+
+    def __init__(self, name: str, available: bool = True) -> None:
+        self.name = name
+        self._available = available
+        self.calls: list[str] = []
+        # Ollama-surface attributes used by routing
+        self.model = f"{name}-model"
+        self.chat_model = f"{name}-chat"
+        self.structured_model = f"{name}-structured"
+        self.providers = [GROQ]
+
+    def is_available(self) -> bool:
+        return self._available
+
+    def has_gpu(self) -> bool:
+        self.calls.append("has_gpu")
+        return False
+
+    def generate(self, prompt: str, **kwargs: Any) -> str:
+        self.calls.append("generate")
+        return f"answer from {self.name}"
+
+    def generate_stream(self, prompt: str, **kwargs: Any) -> Any:
+        self.calls.append("generate_stream")
+        yield self.name
+
+    def ask_question(self, question: str, docs: Any, allow_general_knowledge: bool = True) -> str:
+        self.calls.append("ask_question")
+        return f"answer from {self.name}"
+
+    def summarize_article(self, content: str) -> str:
+        self.calls.append("summarize_article")
+        return f"summary from {self.name}"
+
+    def warmup(self, context: str = "chat") -> tuple[bool, str]:
+        self.calls.append("warmup")
+        return True, f"{self.name}-model"
+
+    def generate_embedding(self, text: str, use_cache: bool = True) -> list[float]:
+        self.calls.append("generate_embedding")
+        return [0.1, 0.2]
+
+    def semantic_search(self, query: str, docs: Any, top_k: int = 5) -> list[Any]:
+        self.calls.append("semantic_search")
+        return []
+
+    def semantic_search_with_precomputed_embeddings(
+        self, query: str, docs: Any, top_k: int = 5
+    ) -> list[Any]:
+        self.calls.append("semantic_search_precomputed")
+        return []
+
+    def clear_cache(self) -> int:
+        self.calls.append("clear_cache")
+        return 0
+
+
+@pytest.fixture
+def flag_state(monkeypatch: pytest.MonkeyPatch) -> dict[str, bool]:
+    """Control the llm_use_api flag seen by RoutingLLMClient."""
+    state = {"llm_use_api": False}
+
+    mock_flags = MagicMock()
+    mock_flags.is_enabled.side_effect = lambda name: state.get(name, False)
+    monkeypatch.setattr("feature_flags.get_feature_flags", lambda: mock_flags)
+    return state
+
+
+class TestRoutingLLMClient:
+    def _make(
+        self, api_available: bool = True
+    ) -> tuple[RoutingLLMClient, MockBackend, MockBackend]:
+        ollama = MockBackend("ollama")
+        api = MockBackend("api", available=api_available)
+        return RoutingLLMClient(ollama, api), ollama, api  # type: ignore[arg-type]
+
+    def test_generation_uses_ollama_when_flag_off(self, flag_state: dict[str, bool]) -> None:
+        routing, ollama, api = self._make()
+        assert routing.generate("hi") == "answer from ollama"
+        assert routing.ask_question("q", []) == "answer from ollama"
+        assert api.calls == []
+
+    def test_generation_uses_api_when_flag_on(self, flag_state: dict[str, bool]) -> None:
+        flag_state["llm_use_api"] = True
+        routing, ollama, api = self._make()
+        assert routing.generate("hi") == "answer from api"
+        assert routing.summarize_article("content") == "summary from api"
+        assert list(routing.generate_stream("hi")) == ["api"]
+        assert ollama.calls == []
+
+    def test_flag_on_without_api_keys_falls_back_to_ollama(
+        self, flag_state: dict[str, bool]
+    ) -> None:
+        flag_state["llm_use_api"] = True
+        routing, ollama, api = self._make(api_available=False)
+        assert routing.generate("hi") == "answer from ollama"
+        assert api.calls == []
+
+    def test_embeddings_always_use_ollama(self, flag_state: dict[str, bool]) -> None:
+        flag_state["llm_use_api"] = True
+        routing, ollama, api = self._make()
+        routing.generate_embedding("text")
+        routing.semantic_search("q", [])
+        routing.semantic_search_with_precomputed_embeddings("q", [])
+        assert "generate_embedding" in ollama.calls
+        assert "semantic_search" in ollama.calls
+        assert "semantic_search_precomputed" in ollama.calls
+        assert api.calls == []
+
+    def test_embedding_warmup_always_uses_ollama(self, flag_state: dict[str, bool]) -> None:
+        flag_state["llm_use_api"] = True
+        routing, ollama, api = self._make()
+        routing.warmup(context="embedding")
+        assert ollama.calls == ["warmup"]
+        assert api.calls == []
+
+    def test_has_gpu_true_in_api_mode(self, flag_state: dict[str, bool]) -> None:
+        flag_state["llm_use_api"] = True
+        routing, ollama, api = self._make()
+        assert routing.has_gpu() is True
+
+    def test_active_provider_names(self, flag_state: dict[str, bool]) -> None:
+        routing, _, _ = self._make()
+        assert routing.active_provider == "ollama"
+        flag_state["llm_use_api"] = True
+        assert routing.active_provider == "groq"
+
+    def test_embedding_model_tag_stays_ollama(self, flag_state: dict[str, bool]) -> None:
+        flag_state["llm_use_api"] = True
+        routing, _, _ = self._make()
+        # .model tags stored embeddings - must stay Ollama's even in API mode
+        assert routing.model == "ollama-model"
+
+
+# ============================================================================
+# Provider construction from settings
+# ============================================================================
+
+
+class TestBuildProviders:
+    def test_no_keys_no_providers(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        settings = MagicMock()
+        settings.groq_api_key = None
+        settings.gemini_api_key = ""
+        monkeypatch.setattr(llm_module, "get_settings", lambda: settings)
+        assert llm_module._build_providers() == []
+
+    def test_groq_before_gemini(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        settings = MagicMock()
+        settings.groq_api_key = "gk"
+        settings.groq_base_url = "https://groq.example"
+        settings.groq_model = "groq-model"
+        settings.gemini_api_key = "mk"
+        settings.gemini_base_url = "https://gemini.example"
+        settings.gemini_model = "gemini-model"
+        monkeypatch.setattr(llm_module, "get_settings", lambda: settings)
+        providers = llm_module._build_providers()
+        assert [p.name for p in providers] == ["groq", "gemini"]

--- a/docs/AI_OPTIMIZATION.md
+++ b/docs/AI_OPTIMIZATION.md
@@ -1,0 +1,134 @@
+# AI/LLM Optimization Plan
+
+Analysis and migration plan for making the knowledge base's AI features fast and cheap. Written 2026-07-03. Tracked in [#190](https://github.com/DEGoodman/mongado/issues/190).
+
+## Problem Statement
+
+AI features (Q&A, semantic search, tag/link suggestions) are slow and constrained by the hosting setup:
+
+- **Single 4GB DigitalOcean droplet** runs frontend, backend, Neo4j, and Ollama.
+- Memory pressure forces aggressive Ollama settings (`OLLAMA_KEEP_ALIVE=0`, `OLLAMA_MAX_LOADED_MODELS=1`, `OLLAMA_NUM_PARALLEL=1`), so **every AI request pays a 15–20s cold model load** before CPU inference even starts.
+- Generation takes **60–120s** on CPU; even semantic search pays ~5–10s for the query embedding because the embed model is unloaded between requests.
+- Quality is capped by what fits in RAM: 1B–1.5B models (`llama3.2:1b`, `qwen2.5:1.5b`) produce mediocre answers and unreliable JSON.
+- `LLM_FEATURES_ENABLED` defaults to off in production because of all of the above — the features exist but are effectively unusable.
+
+## Current Architecture
+
+| Concern | Implementation | Location |
+|---|---|---|
+| Embeddings | Ollama `nomic-embed-text`, precomputed and stored in Neo4j | `ollama_client.py`, `embedding_sync.py` |
+| Semantic search | Query embedding + cosine similarity vs. precomputed vectors | `routers/search.py`, `core/ai.py` |
+| Q&A | RAG: top-5 docs as context → `llama3.2:1b` | `routers/ai.py` `/api/ask` |
+| Tag/link suggestions | `qwen2.5:1.5b` JSON output, cached in Neo4j, SSE streaming | `routers/ai.py`, `notes_service.py` |
+| Gating | Runtime feature flag (`llm_features`), rate limiting | `feature_flags.py`, `rate_limiter.py` |
+
+Notable strengths to preserve:
+- Precomputed embeddings in Neo4j with content-hash/model/version invalidation (`embedding_sync.py`) — already handles a future model change cleanly.
+- Prompt building and JSON parsing are pure functions in `core/ai.py` — provider-agnostic already.
+- All Ollama I/O funnels through `OllamaClient` — a single seam for a provider abstraction.
+- `config.py` already has `anthropic_api_key` / `openai_api_key` placeholders and 1Password secret support.
+
+## Options Analysis
+
+Assumed real-world volume: personal site, admin-heavy usage, rate-limited. Optimistically ~10–50 LLM requests/day at ~3K input + 500 output tokens each → **under 5M tokens/month**. This is tiny; it changes which options make sense.
+
+### Option A: GPU droplet — rejected
+
+DigitalOcean GPU droplets start around **$1.69/GPU/hr (~$1,200+/mo always-on)**. Even the cheapest GPU cloud instances elsewhere are $50–100+/mo. Three orders of magnitude past budget for this workload. ([DO GPU pricing](https://www.digitalocean.com/products/gradient/gpu-droplets))
+
+### Option B: Bigger/dedicated CPU box for Ollama (existing issue #150) — viable but dominated
+
+Hetzner CX32 (~$7.50/mo) running Ollama with `KEEP_ALIVE=5m` fixes the cold-start problem but:
+- Still CPU inference: ~3–5s at best, and only for 1B–3B models. Quality stays low.
+- Adds a second server to patch, monitor, and secure (exposed Ollama endpoint).
+- Costs more than the API options below while delivering less.
+
+### Option C: Third-party inference API — recommended
+
+Move generation (Q&A, suggestions) to a hosted API. All serious candidates speak the OpenAI-compatible chat API, so one integration covers all of them:
+
+| Provider | Free tier | Paid cost at our volume | Speed | Notes |
+|---|---|---|---|---|
+| **Groq** | 14,400 req/day on `llama-3.1-8b-instant` (500K tokens/day) | $0.05/$0.08 per MTok → **<$1/mo** | ~300 tok/s (fastest) | Free tier alone covers expected volume; prepaid credits = hard spend cap |
+| **Gemini Flash** | 1,500 req/day free | Pennies/mo | Fast | Good fallback provider; free tier per GCP project |
+| **Cloudflare Workers AI** | 10K neurons/day | $5/mo Workers Paid + $0.011/1K extra neurons | Fast | The "fixed $5/mo" option; also hosts `bge` embedding models |
+| **OpenRouter** | 50 req/day (1,000/day after one-time $10 credit) | Model-dependent | Varies | Meta-router; good escape hatch, weakest free tier |
+| **Anthropic Haiku 4.5** | None | $1/$5 per MTok → ~$1–5/mo | Fast | Best output quality; console spend limits give a hard cap |
+
+Sources: [Groq pricing](https://groq.com/pricing), [Groq free tier](https://tokenmix.ai/blog/groq-free-tier-limits-2026), [Gemini rate limits](https://ai.google.dev/gemini-api/docs/rate-limits), [Workers AI pricing](https://developers.cloudflare.com/workers-ai/platform/pricing/), [OpenRouter limits](https://openrouter.ai/docs/api/reference/limits), [Anthropic pricing](https://platform.claude.com/docs/en/about-claude/pricing).
+
+Every option here beats the current setup **and** option B on all three axes:
+- **Speed**: 1–3s responses instead of 60–120s.
+- **Quality**: 8B–flash-class models (or Haiku) instead of 1B–1.5B; reliable JSON via native structured-output/JSON modes instead of defensive parsing.
+- **Cost**: $0–5/mo with hard caps, vs. $7.50/mo (Hetzner) or being RAM-hostage on the current droplet.
+
+### Embeddings sub-decision
+
+Semantic search embeddings can stay local or move to an API:
+
+| Approach | Pros | Cons |
+|---|---|---|
+| **Keep Ollama for embeddings only** (`nomic-embed-text`, ~274MB) with `OLLAMA_KEEP_ALIVE=-1` | No re-embedding; no per-query API call; model small enough to stay resident once chat models are gone | Ollama container stays in prod (~500MB–1GB RAM) |
+| **API embeddings** (Workers AI `bge-m3`, Gemini `text-embedding`, OpenAI `text-embedding-3-small`) | Ollama fully removed from prod → frees 1–2GB RAM → droplet can downsize 4GB→2GB (−$12/mo) | One-time full re-embed (already supported by `embedding_sync.py` model-change detection); external dependency for search |
+
+Recommendation: **move embeddings to the same API provider** and drop Ollama from prod entirely. The droplet downsizing pays for the entire AI budget. Keep Ollama in dev compose for offline work.
+
+## Decision (2026-07-03)
+
+**Groq free tier (primary) + Gemini free tier (fallback)**, hard-gated to free tiers (no payment method attached). May switch to Anthropic Haiku 4.5 later — the abstraction makes that a config change. Provider selection is a runtime feature flag (`llm_use_api` in the admin panel), so everything deploys dark with Ollama as the default until API keys are added.
+
+### Activation runbook (once implementation is merged)
+
+1. Create a [Groq](https://console.groq.com) account and API key (free tier, no card).
+2. Create a [Gemini](https://aistudio.google.com) API key (free tier, no card).
+3. Add GitHub Actions secrets `GROQ_API_KEY` and `GEMINI_API_KEY` (repo → Settings → Secrets); the deploy workflow writes them into `backend/.env` on the droplet.
+4. Deploy (push to main). Behavior is unchanged — flag defaults off.
+5. In the admin panel, toggle `llm_use_api` on. Generation now routes Groq → Gemini; toggle off to revert to Ollama instantly.
+
+Local dev override: put the keys in `backend/.env` and toggle the flag in the local admin panel.
+
+## Recommended Plan
+
+**Target state:** Provider-agnostic LLM client. Production uses Groq free tier (primary) + Gemini free tier (fallback), or Cloudflare Workers AI if a single fixed $5/mo bill is preferred. Ollama remains the dev/offline default. Prod droplet loses Ollama and can downsize.
+
+**Projected monthly cost: $0–5 for AI + $12 saved on the droplet → net cheaper than today, ~30x faster, better quality.**
+
+### Phase 1: Provider abstraction (no behavior change)
+
+1. Define an `LLMProvider` protocol: `generate(prompt, *, json_mode, max_tokens) -> str`, `generate_stream(...)`, `embed(text) -> list[float]`, `is_available()`.
+2. Implement `OllamaProvider` (wraps existing `OllamaClient` logic) and `OpenAICompatProvider` (base URL + API key + model names via config — covers Groq/Gemini/OpenRouter/Cloudflare in one class).
+3. Config: `llm_provider` (`ollama` | `openai_compat`), `llm_api_base_url`, `llm_api_key` (1Password ref), `llm_chat_model`, `llm_structured_model`, `embedding_provider`, `embedding_model`.
+4. Route `dependencies.get_ollama` → `get_llm_provider`; update `routers/ai.py`, `routers/search.py`, `notes_service.py`, `embedding_sync.py` call sites.
+5. Provider selection is orthogonal to the existing `llm_features` runtime flag (flag = on/off, provider = where).
+
+### Phase 2: Production cutover
+
+1. Create provider account, set spend cap / stay on free tier, store key in 1Password.
+2. Set prod env to the API provider; use native JSON mode for tag/link suggestions (simplifies `parse_json_response` usage).
+3. Re-embed corpus with the new embedding model (startup sync already handles this via model-change detection; corpus is small).
+4. Warmup endpoints become no-ops for API providers; `gpu-status` endpoint reports provider instead.
+5. Add a fallback chain: primary provider → secondary → graceful "AI unavailable" (pattern already exists).
+6. Verify rate limits (`rate_limiter.py`) are tight enough that even abusive traffic can't exceed the free tier / spend cap. Add a daily request budget counter if needed.
+
+### Phase 3: Infra cleanup and savings
+
+1. Remove Ollama service from `docker-compose.prod.yml`; keep it in dev compose.
+2. Restore Neo4j memory settings (currently squeezed to leave room for Ollama, issues #59/#60).
+3. Evaluate droplet downsize 4GB → 2GB (−$12/mo) once memory headroom is confirmed.
+4. Close/supersede #150 (dedicated Ollama server) — no longer needed.
+
+### Explicit non-goals
+
+- GPU hosting in any form.
+- Self-hosting larger models.
+- Changing the RAG design, caching strategy, or feature flag system — they're sound; only the inference backend changes.
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Free tier terms change | OpenAI-compatible abstraction makes switching providers a config change |
+| Surprise bills | Prepaid credits (Groq) or console spend caps (Anthropic/Cloudflare); public endpoints already rate-limited |
+| Embedding model switch degrades search | `embedding_sync.py` versioning allows clean re-embed; validate search quality before removing Ollama |
+| API outage kills AI features | Fallback chain + existing graceful degradation (features already fail soft) |
+| Dev/prod divergence | Ollama stays the dev default; CI tests mock the provider interface (already done for Ollama, #124) |

--- a/setup-hooks.sh
+++ b/setup-hooks.sh
@@ -11,6 +11,7 @@ git config core.hooksPath .githooks
 echo "✓ Git hooks configured successfully!"
 echo ""
 echo "The following hooks are now active:"
-echo "  • pre-push: Runs quality checks before pushing"
+echo "  • commit-msg: Adds DCO Signed-off-by trailer automatically"
+echo "  • pre-push: Runs quality checks and DCO verification before pushing"
 echo ""
 echo "To skip hooks temporarily, use: git push --no-verify"


### PR DESCRIPTION
## Summary

Implements Phases 1–2 of #190: AI generation can now route to hosted OpenAI-compatible APIs (Groq primary, Gemini fallback) instead of local CPU Ollama, selected at runtime by the new `llm_use_api` admin feature flag.

**Ships dark**: the flag defaults off and the provider chain is empty until `GROQ_API_KEY`/`GEMINI_API_KEY` reach `backend/.env` (deploy workflow already forwards the GitHub secrets, which are set). Zero behavior change until the flag is toggled in the admin panel.

## Changes

- **`backend/llm_client.py`** (new): `ApiLLMClient` — OpenAI-compatible chat completions with provider fallback chain; `RoutingLLMClient` — per-call routing between Ollama and the API chain
- **Embeddings and semantic search always stay on Ollama** so query embeddings match the precomputed vectors in Neo4j (no re-embed needed)
- `OllamaClient` gains unified `generate()`/`generate_stream()`; all raw `ollama.client.generate()` call sites (ai/articles/inspire routers, notes_service) refactored onto the shared surface
- New feature flag `llm_use_api` (appears automatically in the admin panel; no frontend changes)
- `dependencies.get_ollama` → `get_llm` (backwards-compatible alias keeps existing test overrides working)
- Deploy workflow forwards `GROQ_API_KEY`/`GEMINI_API_KEY` into `backend/.env`
- Fix: tolerate empty completions from Gemini (reasoning can consume the whole `max_tokens` budget → `finish_reason=length` with no content); log and advance the chain instead of raising
- Analysis doc: `docs/AI_OPTIMIZATION.md`

## Verification

- 18 new unit tests (provider fallback, SSE parsing, flag routing, embeddings pinned to Ollama); full backend suite 305 passed; mypy strict + ruff clean
- Live-tested locally with real keys, flag on: article summary / Q&A / SSE suggestion streaming all **~1s** (previously 60–120s on CPU Ollama); Gemini fallback verified in isolation; flag off reverts to Ollama instantly

## Post-merge

Deploy is automatic. To activate in prod: toggle `llm_use_api` at `/admin`. Rollback = toggle off.

Refs #190