### PR TITLE
fix: Ollama lazy reconnect + embedding-availability gating (fixes #194)

### DIFF
--- a/backend/embedding_sync.py
+++ b/backend/embedding_sync.py
@@ -221,7 +221,7 @@ def sync_embeddings(
             "embeddings_cached": 0,
         }
 
-    if not ollama_client.is_available():
+    if not ollama_client.embeddings_available():
         logger.warning("Ollama not available - skipping embedding sync")
         return {
             "articles_processed": 0,

--- a/backend/llm_client.py
+++ b/backend/llm_client.py
@@ -273,6 +273,14 @@ class RoutingLLMClient:
         available: bool = self._generation_backend().is_available()
         return available
 
+    def embeddings_available(self) -> bool:
+        """Whether embedding generation is possible (always requires Ollama).
+
+        Distinct from is_available(): in API mode generation can be healthy
+        while Ollama (and therefore semantic search) is down.
+        """
+        return self.ollama.is_available()
+
     def has_gpu(self) -> bool:
         """Hosted APIs are treated as accelerated; Ollama reports its own state."""
         if self._use_api():

--- a/backend/main.py
+++ b/backend/main.py
@@ -531,7 +531,7 @@ def trigger_embedding_sync(
             success=False, message="Neo4j not available - cannot sync embeddings", stats=None
         )
 
-    if not ollama.is_available():
+    if not ollama.embeddings_available():
         return EmbeddingSyncResponse(
             success=False, message="Ollama not available - cannot generate embeddings", stats=None
         )

--- a/backend/notes_service.py
+++ b/backend/notes_service.py
@@ -370,7 +370,7 @@ class NotesService:
             logger.debug("Skipping embedding generation for %s (test mode)", note_id)
             return
 
-        if not self.ollama.is_available():
+        if not self.ollama.embeddings_available():
             logger.debug("Skipping embedding generation for %s (Ollama unavailable)", note_id)
             return
 

--- a/backend/ollama_client.py
+++ b/backend/ollama_client.py
@@ -1,6 +1,7 @@
 """Ollama integration for AI-powered features."""
 
 import logging
+import time
 from collections.abc import Generator
 from typing import Any
 
@@ -9,6 +10,9 @@ from utils import calculate_content_hash
 
 logger = logging.getLogger(__name__)
 settings = get_settings()
+
+# Minimum seconds between reconnection attempts when Ollama is unreachable
+RECONNECT_COOLDOWN_SECONDS = 30.0
 
 
 class OllamaClient:
@@ -25,30 +29,55 @@ class OllamaClient:
         self.model = settings.ollama_chat_model  # Backwards compatibility
         self.num_ctx = settings.ollama_num_ctx
         self.client: Any | None = None
+        self._last_connect_attempt = 0.0
 
         # Embedding cache: {content_hash: embedding_vector}
         # This prevents regenerating embeddings for the same content
         self.embedding_cache: dict[str, list[float]] = {}
 
         if self.enabled:
-            try:
-                import ollama
+            self._try_connect()
 
-                # Create client with host configuration
-                self.client = ollama.Client(host=self.host)
-                # Test connection
-                self.client.list()
-                logger.info("Ollama client initialized successfully at %s", self.host)
-            except Exception as e:
-                logger.warning("Failed to initialize Ollama client: %s", e)
-                logger.warning(
-                    "Ollama features will be disabled. Is Ollama running at %s?", self.host
-                )
-                self.enabled = False
+    def _try_connect(self) -> bool:
+        """Attempt to connect to Ollama. Safe to call repeatedly.
+
+        A failed attempt does NOT disable the client permanently - the backend
+        can boot before the Ollama container is ready (prod compose ordering),
+        so is_available() retries after RECONNECT_COOLDOWN_SECONDS.
+        """
+        self._last_connect_attempt = time.monotonic()
+        try:
+            import ollama
+
+            client = ollama.Client(host=self.host)
+            # Test connection
+            client.list()
+            self.client = client
+            logger.info("Ollama client connected at %s", self.host)
+            return True
+        except Exception as e:
+            self.client = None
+            logger.warning(
+                "Ollama not reachable at %s (%s) - will retry in %.0fs",
+                self.host,
+                e,
+                RECONNECT_COOLDOWN_SECONDS,
+            )
+            return False
 
     def is_available(self) -> bool:
-        """Check if Ollama is available and enabled."""
-        return self.enabled and self.client is not None
+        """Check if Ollama is available, reconnecting if the last attempt failed."""
+        if not self.enabled:
+            return False
+        if self.client is not None:
+            return True
+        if time.monotonic() - self._last_connect_attempt >= RECONNECT_COOLDOWN_SECONDS:
+            return self._try_connect()
+        return False
+
+    def embeddings_available(self) -> bool:
+        """Check if embedding generation is possible (requires Ollama)."""
+        return self.is_available()
 
     def has_gpu(self) -> bool:
         """Check if GPU acceleration is available.

--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -177,7 +177,8 @@ def ask_question(
     relevant_docs = []
 
     # Try to use fast semantic search with precomputed embeddings from Neo4j
-    if neo4j.is_available():
+    # (needs Ollama for the query embedding even when generation uses the API)
+    if neo4j.is_available() and ollama.embeddings_available():
         logger.info("Q&A: Using fast semantic search with precomputed embeddings from Neo4j")
 
         # Fetch precomputed embeddings for articles and notes

--- a/backend/routers/articles.py
+++ b/backend/routers/articles.py
@@ -180,8 +180,9 @@ def get_related_notes(
     if not notes_with_embeddings:
         return {"notes": [], "count": 0}
 
-    # Check if Ollama is available for generating article embedding
-    if not ollama.is_available():
+    # Related-notes search needs Ollama to embed the article, regardless of
+    # which backend serves generation
+    if not ollama.embeddings_available():
         logger.warning("Ollama not available for semantic search")
         return {"notes": [], "count": 0}
 

--- a/backend/routers/search.py
+++ b/backend/routers/search.py
@@ -206,8 +206,9 @@ def search_resources(
     # Semantic mode: Use Ollama for AI-powered search (opt-in)
     logger.info("Using semantic search via Ollama (corpus size: %d)", len(all_resources))
 
-    # Check if Ollama is available
-    if not ollama.is_available():
+    # Semantic search needs Ollama for the query embedding regardless of
+    # which backend serves generation (llm_use_api flag)
+    if not ollama.embeddings_available():
         logger.warning("Ollama not available, falling back to text search with fuzzy matching")
         query_lower = search_request.query.lower()
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -70,6 +70,10 @@ class MockOllamaClient:
         """Check if Ollama is available."""
         return self._available
 
+    def embeddings_available(self) -> bool:
+        """Check if embedding generation is possible."""
+        return self._available
+
     def has_gpu(self) -> bool:
         """Check if GPU is available."""
         return self._has_gpu if self._available else False

--- a/backend/tests/unit/test_llm_client.py
+++ b/backend/tests/unit/test_llm_client.py
@@ -254,6 +254,15 @@ class TestRoutingLLMClient:
         # .model tags stored embeddings - must stay Ollama's even in API mode
         assert routing.model == "ollama-model"
 
+    def test_embeddings_available_tracks_ollama_not_api(self, flag_state: dict[str, bool]) -> None:
+        """In API mode, generation can be up while embeddings (Ollama) are down."""
+        flag_state["llm_use_api"] = True
+        ollama = MockBackend("ollama", available=False)
+        api = MockBackend("api")
+        routing = RoutingLLMClient(ollama, api)  # type: ignore[arg-type]
+        assert routing.is_available() is True
+        assert routing.embeddings_available() is False
+
 
 # ============================================================================
 # Provider construction from settings

--- a/backend/tests/unit/test_ollama_reconnect.py
+++ b/backend/tests/unit/test_ollama_reconnect.py
@@ -1,0 +1,74 @@
+"""Unit tests for OllamaClient lazy reconnection (issue #194)."""
+
+import time
+
+import pytest
+
+from ollama_client import RECONNECT_COOLDOWN_SECONDS, OllamaClient
+
+
+def _make_disconnected_client() -> OllamaClient:
+    """Build an OllamaClient in the 'failed initial connect' state without I/O."""
+    client = OllamaClient.__new__(OllamaClient)
+    client.enabled = True
+    client.client = None
+    client._last_connect_attempt = time.monotonic()
+    return client
+
+
+class TestLazyReconnect:
+    def test_disabled_client_never_connects(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = _make_disconnected_client()
+        client.enabled = False
+        monkeypatch.setattr(client, "_try_connect", lambda: pytest.fail("must not attempt connect"))
+        assert client.is_available() is False
+
+    def test_no_retry_within_cooldown(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = _make_disconnected_client()
+        monkeypatch.setattr(
+            client, "_try_connect", lambda: pytest.fail("must not retry within cooldown")
+        )
+        assert client.is_available() is False
+
+    def test_retries_after_cooldown(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = _make_disconnected_client()
+        client._last_connect_attempt = time.monotonic() - RECONNECT_COOLDOWN_SECONDS - 1
+        attempts: list[int] = []
+
+        def fake_connect() -> bool:
+            attempts.append(1)
+            client.client = object()  # simulate successful connection
+            return True
+
+        monkeypatch.setattr(client, "_try_connect", fake_connect)
+        assert client.is_available() is True
+        assert attempts == [1]
+        # Once connected, no further reconnect attempts
+        assert client.is_available() is True
+        assert attempts == [1]
+
+    def test_failed_retry_stays_unavailable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = _make_disconnected_client()
+        client._last_connect_attempt = time.monotonic() - RECONNECT_COOLDOWN_SECONDS - 1
+
+        def fake_connect() -> bool:
+            client._last_connect_attempt = time.monotonic()
+            return False
+
+        monkeypatch.setattr(client, "_try_connect", fake_connect)
+        assert client.is_available() is False
+
+    def test_try_connect_failure_does_not_disable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A failed connection must not flip enabled=False (the old behavior)."""
+        client = _make_disconnected_client()
+        client.host = "http://localhost:1"  # nothing listening
+
+        assert client._try_connect() is False
+        assert client.enabled is True
+        assert client.client is None
+
+    def test_embeddings_available_mirrors_is_available(self) -> None:
+        client = _make_disconnected_client()
+        assert client.embeddings_available() is False
+        client.client = object()
+        assert client.embeddings_available() is True

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -81,7 +81,7 @@ services:
       neo4j:
         condition: service_healthy
       ollama:
-        condition: service_started
+        condition: service_healthy  # Backend disables embeddings if Ollama isn't up yet (#194)
     restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/"]


### PR DESCRIPTION
## Problem

Prod backend booted before the Ollama container was ready and permanently disabled its Ollama client (one-shot connection test in `__init__`, compose only waited for `service_started`). Result after enabling `llm_use_api`: chat generation worked via Groq (~1s) but retrieval was dead — semantic search returned `[]` in 0.3s and Q&A answered with no KB context. The routing client masked it because `is_available()` reported the healthy API chain, so the search router never fell back to text search.

## Fix

- **`OllamaClient` lazy reconnect**: a failed connection no longer sets `enabled=False` forever; `is_available()` retries after a 30s cooldown. Heals automatically whenever Ollama comes up.
- **`embeddings_available()`** (Ollama-only concern) is now distinct from `is_available()` (generation concern) and gates: semantic search (falls back to fuzzy text search), Q&A retrieval phase, related-notes, note embedding generation, and embedding sync.
- **prod compose**: backend waits for Ollama's healthcheck (`service_healthy`).

## Verification

- 7 new unit tests (cooldown/retry semantics, no permanent disable, routing availability split); full suite 312 passed; mypy + ruff clean
- Diagnosed against live prod: `/api/ask` returns in 0.75s via Groq but with 'no relevant documents'; semantic `/api/search` returns `[]` in 0.3s while text search works — matching the dead-Ollama signature

## Post-merge

Deploy restarts the backend, which reconnects to Ollama. Then verify prod embeddings are populated:
```
curl -X POST https://api.mongado.com/api/admin/sync-embeddings -H "Authorization: Bearer $ADMIN_TOKEN"
```

Fixes #194