### PR TITLE
fix: eliminate horizontal overflow on mobile viewports (fixes #195)

### DIFF
--- a/frontend/src/app/knowledge-base/articles/[id]/page.module.scss
+++ b/frontend/src/app/knowledge-base/articles/[id]/page.module.scss
@@ -3,12 +3,16 @@
  * Matches production Tailwind design with blue theme
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 .container {
   min-height: 100vh;
-  background: linear-gradient(to bottom right, $color-page-bg-gradient-start, $color-page-bg-gradient-end);
+  background: linear-gradient(
+    to bottom right,
+    $color-page-bg-gradient-start,
+    $color-page-bg-gradient-end
+  );
 }
 
 // ===== LOADING STATE =====
@@ -38,7 +42,8 @@
 }
 
 @keyframes pulse {
-  0%, 100% {
+  0%,
+  100% {
     opacity: 1;
   }
   50% {
@@ -87,11 +92,13 @@
   // Slightly bluer at top, more transparent at bottom for badge visibility
   background: linear-gradient(
     to bottom,
-    $slate-blue-200 0%,              // Bluer, more saturated top
-    $slate-blue-100 50%,             // Transition to lighter
-    rgba($slate-blue-50, 0.7) 100%   // More transparent bottom
+    $slate-blue-200 0%,
+    // Bluer, more saturated top
+    $slate-blue-100 50%,
+    // Transition to lighter
+    rgba($slate-blue-50, 0.7) 100% // More transparent bottom
   );
-  border-bottom: 1px solid $slate-blue-300;  // Refined 1px border
+  border-bottom: 1px solid $slate-blue-300; // Refined 1px border
   box-shadow: $shadow-card-sm;
   padding-top: $spacing-3;
   padding-bottom: $spacing-3;
@@ -234,6 +241,8 @@
 }
 
 .articleContent {
+  min-width: 0; // let wide markdown (code, tables) shrink instead of widening the grid track
+
   @media (min-width: 1024px) {
     grid-column: span 3;
   }
@@ -279,6 +288,8 @@
 }
 
 .tocSidebar {
+  min-width: 0;
+
   @media (min-width: 1024px) {
     grid-column: span 1;
   }
@@ -356,7 +367,12 @@
   line-height: $line-height-relaxed;
 
   // === TYPOGRAPHY ===
-  h1, h2, h3, h4, h5, h6 {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     color: $color-text-heading;
     font-weight: $font-weight-semibold;
     margin-top: $spacing-6;
@@ -364,17 +380,26 @@
     letter-spacing: $letter-spacing-wide;
   }
 
-  h1 { font-size: $heading-h1-size; }
-  h2 { font-size: $heading-h2-size; }
-  h3 { font-size: $heading-h3-size; }
-  h4 { font-size: $heading-h4-size; }
+  h1 {
+    font-size: $heading-h1-size;
+  }
+  h2 {
+    font-size: $heading-h2-size;
+  }
+  h3 {
+    font-size: $heading-h3-size;
+  }
+  h4 {
+    font-size: $heading-h4-size;
+  }
 
   p {
     margin-top: $spacing-3;
     margin-bottom: $spacing-3;
   }
 
-  ul, ol {
+  ul,
+  ol {
     margin-top: $spacing-3;
     margin-bottom: $spacing-3;
     padding-left: $spacing-6;
@@ -446,7 +471,8 @@
     overflow-x: auto;
   }
 
-  th, td {
+  th,
+  td {
     padding: $spacing-2 $spacing-3;
     border: $border-default;
     text-align: left;

--- a/frontend/src/components/TopNavigation.module.scss
+++ b/frontend/src/components/TopNavigation.module.scss
@@ -3,8 +3,8 @@
  * Persistent navigation bar for Knowledge Base section
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 .topNav {
   position: sticky;
@@ -146,21 +146,42 @@
   }
 }
 
+// Small screens: two-row layout. Row 1: logo + actions, row 2: section links.
+// Everything fits the viewport - no horizontal page scroll (issue #195).
 @media (max-width: 640px) {
   .container {
-    height: 56px;
+    flex-wrap: wrap;
+    height: auto;
+    padding-top: $spacing-2;
+    row-gap: 0;
+  }
+
+  .left {
+    flex: 1;
+    min-width: 0;
   }
 
   .logoText {
     font-size: 1.125rem;
   }
 
+  .right {
+    flex-shrink: 0;
+  }
+
   .center {
+    order: 3;
+    width: 100%;
+    justify-content: space-between;
     gap: 0;
+    padding: $spacing-1 0;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
   }
 
   .navLink {
     padding: $spacing-2 $spacing-2;
-    font-size: 0.75rem;
+    font-size: 0.8125rem;
+    white-space: nowrap;
   }
 }

--- a/frontend/src/styles/globals.scss
+++ b/frontend/src/styles/globals.scss
@@ -3,9 +3,9 @@
  * Base styles, CSS reset, and typography for the retro-modern UI
  */
 
-@use 'design-tokens' as *;
-@use 'mixins' as *;
-@use 'utilities';
+@use "design-tokens" as *;
+@use "mixins" as *;
+@use "utilities";
 
 // ===== CSS RESET =====
 *,
@@ -31,6 +31,9 @@ body {
   color: $color-text-primary;
   background-color: $color-bg-canvas;
   min-height: 100vh;
+  // Guardrail: a single overflowing element must not make the whole page
+  // pannable on mobile (clip, unlike hidden, keeps position:sticky working)
+  overflow-x: clip;
 }
 
 // ===== HEADINGS =====

--- a/frontend/tests/e2e/mobile-viewport.spec.ts
+++ b/frontend/tests/e2e/mobile-viewport.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Regression test for issue #195: pages must never scroll horizontally
+ * on a phone-sized viewport (iPhone 12/13/14 logical width).
+ */
+const PAGES = [
+  "/",
+  "/knowledge-base",
+  "/knowledge-base/articles",
+  "/knowledge-base/articles/1",
+  "/knowledge-base/notes",
+  "/knowledge-base/inspire",
+];
+
+test.use({ viewport: { width: 390, height: 844 } });
+
+for (const path of PAGES) {
+  test(`no horizontal overflow on ${path}`, async ({ page }) => {
+    await page.goto(path);
+    await page.waitForLoadState("networkidle");
+    const { viewportWidth, documentWidth } = await page.evaluate(() => ({
+      viewportWidth: document.documentElement.clientWidth,
+      documentWidth: document.documentElement.scrollWidth,
+    }));
+    expect(documentWidth, `document wider than viewport on ${path}`).toBeLessThanOrEqual(
+      viewportWidth + 1
+    );
+  });
+}


### PR DESCRIPTION
## Problem

On phone-sized viewports every knowledge-base page scrolled horizontally (document rendered at 534px on a 390px screen). Root cause: the top nav's single flex row (logo + 4 section links + search/settings/user menu) can't fit and doesn't wrap, so the right-side action group extended past the viewport and widened the whole document — making content pan sideways and panels render half off-screen. The article detail page had a second, independent 17px overflow from wide markdown stretching its `1fr` grid track.

## Fix

- **TopNavigation**: two-row layout below 640px — logo + actions in row one, section links on their own full-width row. CSS-only, no hamburger/JS.
- **Article detail**: `min-width: 0` on the grid children so wide code/tables scroll inside `pre` (already `overflow-x: auto`) instead of widening the track.
- **globals**: `overflow-x: clip` guardrail on `body` — one stray wide element can no longer make the page pannable (`clip`, unlike `hidden`, keeps `position: sticky` nav working).
- **Regression test**: Playwright spec asserting `scrollWidth <= clientWidth` at 390×844 across key pages (runs when e2e infra is enabled; note: e2e can't run in the Alpine frontend container).

## Verification

Probed headless Chromium at 390×844 before/after: docWidth 534→390 on all knowledge-base pages, note detail, and article detail. Screenshot-verified the two-row nav and article layout. Frontend lint, type-check, unit tests (55), and prettier all pass.

Fixes #195