### PR TITLE
Design: grey/orange future-retro identity + phosphor dark mode

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@codemirror/lang-markdown": "^6.4.0",
         "@codemirror/theme-one-dark": "^6.1.3",
+        "@phosphor-icons/react": "^2.1.10",
         "@types/d3": "^7.4.3",
         "@uiw/react-codemirror": "^4.25.2",
         "d3": "^7.9.0",
@@ -2542,6 +2543,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@phosphor-icons/react": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.10.tgz",
+      "integrity": "sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8",
+        "react-dom": ">= 16.8"
       }
     },
     "node_modules/@pkgjs/parseargs": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@codemirror/lang-markdown": "^6.4.0",
     "@codemirror/theme-one-dark": "^6.1.3",
+    "@phosphor-icons/react": "^2.1.10",
     "@types/d3": "^7.4.3",
     "@uiw/react-codemirror": "^4.25.2",
     "d3": "^7.9.0",

--- a/frontend/src/__tests__/SearchModal.test.tsx
+++ b/frontend/src/__tests__/SearchModal.test.tsx
@@ -72,7 +72,7 @@ describe("SearchModal", () => {
 
     it("shows search icon", () => {
       render(<SearchModal isOpen={true} onClose={mockOnClose} />);
-      expect(screen.getByText("🔍")).toBeInTheDocument();
+      expect(document.querySelector("svg")).toBeInTheDocument();
     });
 
     it("shows escape hint", () => {
@@ -186,9 +186,9 @@ describe("SearchModal", () => {
         expect(screen.getByText(/Design Note/)).toBeInTheDocument();
       });
 
-      // Check icons for article vs note
-      expect(screen.getByText("📚")).toBeInTheDocument();
-      expect(screen.getByText("📝")).toBeInTheDocument();
+      // Check mono type labels for article vs note
+      expect(screen.getByText("ART")).toBeInTheDocument();
+      expect(screen.getByText("NOTE")).toBeInTheDocument();
 
       // Check snippets are displayed
       expect(screen.getByText("...contextual snippet...")).toBeInTheDocument();

--- a/frontend/src/__tests__/TopNavigation.test.tsx
+++ b/frontend/src/__tests__/TopNavigation.test.tsx
@@ -136,7 +136,9 @@ describe("TopNavigation", () => {
     it("renders search button with icon", () => {
       render(<TopNavigation />);
 
-      expect(screen.getByText("🔍")).toBeInTheDocument();
+      const searchButton = screen.getByRole("button", { name: "Open search" });
+      expect(searchButton).toBeInTheDocument();
+      expect(searchButton.querySelector("svg")).toBeInTheDocument();
     });
 
     it("renders search label", () => {

--- a/frontend/src/__tests__/page.test.tsx
+++ b/frontend/src/__tests__/page.test.tsx
@@ -10,12 +10,12 @@ describe("Home Page", () => {
 
   it("shows engineering leader title", () => {
     render(<Home />);
-    expect(screen.getByText("Engineering Leader & Builder")).toBeInTheDocument();
+    expect(screen.getByText(/Engineering Leader & Builder/)).toBeInTheDocument();
   });
 
   it("shows location", () => {
     render(<Home />);
-    expect(screen.getByText("Birmingham, AL")).toBeInTheDocument();
+    expect(screen.getAllByText(/Birmingham, AL/).length).toBeGreaterThan(0);
   });
 
   it("shows GitHub links", () => {

--- a/frontend/src/app/admin/page.module.scss
+++ b/frontend/src/app/admin/page.module.scss
@@ -135,7 +135,7 @@
 
   &:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 2px rgba($blue-500, 0.3);
+    box-shadow: $shadow-focus-primary;
   }
 
   &:disabled {

--- a/frontend/src/app/knowledge-base/articles/[id]/page.module.scss
+++ b/frontend/src/app/knowledge-base/articles/[id]/page.module.scss
@@ -168,10 +168,11 @@
     .metadata {
       margin-bottom: $spacing-4;
       @include stack($spacing-1);
-      @include text-secondary;
+      @include text-meta-mono;
+      font-size: $font-size-sm;
 
       @media (max-width: 640px) {
-        font-size: $font-size-sm;
+        font-size: $font-size-xs;
       }
 
       .metaItem {

--- a/frontend/src/app/knowledge-base/articles/page.module.scss
+++ b/frontend/src/app/knowledge-base/articles/page.module.scss
@@ -16,11 +16,11 @@
   // Cool slate blue header zone (consistent across KB)
   background: linear-gradient(
     to bottom,
-    $slate-blue-200 0%,              // Bluer, more saturated top
-    $slate-blue-100 50%,             // Transition to lighter
-    rgba($slate-blue-50, 0.7) 100%   // More transparent bottom
+    var(--color-header-bg-start) 0%,
+    var(--color-header-bg-mid) 50%,
+    var(--color-header-bg-end) 100%
   );
-  border-bottom: 1px solid $slate-blue-300;
+  border-bottom: 1px solid var(--color-header-border);
   box-shadow: $shadow-card-sm;
 
   .headerContent {
@@ -91,7 +91,7 @@
     &:focus {
       outline: none;
       border-color: $color-input-border-focus;
-      box-shadow: 0 0 0 2px rgba($blue-500, 0.2);
+      box-shadow: $shadow-focus-primary;
     }
 
     &::placeholder {
@@ -125,11 +125,11 @@
     &:focus {
       outline: none;
       border-color: $color-input-border-focus;
-      box-shadow: 0 0 0 2px rgba($blue-500, 0.2);
+      box-shadow: $shadow-focus-primary;
     }
 
     &:hover {
-      border-color: $blue-300;
+      border-color: $color-border-hover;
     }
   }
 }
@@ -176,13 +176,15 @@
       }
 
       &.tagBadgeActive {
-        background-color: $blue-500;
-        border-color: $blue-600;
+        // Selected = interactive, so it takes the orange accent.
+        // orange-700 keeps white text at >4.5:1 contrast.
+        background-color: $orange-700;
+        border-color: $orange-800;
         color: $white;
 
         &:hover {
-          background-color: $blue-600;
-          border-color: $blue-700;
+          background-color: $orange-800;
+          border-color: $orange-900;
         }
       }
 
@@ -208,13 +210,13 @@
   .showMoreButton {
     margin-top: $spacing-3;
     @include text-secondary;
-    color: $blue-600;
+    color: $color-link-default;
     cursor: pointer;
     font-weight: $font-weight-medium;
     transition: all 0.2s ease;
 
     &:hover {
-      color: $blue-800;
+      color: $color-link-hover;
       text-decoration: underline;
     }
   }
@@ -225,18 +227,18 @@
   width: 100%;
   padding: $spacing-3 $spacing-4;
   background-color: $white;
-  border: $border-width-thin solid $blue-300;
+  border: $border-width-thin solid $orange-300;
   border-radius: $border-radius-button;
   @include text-secondary;
-  color: $blue-600;
+  color: $color-link-default;
   font-weight: $font-weight-medium;
   cursor: pointer;
   transition: all 0.2s ease;
 
   &:hover {
-    background-color: $blue-50;
-    border-color: $blue-400;
-    color: $blue-700;
+    background-color: $orange-50;
+    border-color: $orange-400;
+    color: $color-link-hover;
   }
 }
 
@@ -288,7 +290,7 @@
 
   .clearSearchButton {
     @include text-secondary;
-    color: $blue-600;
+    color: $color-link-default;
     cursor: pointer;
     text-decoration: none;
 
@@ -308,7 +310,7 @@
 
   &:hover {
     .articleTitle {
-      color: $blue-600;
+      color: $color-link-default;
     }
   }
 
@@ -329,7 +331,7 @@
     }
 
     .articleMeta {
-      @include text-secondary;
+      @include text-meta-mono;
     }
   }
 
@@ -348,17 +350,13 @@
     margin-top: $spacing-4;
     @include text-secondary;
     font-weight: $font-weight-medium;
-    color: $blue-600;
+    color: $color-link-default;
   }
 }
 
 // Draft article styling
 .draftCard {
-  background: linear-gradient(
-    to bottom right,
-    rgba($neutral-100, 0.5),
-    rgba($neutral-50, 0.3)
-  );
+  background-color: $color-surface-tertiary;
   border-left: 3px solid $neutral-400;
 }
 

--- a/frontend/src/app/knowledge-base/notes/[id]/page.module.scss
+++ b/frontend/src/app/knowledge-base/notes/[id]/page.module.scss
@@ -99,11 +99,11 @@
   // Slightly bluer at top, more transparent at bottom for badge visibility
   background: linear-gradient(
     to bottom,
-    $slate-blue-200 0%,              // Bluer, more saturated top
-    $slate-blue-100 50%,             // Transition to lighter
-    rgba($slate-blue-50, 0.7) 100%   // More transparent bottom
+    var(--color-header-bg-start) 0%,
+    var(--color-header-bg-mid) 50%,
+    var(--color-header-bg-end) 100%
   );
-  border-bottom: 1px solid $slate-blue-300;  // Refined 1px border
+  border-bottom: 1px solid var(--color-header-border);  // Refined 1px border
   padding: $spacing-3xl $spacing-2xl $spacing-xl;
   margin-bottom: $spacing-2xl;
 
@@ -398,7 +398,7 @@
   &:focus {
     outline: none;
     border-color: $color-input-border-focus;
-    box-shadow: 0 0 0 3px rgba($blue-500, 0.1);
+    box-shadow: $shadow-focus-primary;
   }
 
   &::placeholder {

--- a/frontend/src/app/knowledge-base/notes/graph/page.module.scss
+++ b/frontend/src/app/knowledge-base/notes/graph/page.module.scss
@@ -163,11 +163,11 @@
   // Cool slate blue header zone (consistent across KB)
   background: linear-gradient(
     to bottom,
-    $slate-blue-200 0%,              // Bluer, more saturated top
-    $slate-blue-100 50%,             // Transition to lighter
-    rgba($slate-blue-50, 0.7) 100%   // More transparent bottom
+    var(--color-header-bg-start) 0%,
+    var(--color-header-bg-mid) 50%,
+    var(--color-header-bg-end) 100%
   );
-  border-bottom: 1px solid $slate-blue-300;
+  border-bottom: 1px solid var(--color-header-border);
   box-shadow: $shadow-card-sm;
 
   .headerContent {

--- a/frontend/src/app/knowledge-base/notes/new/page.module.scss
+++ b/frontend/src/app/knowledge-base/notes/new/page.module.scss
@@ -77,7 +77,7 @@
       &:focus {
         outline: none;
         border-color: $color-input-border-focus;
-        box-shadow: 0 0 0 2px rgba($blue-500, 0.2);
+        box-shadow: $shadow-focus-primary;
       }
 
       &::placeholder {
@@ -274,7 +274,7 @@
   &:focus {
     outline: none;
     border-color: $color-input-border-focus;
-    box-shadow: 0 0 0 3px rgba($blue-500, 0.1);
+    box-shadow: $shadow-focus-primary;
   }
 
   &::placeholder {
@@ -300,7 +300,7 @@
   &:focus {
     outline: none;
     border-color: $color-input-border-focus;
-    box-shadow: 0 0 0 3px rgba($blue-500, 0.1);
+    box-shadow: $shadow-focus-primary;
   }
 
   &:disabled {

--- a/frontend/src/app/knowledge-base/notes/page.module.scss
+++ b/frontend/src/app/knowledge-base/notes/page.module.scss
@@ -126,7 +126,7 @@
     &:focus {
       outline: none;
       border-color: $color-input-border-focus;
-      box-shadow: 0 0 0 2px rgba($blue-500, 0.2);
+      box-shadow: $shadow-focus-primary;
     }
 
     &::placeholder {
@@ -160,7 +160,7 @@
     &:focus {
       outline: none;
       border-color: $color-input-border-focus;
-      box-shadow: 0 0 0 2px rgba($blue-500, 0.2);
+      box-shadow: $shadow-focus-primary;
     }
 
     &:hover {
@@ -350,11 +350,11 @@
   // Cool slate blue header zone (consistent across KB)
   background: linear-gradient(
     to bottom,
-    $slate-blue-200 0%,              // Bluer, more saturated top
-    $slate-blue-100 50%,             // Transition to lighter
-    rgba($slate-blue-50, 0.7) 100%   // More transparent bottom
+    var(--color-header-bg-start) 0%,
+    var(--color-header-bg-mid) 50%,
+    var(--color-header-bg-end) 100%
   );
-  border-bottom: 1px solid $slate-blue-300;
+  border-bottom: 1px solid var(--color-header-border);
   box-shadow: $shadow-card-sm;
 
   .headerContent {
@@ -622,21 +622,25 @@
 
         .noteId {
           padding: $spacing-1 $spacing-2;
-          background-color: rgba(196, 98, 79, 0.1);
+          background-color: $color-interactive-primary-bg-subtle;
           border-radius: $border-radius-sm;
           font-family: $font-family-mono;
           @include text-secondary;
-          color: $color-secondary;
+          color: $color-link-hover;
         }
 
         .referenceBadge {
           display: inline-block;
           padding: 2px 8px;
-          background-color: $amber-100;
-          color: $amber-800;
+          background-color: transparent;
+          border: $border-width-thin dashed $color-border-strong;
+          color: $color-text-secondary;
           border-radius: $border-radius-sm;
           font-size: 11px;
           font-weight: $font-weight-medium;
+          font-family: $font-family-mono;
+          letter-spacing: $letter-spacing-wide;
+          text-transform: uppercase;
         }
       }
 
@@ -659,7 +663,7 @@
         margin-bottom: $spacing-2;
         @include flex-start;
         gap: $spacing-4;
-        @include text-tertiary;
+        @include text-meta-mono;
       }
 
       .noteTags {

--- a/frontend/src/app/knowledge-base/notes/page.tsx
+++ b/frontend/src/app/knowledge-base/notes/page.tsx
@@ -433,7 +433,7 @@ function NotesContent() {
                           <div className={styles.noteIdRow}>
                             <code className={styles.noteId}>{note.id}</code>
                             {note.is_reference && (
-                              <span className={styles.referenceBadge}>Reference</span>
+                              <span className={styles.referenceBadge}>REF</span>
                             )}
                           </div>
 

--- a/frontend/src/app/knowledge-base/page.module.scss
+++ b/frontend/src/app/knowledge-base/page.module.scss
@@ -16,11 +16,11 @@
   // Cool slate blue header zone (consistent across KB)
   background: linear-gradient(
     to bottom,
-    $slate-blue-200 0%,              // Bluer, more saturated top
-    $slate-blue-100 50%,             // Transition to lighter
-    rgba($slate-blue-50, 0.7) 100%   // More transparent bottom
+    var(--color-header-bg-start) 0%,
+    var(--color-header-bg-mid) 50%,
+    var(--color-header-bg-end) 100%
   );
-  border-bottom: 1px solid $slate-blue-300;
+  border-bottom: 1px solid var(--color-header-border);
   box-shadow: $shadow-card-sm;
 
   .headerContent {
@@ -74,7 +74,7 @@
         &:focus {
           outline: none;
           border-color: $color-input-border-focus;
-          box-shadow: 0 0 0 2px rgba($blue-500, 0.2);
+          box-shadow: $shadow-focus-primary;
         }
 
         &::placeholder {
@@ -145,12 +145,11 @@
         gap: $spacing-2;
 
         .resultType {
-          @include text-secondary;
-          font-weight: $font-weight-medium;
+          @include text-label-mono;
         }
 
         .resultScore {
-          @include text-tertiary;
+          @include text-meta-mono;
         }
       }
 
@@ -204,30 +203,28 @@
   @include card-elevated;
   transition: all 0.2s ease;
 
+  // One card system: white surface, grey border. The featured card
+  // (articles) carries the single orange accent for the view.
+  background-color: $color-surface-default;
+  border-color: $color-border-default;
+
   &.articles {
-    background-color: rgba($blue-50, 0.3);
-    border-color: $blue-200;
-  }
-
-  &.notes {
-    background-color: rgba($purple-50, 0.3);
-    border-color: $purple-200;
-  }
-
-  &.toolbox {
-    background-color: rgba($amber-50, 0.3);
-    border-color: $amber-200;
+    border-left: $border-width-thick solid $color-interactive-primary;
   }
 
   .toolboxBadge {
     display: inline-flex;
     align-items: center;
     padding: 2px 8px;
-    background-color: $amber-100;
-    color: $amber-800;
+    background-color: transparent;
+    border: $border-width-thin dashed $color-border-strong;
+    color: $color-text-secondary;
     border-radius: $border-radius-sm;
     font-size: 11px;
     font-weight: $font-weight-medium;
+    font-family: $font-family-mono;
+    letter-spacing: $letter-spacing-wide;
+    text-transform: uppercase;
   }
 
   .cardBadge {
@@ -261,8 +258,8 @@
     transition: all 0.2s ease;
 
     &.primary {
-      background-color: $color-primary;
-      color: white;
+      background-color: $color-interactive-primary;
+      color: $color-interactive-primary-text;
 
       &:hover {
         background-color: $color-primary-hover;
@@ -279,41 +276,18 @@
       }
     }
 
-    &.notePrimary {
-      background-color: $color-secondary;
-      color: white;
-
-      &:hover {
-        background-color: $color-secondary-hover;
-      }
-    }
-
-    &.noteSecondary {
-      background-color: transparent;
-      color: $color-secondary;
-      border: $border-width-thin solid $color-secondary;
-
-      &:hover {
-        background-color: $color-secondary-light;
-      }
-    }
-
-    &.toolboxPrimary {
-      background-color: $amber-600;
-      color: white;
-
-      &:hover {
-        background-color: $amber-700;
-      }
-    }
-
+    // One orange primary per view; every other card action is a ghost.
+    &.notePrimary,
+    &.toolboxPrimary,
+    &.noteSecondary,
     &.toolboxSecondary {
       background-color: transparent;
-      color: $amber-600;
-      border: $border-width-thin solid $amber-600;
+      color: $color-primary-dark;
+      border: $border-width-thin solid $orange-300;
 
       &:hover {
-        background-color: $amber-50;
+        background-color: $color-primary-light;
+        border-color: $color-primary;
       }
     }
   }
@@ -334,14 +308,14 @@
 // ===== INFO SECTION =====
 .infoSection {
   @include card;
-  background-color: $blue-50;
-  border-color: $blue-200;
+  background-color: $color-surface-secondary;
+  border-color: $color-border-default;
 
   .infoTitle {
     @include heading-h3;
     font-size: $font-size-xl; // Reduced from h3 (21px) to xl (18px)
     margin-bottom: $spacing-2; // Keep at 8px
-    color: $blue-900;
+    color: $color-text-heading;
   }
 
   .infoGrid {
@@ -351,7 +325,7 @@
     font-size: $font-size-sm; // Reduced from base (14px) to sm (12px)
     line-height: $line-height-relaxed; // 1.6 (already optimized)
     @include text-secondary;
-    color: $blue-800;
+    color: $color-text-secondary;
 
     @media (min-width: 768px) {
       grid-template-columns: repeat(2, 1fr);
@@ -360,15 +334,15 @@
     .infoItem {
       strong {
         font-weight: $font-weight-semibold;
-        color: $blue-900;
+        color: $color-text-heading;
       }
 
       a {
         text-decoration: underline;
-        color: $blue-700;
+        color: $color-link-default;
 
         &:hover {
-          color: $blue-600;
+          color: $color-link-hover;
         }
       }
     }

--- a/frontend/src/app/knowledge-base/page.tsx
+++ b/frontend/src/app/knowledge-base/page.tsx
@@ -146,7 +146,7 @@ export default function KnowledgeBasePage() {
       <main className={styles.main}>
         {/* Search Section */}
         <div className={styles.searchSection}>
-          <h2 className={styles.searchTitle}>🔍 Search Everything</h2>
+          <h2 className={styles.searchTitle}>Search everything</h2>
           <form onSubmit={handleSearch} className={styles.searchForm}>
             <div className={styles.searchRow}>
               <input
@@ -199,7 +199,7 @@ export default function KnowledgeBasePage() {
                   >
                     <div className={styles.resultMeta}>
                       <span className={styles.resultType}>
-                        {result.type === "article" ? "📚 Article" : "📝 Note"}
+                        {result.type === "article" ? "ART" : "NOTE"}
                       </span>
                       <span className={styles.resultScore}>Score: {result.score.toFixed(1)}</span>
                     </div>
@@ -272,7 +272,7 @@ export default function KnowledgeBasePage() {
           {/* Toolbox Card */}
           <div className={`${styles.contentCard} ${styles.toolbox}`}>
             <div className={styles.cardBadge}>
-              <span className={styles.toolboxBadge}>Reference</span>
+              <span className={styles.toolboxBadge}>REF</span>
             </div>
             <h3 className={styles.cardTitle}>Toolbox</h3>
             <p className={styles.cardDescription}>
@@ -292,7 +292,7 @@ export default function KnowledgeBasePage() {
 
         {/* Info Section */}
         <div className={styles.infoSection}>
-          <h3 className={styles.infoTitle}>💡 How to Use</h3>
+          <h3 className={styles.infoTitle}>How to use</h3>
           <div className={styles.infoGrid}>
             <div className={styles.infoItem}>
               <strong>Articles</strong> are long-form, polished content for deep exploration of

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -52,7 +52,21 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`${spaceGrotesk.variable} ${spaceMono.variable}`}>
+    <html
+      lang="en"
+      className={`${spaceGrotesk.variable} ${spaceMono.variable}`}
+      // The theme script below sets data-theme before hydration; the
+      // attribute intentionally differs from the server-rendered HTML.
+      suppressHydrationWarning
+    >
+      <head>
+        {/* Apply the stored theme choice before first paint (no flash). */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `try{var t=localStorage.getItem("theme");if(t==="dark"||t==="light"){document.documentElement.dataset.theme=t;}}catch(e){}`,
+          }}
+        />
+      </head>
       <body>{children}</body>
     </html>
   );

--- a/frontend/src/app/login/page.module.scss
+++ b/frontend/src/app/login/page.module.scss
@@ -136,7 +136,7 @@
     &:focus {
       outline: none;
       border-color: $color-input-border-focus;
-      box-shadow: 0 0 0 2px rgba($blue-500, 0.2);
+      box-shadow: $shadow-focus-primary;
     }
 
     &::placeholder {
@@ -194,7 +194,7 @@
 
   &:focus {
     outline: none;
-    box-shadow: 0 0 0 2px rgba($blue-500, 0.3);
+    box-shadow: $shadow-focus-primary;
   }
 
   &:disabled {

--- a/frontend/src/app/page.module.scss
+++ b/frontend/src/app/page.module.scss
@@ -1,6 +1,6 @@
 /**
  * Home Page Styles
- * Matches production Tailwind design
+ * Grounded typographic hero on the warm grey page - no card, no gradient.
  */
 
 @use '@/styles/design-tokens' as *;
@@ -8,180 +8,158 @@
 
 .container {
   min-height: 100vh;
-  background: linear-gradient(to bottom right, $blue-50 0%, $white 50%, $indigo-50 100%);
+  background-color: $color-page-bg;
+}
+
+.themeCorner {
+  position: absolute;
+  top: $spacing-4;
+  right: $spacing-4;
 }
 
 .main {
   @include container;
-  padding-top: $spacing-8; // Reduced from 48px to 32px
-  padding-bottom: $spacing-6; // Reduced from 48px to 24px
+  max-width: 52rem;
+  padding-top: $spacing-16;
+  padding-bottom: $spacing-8;
 
-  @media (min-width: 768px) {
-    padding-top: $spacing-8; // Reduced from 64px to 32px
-    padding-bottom: $spacing-8; // Reduced from 64px to 32px
+  @media (max-width: 640px) {
+    // Clear the theme toggle pinned to the top-right corner
+    padding-top: $spacing-16;
   }
 }
 
 // ===== HERO SECTION =====
-.heroCard {
-  @include card-elevated;
-  margin-bottom: $spacing-6; // Reduced from 32px to 24px
-  text-align: center;
-  background-color: $color-surface-elevated;
+.hero {
+  margin-bottom: $spacing-16;
 
-  .header {
-    margin-bottom: $spacing-6; // Reduced from 32px to 24px
+  .eyebrow {
+    @include text-label-mono;
+    color: $color-link-hover;
+    margin-bottom: $spacing-3;
+  }
 
-    .title {
-      @include heading-h1;
-      margin-bottom: $spacing-3; // Reduced from 16px to 12px (tighter gap)
-      color: $neutral-900;
-      font-size: clamp(2.5rem, 5vw, 3rem); // Slightly smaller: 40-48px instead of 48-60px
-    }
+  .title {
+    @include heading-h1;
+    color: $neutral-900;
+    font-size: clamp(2.75rem, 7vw, 4rem);
+    line-height: 1.05;
+    margin: 0;
+    text-wrap: balance;
+  }
 
-    .subtitle {
-      font-size: $font-size-lg; // Reduced from xl (18px) to lg (16px)
-      color: $color-text-secondary;
-      margin-bottom: $spacing-2; // Keep 8px gap
-    }
-
-    .location {
-      font-size: $font-size-sm; // Reduced from base (14px) to sm (12px)
-      color: $color-text-tertiary;
-    }
+  .rule {
+    width: 4rem;
+    height: 3px;
+    background-color: $color-interactive-primary;
+    margin: $spacing-6 0;
   }
 
   .bio {
-    max-width: 48rem;
-    margin: 0 auto $spacing-6; // Reduced from 32px to 24px
-    font-size: $font-size-base; // Reduced from lg (16px) to base (14px)
-    line-height: $line-height-relaxed; // 1.6 (already optimized)
+    max-width: 40rem;
+    font-size: $font-size-lg;
+    line-height: $line-height-relaxed;
     color: $color-text-secondary;
-  }
-
-  .socialLinks {
-    @include cluster($spacing-3); // Reduced gap from 16px to 12px
-    justify-content: center;
-    margin-top: $spacing-6; // Reduced from 32px to 24px
+    margin: 0 0 $spacing-6;
   }
 }
 
-// ===== SOCIAL LINK BUTTONS =====
-.socialLink {
-  @include flex-center;
-  gap: $spacing-2;
-  padding: $spacing-3 $spacing-6;
-  border-radius: $border-radius-button;
-  font-weight: $font-weight-semibold;
-  text-decoration: none;
-  box-shadow: $shadow-button;
-  transition: all 0.2s ease;
+// ===== SOCIAL LINKS (quiet mono text links) =====
+.socialLinks {
+  @include cluster($spacing-6);
 
-  svg {
-    width: 1.25rem;
-    height: 1.25rem;
-  }
-
-  &:hover {
-    box-shadow: $shadow-button-hover;
-    transform: translateY(-1px);
-  }
-
-  &.github {
-    background-color: $color-social-github-bg;
-    color: $color-social-github-text;
+  a {
+    font-family: $font-family-mono;
+    font-size: $font-size-sm;
+    letter-spacing: $letter-spacing-wide;
+    color: $color-link-hover;
+    text-decoration: none;
+    border-bottom: 1px solid $orange-300;
+    padding-bottom: 2px;
+    transition: color 0.2s ease, border-color 0.2s ease;
 
     &:hover {
-      background-color: $color-social-github-bg-hover;
+      color: $color-link-active;
+      border-color: $color-link-hover;
     }
-  }
 
-  &.linkedin {
-    background-color: $color-social-linkedin-bg;
-    color: $color-social-linkedin-text;
-
-    &:hover {
-      background-color: $color-social-linkedin-bg-hover;
-    }
-  }
-
-  &.email {
-    background-color: $color-social-email-bg;
-    color: $color-social-email-text;
-    border: $border-default;
-
-    &:hover {
-      background-color: $color-social-email-bg-hover;
+    &:focus-visible {
+      outline: 2px solid $color-interactive-primary-focus;
+      outline-offset: 3px;
+      border-radius: 2px;
     }
   }
 }
 
 // ===== KNOWLEDGE BASE SECTION =====
 .kbSection {
-  @include card-elevated;
-  margin-bottom: $spacing-6; // Reduced from 32px to 24px
-  background: linear-gradient(to bottom right, $orange-50 0%, $white 50%, $gray-50 100%);
+  border-top: 1px solid $color-border-default;
+  padding-top: $spacing-10;
+  margin-bottom: $spacing-12;
 
-  .kbIcon {
-    font-size: 2.5rem; // Reduced from 3rem (48px) to 2.5rem (40px)
-    margin-bottom: $spacing-4; // Reduced from 24px to 16px
-    line-height: 1;
+  .kbEyebrow {
+    @include text-label-mono;
+    margin-bottom: $spacing-3;
   }
 
   .kbTitle {
     @include heading-h2;
-    margin-bottom: $spacing-4; // Reduced from 24px to 16px (tighter gap)
     color: $neutral-900;
+    margin-bottom: $spacing-4;
+    text-wrap: balance;
   }
 
   .kbDescription {
-    max-width: 56rem;
-    margin: 0 auto $spacing-6; // Reduced from 32px to 24px
-    font-size: $font-size-base; // Reduced from lg (16px) to base (14px)
-    line-height: $line-height-relaxed; // 1.6 (already optimized)
+    max-width: 40rem;
+    font-size: $font-size-base;
+    line-height: $line-height-relaxed;
     color: $color-text-secondary;
-  }
-
-  .kbButtonContainer {
-    display: flex;
-    justify-content: center;
+    margin: 0 0 $spacing-6;
   }
 
   .kbButton {
-    @include flex-center;
+    display: inline-flex;
+    align-items: center;
     gap: $spacing-2;
-    padding: $spacing-3 $spacing-6; // Reduced from spacing-4/8 (16/32px) to spacing-3/6 (12/24px)
+    padding: $spacing-3 $spacing-6;
     border-radius: $border-radius-button;
-    font-size: $font-size-base; // Reduced from lg (16px) to base (14px)
+    font-size: $font-size-base;
     font-weight: $font-weight-semibold;
     text-decoration: none;
-    color: white;
-    background: linear-gradient(to right, $orange-500, $orange-600);
-    box-shadow: $shadow-card-md;
-    transition: all 0.2s ease;
-
-    svg {
-      width: 1.125rem; // Reduced from 1.25rem
-      height: 1.125rem;
-    }
+    color: $color-interactive-primary-text;
+    background-color: $color-interactive-primary;
+    box-shadow: $shadow-button;
+    transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 
     &:hover {
-      background: linear-gradient(to right, $orange-600, $orange-700);
-      box-shadow: $shadow-card-lg;
-      transform: translateY(-2px);
+      background-color: $color-interactive-primary-hover;
+      box-shadow: $shadow-button-hover;
+      transform: translateY(-1px);
+    }
+
+    &:focus-visible {
+      outline: 2px solid $color-interactive-primary-focus;
+      outline-offset: 3px;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+
+      &:hover {
+        transform: none;
+      }
     }
   }
 }
 
 // ===== OTHER SECTIONS =====
 .projectsLink {
-  text-align: center;
-  margin-bottom: $spacing-6; // Reduced from 32px to 24px
+  margin-bottom: $spacing-8;
 
   a {
     @include link-default;
     color: $color-text-secondary;
-    font-size: $font-size-sm; // Reduced from base (14px) to sm (12px)
+    font-size: $font-size-sm;
 
     &:hover {
       color: $color-primary;
@@ -190,9 +168,9 @@
 }
 
 .footer {
-  margin-top: $spacing-8; // Reduced from 48px to 32px
-  padding: $spacing-6 0; // Reduced padding from implicit spacing
-  text-align: center;
+  margin-top: $spacing-8;
+  padding: $spacing-6 0;
+  border-top: 1px solid $color-border-default;
   @include text-secondary;
 
   p {
@@ -200,6 +178,7 @@
   }
 
   .copyright {
+    font-family: $font-family-mono;
     font-size: $font-size-xs;
     color: $color-text-tertiary;
     margin-top: $spacing-2;

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,89 +1,58 @@
 import { siteConfig } from "@/lib/site-config";
+import ThemeToggle from "@/components/ThemeToggle";
 import styles from "./page.module.scss";
 
 export default function Home() {
   return (
     <div className={styles.container}>
+      <div className={styles.themeCorner}>
+        <ThemeToggle />
+      </div>
       <main className={styles.main}>
         {/* Hero Section */}
-        <div className={styles.heroCard}>
-          {/* Header */}
-          <div className={styles.header}>
-            <h1 className={styles.title}>{siteConfig.author.fullTitle}</h1>
-            <p className={styles.subtitle}>{siteConfig.author.title}</p>
-            <p className={styles.location}>{siteConfig.author.location}</p>
-          </div>
+        <header className={styles.hero}>
+          <p className={styles.eyebrow}>
+            {siteConfig.author.title} — {siteConfig.author.location}
+          </p>
+          <h1 className={styles.title}>{siteConfig.author.fullTitle}</h1>
+          <div className={styles.rule} aria-hidden="true" />
+          <p className={styles.bio}>{siteConfig.author.bio}</p>
 
-          {/* Bio */}
-          <div className={styles.bio}>
-            <p>{siteConfig.author.bio}</p>
-          </div>
+          <nav className={styles.socialLinks} aria-label="Social links">
+            <a href={siteConfig.links.github} target="_blank" rel="noopener noreferrer">
+              github ↗
+            </a>
+            <a href={siteConfig.links.linkedin} target="_blank" rel="noopener noreferrer">
+              linkedin ↗
+            </a>
+            <a href={siteConfig.links.email}>email ↗</a>
+          </nav>
+        </header>
 
-          {/* Social Links */}
-          <div className={styles.socialLinks}>
-            <a
-              href={siteConfig.links.github}
-              target="_blank"
-              rel="noopener noreferrer"
-              className={`${styles.socialLink} ${styles.github}`}
+        {/* Knowledge Base Section */}
+        <section className={styles.kbSection}>
+          <p className={styles.kbEyebrow}>Knowledge base</p>
+          <h2 className={styles.kbTitle}>Part published blog, part digital garden</h2>
+          <p className={styles.kbDescription}>
+            A curated collection of engineering and leadership insights. Long-form articles on
+            topics I&apos;m passionate about, alongside quick-reference notes and interconnected
+            thoughts following a Zettelkasten approach — from technical deep-dives to frameworks
+            like &quot;The 5 Dysfunctions of a Team&quot; and Daniel Pink&apos;s motivation triad.
+          </p>
+          <a href="/knowledge-base" className={styles.kbButton}>
+            Explore the knowledge base
+            <svg
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              width="18"
+              height="18"
+              aria-hidden="true"
             >
-              <svg fill="currentColor" viewBox="0 0 24 24">
-                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-              </svg>
-              GitHub
-            </a>
-            <a
-              href={siteConfig.links.linkedin}
-              target="_blank"
-              rel="noopener noreferrer"
-              className={`${styles.socialLink} ${styles.linkedin}`}
-            >
-              <svg fill="currentColor" viewBox="0 0 24 24">
-                <path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z" />
-              </svg>
-              LinkedIn
-            </a>
-            <a href={siteConfig.links.email} className={`${styles.socialLink} ${styles.email}`}>
-              <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
-                />
-              </svg>
-              Email
-            </a>
-          </div>
-        </div>
-
-        {/* Knowledge Base Hero Section */}
-        <div className={styles.kbSection}>
-          <div className={styles.kbIcon}>📚</div>
-          <h2 className={styles.kbTitle}>Explore My Knowledge Base</h2>
-          <div className={styles.kbDescription}>
-            <p>
-              A curated collection of engineering and leadership insights. Explore long-form
-              articles on topics I&apos;m passionate about alongside quick-reference notes and
-              interconnected thoughts following a Zettelkasten approach. From technical deep-dives
-              to frameworks like &quot;The 5 Dysfunctions of a Team&quot; and Daniel Pink&apos;s
-              motivation triad. It&apos;s part published blog, part digital garden.
-            </p>
-          </div>
-          <div className={styles.kbButtonContainer}>
-            <a href="/knowledge-base" className={styles.kbButton}>
-              Explore Knowledge Base
-              <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M9 5l7 7-7 7"
-                />
-              </svg>
-            </a>
-          </div>
-        </div>
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </a>
+        </section>
 
         {/* Other Projects Link */}
         <div className={styles.projectsLink}>
@@ -93,12 +62,12 @@ export default function Home() {
         </div>
 
         {/* Footer note */}
-        <div className={styles.footer}>
-          <p>Built with Next.js, FastAPI, and Python ☕</p>
+        <footer className={styles.footer}>
+          <p>Built with Next.js, FastAPI, and Python</p>
           <p className={styles.copyright}>
             © 2025 {siteConfig.author.name} • {siteConfig.author.location}
           </p>
-        </div>
+        </footer>
       </main>
     </div>
   );

--- a/frontend/src/components/Badge.module.scss
+++ b/frontend/src/components/Badge.module.scss
@@ -1,6 +1,6 @@
 /**
  * Badge Component Styles
- * Retro-modern design with blue (articles) and purple (notes) colors
+ * Uppercase mono labels: articles carry the orange accent, notes stay grey.
  */
 
 @use '@/styles/design-tokens' as *;
@@ -8,30 +8,26 @@
 .badge {
   display: inline-flex;
   align-items: center;
-  gap: $spacing-1;
   padding: $spacing-1 $spacing-2;
+  font-family: $font-family-mono;
   font-size: $font-size-xs;
   font-weight: $font-weight-medium;
+  letter-spacing: $letter-spacing-wider;
+  text-transform: uppercase;
   border-radius: $border-radius-tag;
   border: $border-width-thin solid;
-  transition: background-color 0.2s ease, border-color 0.2s ease;
+  background-color: transparent;
+  transition: border-color 0.2s ease;
 
-  // Article badge - Blue
+  // Article badge - orange accent
   &[data-type='article'] {
-    background-color: $color-badge-article-bg;
-    color: $color-badge-article-text;
-    border-color: $color-badge-article-border;
+    color: $orange-700;
+    border-color: $orange-300;
   }
 
-  // Note badge - Purple
+  // Note badge - quiet grey
   &[data-type='note'] {
-    background-color: $color-badge-note-bg;
-    color: $color-badge-note-text;
-    border-color: $color-badge-note-border;
-  }
-
-  // Icon styling
-  .icon {
-    line-height: 1;
+    color: $color-text-secondary;
+    border-color: $color-border-strong;
   }
 }

--- a/frontend/src/components/Badge.tsx
+++ b/frontend/src/components/Badge.tsx
@@ -1,7 +1,7 @@
 /**
  * Badge component for indicating content type
  * Used to distinguish between Articles (read-only) and Notes (editable)
- * Migrated to CSS Modules with retro-modern color scheme
+ * Uppercase mono labels - category identity via typography, not hue.
  */
 
 import styles from "./Badge.module.scss";
@@ -14,16 +14,16 @@ interface BadgeProps {
 export default function Badge({ type, className = "" }: BadgeProps) {
   const config = {
     article: {
-      icon: "📚",
       label: "Article",
+      short: "ART",
     },
     note: {
-      icon: "📝",
       label: "Note",
+      short: "NOTE",
     },
   };
 
-  const { icon, label } = config[type];
+  const { label, short } = config[type];
 
   return (
     <span
@@ -32,10 +32,7 @@ export default function Badge({ type, className = "" }: BadgeProps) {
       role="status"
       aria-label={`Content type: ${label}`}
     >
-      <span className={styles.icon} aria-hidden="true">
-        {icon}
-      </span>
-      {label}
+      {short}
     </span>
   );
 }

--- a/frontend/src/components/MarkdownWithWikilinks.module.scss
+++ b/frontend/src/components/MarkdownWithWikilinks.module.scss
@@ -23,28 +23,29 @@
 }
 
 // Wikilink styling (for note links)
+// Note links are the interactive accent: orange, in the mono metadata voice.
 .wikilink {
   display: inline-block;
   padding: 0 $spacing-1;
   border-radius: $border-radius-sm;
   @include text-secondary;
-  background-color: $blue-50;
-  color: $blue-600;
+  background-color: $color-interactive-primary-bg-subtle;
+  color: $color-link-hover;
   text-decoration: none;
-  font-family: monospace;
+  font-family: $font-family-mono;
 
   &:hover {
     text-decoration: underline;
   }
 }
 
-// Article link styling (distinct from note links)
+// Article link styling (distinct from note links: slate, body face)
 .articleLink {
-  background-color: $green-50;
-  color: $green-700;
+  background-color: $slate-blue-50;
+  color: $slate-blue-700;
   font-family: inherit; // Use regular font, not monospace
 
   &:hover {
-    background-color: $green-100;
+    background-color: $slate-blue-100;
   }
 }

--- a/frontend/src/components/NoteOfDay/NoteOfDay.tsx
+++ b/frontend/src/components/NoteOfDay/NoteOfDay.tsx
@@ -71,10 +71,7 @@ export default function NoteOfDay() {
   return (
     <div className={`${styles.noteOfDay} ${is_stale ? styles.stale : ""}`}>
       <div className={styles.header}>
-        <span className={styles.icon} aria-hidden="true">
-          {is_stale ? "🕰️" : "💡"}
-        </span>
-        <h3 className={styles.title}>{is_stale ? "Note to Revisit" : "Note of the Day"}</h3>
+        <h3 className={styles.title}>{is_stale ? "Note to revisit" : "Note of the day"}</h3>
         {is_stale && <span className={styles.staleBadge}>Needs Review</span>}
       </div>
 

--- a/frontend/src/components/SearchModal.module.scss
+++ b/frontend/src/components/SearchModal.module.scss
@@ -50,7 +50,9 @@
 }
 
 .searchIcon {
-  font-size: 1.25rem;
+  display: inline-flex;
+  align-items: center;
+  color: $color-text-tertiary;
   flex-shrink: 0;
 }
 
@@ -122,7 +124,7 @@
   @include transition-default;
 
   &:hover {
-    background-color: $blue-50;
+    background-color: $orange-50;
   }
 }
 
@@ -132,13 +134,24 @@
   align-items: center;
   gap: $spacing-1;
   flex-shrink: 0;
-  width: 2.5rem;
+  width: 3rem;
 
   .resultType {
-    font-size: 1.25rem;
+    font-family: $font-family-mono;
+    font-size: $font-size-xs;
+    letter-spacing: $letter-spacing-wide;
+
+    &[data-type='article'] {
+      color: $orange-700;
+    }
+
+    &[data-type='note'] {
+      color: $color-text-secondary;
+    }
   }
 
   .resultScore {
+    font-family: $font-family-mono;
     font-size: 0.6875rem;
     color: $neutral-400;
   }

--- a/frontend/src/components/SearchModal.tsx
+++ b/frontend/src/components/SearchModal.tsx
@@ -14,6 +14,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import Link from "next/link";
 import { logger } from "@/lib/logger";
+import { MagnifyingGlass } from "@phosphor-icons/react";
 import styles from "./SearchModal.module.scss";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -156,7 +157,9 @@ export default function SearchModal({ isOpen, onClose }: SearchModalProps) {
       <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
         {/* Search Input */}
         <div className={styles.searchHeader}>
-          <span className={styles.searchIcon}>🔍</span>
+          <span className={styles.searchIcon} aria-hidden="true">
+            <MagnifyingGlass size={18} />
+          </span>
           <input
             ref={inputRef}
             type="text"
@@ -193,8 +196,8 @@ export default function SearchModal({ isOpen, onClose }: SearchModalProps) {
                     onClick={handleResultClick}
                   >
                     <div className={styles.resultMeta}>
-                      <span className={styles.resultType}>
-                        {result.type === "article" ? "📚" : "📝"}
+                      <span className={styles.resultType} data-type={result.type}>
+                        {result.type === "article" ? "ART" : "NOTE"}
                       </span>
                       <span className={styles.resultScore}>{result.score.toFixed(1)}</span>
                     </div>

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -16,6 +16,7 @@ import { useUserPreferences } from "@/hooks/useUserPreferences";
 import type { AiMode } from "@/lib/settings";
 import { logger } from "@/lib/logger";
 import { useFeatureFlags } from "@/hooks/useFeatureFlags";
+import { GearSix } from "@phosphor-icons/react";
 import styles from "./Settings.module.scss";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -81,7 +82,9 @@ export default function Settings() {
         aria-expanded={isOpen}
         title="Settings"
       >
-        <span className={styles.icon}>⚙️</span>
+        <span className={styles.icon} aria-hidden="true">
+          <GearSix size={18} />
+        </span>
       </button>
 
       {/* Dropdown menu */}

--- a/frontend/src/components/ThemeToggle.module.scss
+++ b/frontend/src/components/ThemeToggle.module.scss
@@ -1,0 +1,30 @@
+/**
+ * ThemeToggle Component Styles
+ */
+
+@use '@/styles/design-tokens' as *;
+@use '@/styles/mixins' as *;
+
+.toggle {
+  @include flex-center;
+  width: 38px;
+  height: 38px;
+  padding: 0;
+  border: 1px solid $neutral-300;
+  border-radius: $border-radius-md;
+  background-color: $white;
+  color: $color-text-secondary;
+  cursor: pointer;
+  @include transition-default;
+
+  &:hover {
+    background-color: $color-surface-hover;
+    border-color: $color-border-hover;
+    color: $color-link-default;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $color-interactive-primary-focus;
+    outline-offset: 2px;
+  }
+}

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -48,7 +48,11 @@ export default function ThemeToggle() {
       title={theme === "dark" ? "Switch to light theme" : "Switch to dark theme"}
     >
       {/* Render both and pick via CSS-free state to avoid hydration mismatch */}
-      {theme === "dark" ? <Sun size={18} aria-hidden="true" /> : <Moon size={18} aria-hidden="true" />}
+      {theme === "dark" ? (
+        <Sun size={18} aria-hidden="true" />
+      ) : (
+        <Moon size={18} aria-hidden="true" />
+      )}
     </button>
   );
 }

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,54 @@
+/**
+ * ThemeToggle - switches between light and dark ("phosphor") themes.
+ *
+ * Resolution order: explicit choice (localStorage "theme") wins, otherwise
+ * the OS preference applies. An inline script in the root layout applies the
+ * stored choice before first paint, so there is no flash of the wrong theme.
+ */
+
+"use client";
+
+import { useEffect, useState } from "react";
+import { Moon, Sun } from "@phosphor-icons/react";
+import styles from "./ThemeToggle.module.scss";
+
+type Theme = "light" | "dark";
+
+function resolveInitialTheme(): Theme {
+  const explicit = document.documentElement.dataset.theme;
+  if (explicit === "light" || explicit === "dark") return explicit;
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+export default function ThemeToggle() {
+  // null until mounted - the server doesn't know the theme
+  const [theme, setTheme] = useState<Theme | null>(null);
+
+  useEffect(() => {
+    setTheme(resolveInitialTheme());
+  }, []);
+
+  const toggle = () => {
+    const next: Theme = theme === "dark" ? "light" : "dark";
+    document.documentElement.dataset.theme = next;
+    try {
+      localStorage.setItem("theme", next);
+    } catch {
+      // Private browsing or blocked storage - the choice just won't persist
+    }
+    setTheme(next);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      className={styles.toggle}
+      aria-label={theme === "dark" ? "Switch to light theme" : "Switch to dark theme"}
+      title={theme === "dark" ? "Switch to light theme" : "Switch to dark theme"}
+    >
+      {/* Render both and pick via CSS-free state to avoid hydration mismatch */}
+      {theme === "dark" ? <Sun size={18} aria-hidden="true" /> : <Moon size={18} aria-hidden="true" />}
+    </button>
+  );
+}

--- a/frontend/src/components/TopNavigation.module.scss
+++ b/frontend/src/components/TopNavigation.module.scss
@@ -73,8 +73,8 @@
   }
 
   &.active {
-    background-color: $blue-50;
-    color: $blue-700;
+    background-color: $orange-50;
+    color: $orange-700;
     font-weight: 600;
   }
 }
@@ -111,7 +111,9 @@
 }
 
 .searchIcon {
-  font-size: 1.125rem;
+  display: inline-flex;
+  align-items: center;
+  color: $color-text-tertiary;
 }
 
 .searchLabel {

--- a/frontend/src/components/TopNavigation.tsx
+++ b/frontend/src/components/TopNavigation.tsx
@@ -14,9 +14,11 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { MagnifyingGlass } from "@phosphor-icons/react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import Settings from "./Settings";
+import ThemeToggle from "./ThemeToggle";
 import UserMenu from "./UserMenu";
 import SearchModal from "./SearchModal";
 import styles from "./TopNavigation.module.scss";
@@ -90,10 +92,13 @@ export default function TopNavigation() {
               className={styles.searchButton}
               aria-label="Open search"
             >
-              <span className={styles.searchIcon}>🔍</span>
+              <span className={styles.searchIcon} aria-hidden="true">
+                <MagnifyingGlass size={16} />
+              </span>
               <span className={styles.searchLabel}>Search</span>
               <kbd className={styles.searchKbd}>⌘K</kbd>
             </button>
+            <ThemeToggle />
             <Settings />
             <UserMenu />
           </div>

--- a/frontend/src/components/UserMenu.module.scss
+++ b/frontend/src/components/UserMenu.module.scss
@@ -12,7 +12,7 @@
 
 .signInLink {
   font-size: 0.9375rem;
-  color: $blue-600;
+  color: $color-link-default;
   text-decoration: none;
   padding: $spacing-2 $spacing-4;
   border-radius: $border-radius-md;
@@ -25,8 +25,8 @@
   }
 
   &:hover {
-    background-color: $blue-50;
-    color: $blue-700;
+    background-color: $orange-50;
+    color: $color-link-hover;
   }
 }
 

--- a/frontend/src/styles/design-tokens/_colors.scss
+++ b/frontend/src/styles/design-tokens/_colors.scss
@@ -32,16 +32,17 @@ $neutral-cool-900: #111827;   // Cool darkest
 
 // BALANCED NEUTRALS (Mix of both)
 // Surfaces = warm, Text = cool (best of both worlds)
-$neutral-50: $neutral-warm-50;     // Surfaces = warm
-$neutral-100: $neutral-warm-100;   // Surfaces = warm
-$neutral-200: $neutral-warm-200;   // Borders = warm
-$neutral-300: $neutral-warm-300;   // Borders = warm
-$neutral-400: $neutral-cool-400;   // Mid tones = cool
-$neutral-500: $neutral-cool-500;   // Text = cool (readable)
-$neutral-600: $neutral-cool-600;   // Text = cool
-$neutral-700: $neutral-cool-700;   // Headings = cool (sharp)
-$neutral-800: $neutral-cool-800;   // Body text = cool (legible)
-$neutral-900: $neutral-cool-900;   // Darkest = cool
+// Theme-aware: the ramp flips in dark mode (see styles/themes.scss).
+$neutral-50: var(--neutral-50);    // Surfaces = warm
+$neutral-100: var(--neutral-100);  // Surfaces = warm
+$neutral-200: var(--neutral-200);  // Borders = warm
+$neutral-300: var(--neutral-300);  // Borders = warm
+$neutral-400: var(--neutral-400);  // Mid tones = cool
+$neutral-500: var(--neutral-500);  // Text = cool (readable)
+$neutral-600: var(--neutral-600);  // Text = cool
+$neutral-700: var(--neutral-700);  // Headings = cool (sharp)
+$neutral-800: var(--neutral-800);  // Body text = cool (legible)
+$neutral-900: var(--neutral-900);  // Darkest = cool
 
 // === ORANGE (Primary - Warm) ===
 // Medium-dark orange - sophisticated, not loud
@@ -146,61 +147,62 @@ $red-600: #DC2626;
 $red-700: #B91C1C;
 $red-800: #991B1B;
 
-// === OLD COLOR SCALES (Keep for reference during migration) ===
-// Blues (Primary) - Tailwind blue scale
-$blue-50: #eff6ff;
-$blue-100: #dbeafe;
-$blue-200: #bfdbfe;
-$blue-300: #93c5fd;
-$blue-400: #60a5fa;
-$blue-500: #3b82f6;
-$blue-600: #2563eb;
-$blue-700: #1d4ed8;
-$blue-800: #1e40af;
-$blue-900: #1e3a8a;
+// === LEGACY SCALE ALIASES (Palette collapse) ===
+// These names remain for existing modules but now resolve into the
+// grey/orange/slate system. Blue and purple collapse to slate-blue (the
+// single cool accent); yellow and amber collapse to mustard (warnings /
+// highlights); green collapses to sage (success).
+$blue-50: $slate-blue-50;
+$blue-100: $slate-blue-100;
+$blue-200: $slate-blue-200;
+$blue-300: $slate-blue-300;
+$blue-400: $slate-blue-400;
+$blue-500: $slate-blue-500;
+$blue-600: $slate-blue-600;
+$blue-700: $slate-blue-700;
+$blue-800: $slate-blue-800;
+$blue-900: $slate-blue-900;
 
-// Purples (Secondary) - Tailwind purple scale
-$purple-50: #faf5ff;
-$purple-100: #f3e8ff;
-$purple-200: #e9d5ff;
-$purple-300: #d8b4fe;
-$purple-500: #a855f7;
-$purple-600: #9333ea;
-$purple-700: #7e22ce;
-$purple-800: #6b21a8;
-$purple-900: #581c87;
+$purple-50: $slate-blue-50;
+$purple-100: $slate-blue-100;
+$purple-200: $slate-blue-200;
+$purple-300: $slate-blue-300;
+$purple-500: $slate-blue-500;
+$purple-600: $slate-blue-600;
+$purple-700: $slate-blue-700;
+$purple-800: $slate-blue-800;
+$purple-900: $slate-blue-900;
 
-// Greens (Success) - Tailwind green scale
-$green-50: #f0fdf4;
-$green-100: #dcfce7;
-$green-500: #22c55e;
-$green-600: #16a34a;
-$green-700: #15803d;
+$green-50: $sage-50;
+$green-100: $sage-100;
+$green-500: $sage-500;
+$green-600: $sage-600;
+$green-700: $sage-700;
 
-// Yellows (Highlights/Search) - Tailwind yellow scale
-$yellow-50: #fefce8;
-$yellow-100: #fef9c3;
-$yellow-200: #fef08a;
-$yellow-300: #fde047;
+$yellow-50: $mustard-50;
+$yellow-100: $mustard-100;
+$yellow-200: $mustard-200;
+$yellow-300: $mustard-300;
 
-// Amber (Warnings) - Tailwind amber scale
-$amber-50: #fffbeb;
-$amber-100: #fef3c7;
-$amber-200: #fde68a;
-$amber-300: #fcd34d;
-$amber-400: #fbbf24;
-$amber-500: #f59e0b;
-$amber-600: #d97706;
-$amber-700: #b45309;
-$amber-800: #92400e;
-$amber-900: #78350f;
+$amber-50: $mustard-50;
+$amber-100: $mustard-100;
+$amber-200: $mustard-200;
+$amber-300: $mustard-300;
+$amber-400: $mustard-400;
+$amber-500: $mustard-500;
+$amber-600: $mustard-600;
+$amber-700: $mustard-700;
+$amber-800: $mustard-800;
+$amber-900: $mustard-800;
 
-// Gray (additional shades) - Tailwind gray scale
-$gray-50: #f9fafb;
-$gray-100: #f3f4f6;
+// Gray (additional shades) - theme-aware
+$gray-50: var(--gray-50);
+$gray-100: var(--gray-100);
 
 // White/Black
-$white: #ffffff;
+// $white is a *surface* color and flips to a dark surface in dark mode.
+// Use literal #fff only where true white is required regardless of theme.
+$white: var(--white);
 $black: #000000;
 
 // ============================================================================
@@ -210,214 +212,214 @@ $black: #000000;
 
 // === PAGE STRUCTURE ===
 // Warm to Cool gradient - warm cream to cool slate
-$color-page-bg: $neutral-warm-50;                  // Main page background (warm cream)
-$color-page-bg-gradient-start: $neutral-warm-50;   // Gradient start (warm cream)
-$color-page-bg-gradient-end: $indigo-50;           // Gradient end (cool slate)
-$color-page-bg-alt: $neutral-100;                  // Alternative page background (warm)
+$color-page-bg: var(--color-page-bg);                  // Main page background (warm cream)
+$color-page-bg-gradient-start: var(--color-page-bg-gradient-start);   // Gradient start (warm cream)
+$color-page-bg-gradient-end: var(--color-page-bg-gradient-end);           // Gradient end (cool slate)
+$color-page-bg-alt: var(--color-page-bg-alt);                  // Alternative page background (warm)
 
 // === SURFACES (Cards, Panels) ===
-$color-surface-default: $white;                    // Default card/surface background (neutral anchor)
-$color-surface-secondary: $neutral-warm-50;        // Secondary surfaces (warm cream - inviting)
-$color-surface-tertiary: $neutral-100;             // Tertiary surfaces (warm light grey)
-$color-surface-elevated: $white;                   // Elevated cards (white with warm shadow)
-$color-surface-hover: $neutral-warm-50;            // Surface hover state (warm)
-$color-surface-cool: $slate-blue-50;               // Cool surface variant (for contrast)
-$color-surface-hover-cool: $teal-50;               // Cool hover (alternative)
+$color-surface-default: var(--color-surface-default);                    // Default card/surface background (neutral anchor)
+$color-surface-secondary: var(--color-surface-secondary);        // Secondary surfaces (warm cream - inviting)
+$color-surface-tertiary: var(--color-surface-tertiary);             // Tertiary surfaces (warm light grey)
+$color-surface-elevated: var(--color-surface-elevated);                   // Elevated cards (white with warm shadow)
+$color-surface-hover: var(--color-surface-hover);            // Surface hover state (warm)
+$color-surface-cool: var(--color-surface-cool);               // Cool surface variant (for contrast)
+$color-surface-hover-cool: var(--color-surface-hover-cool);               // Cool hover (alternative)
 
 // === TEXT ===
-$color-text-primary: $neutral-cool-800;            // Primary text (cool dark grey - sharp, readable)
-$color-text-secondary: $neutral-cool-600;          // Secondary text (cool mid grey)
-$color-text-tertiary: $neutral-cool-500;           // Tertiary text (cool lighter grey)
-$color-text-heading: $neutral-cool-700;            // Headings (cool - clear hierarchy)
-$color-text-disabled: $neutral-cool-500;           // Disabled text
-$color-text-inverse: $white;                       // Text on dark backgrounds
-$color-text-warm: $neutral-warm-300;               // Warm text variant (for use on cool backgrounds)
+$color-text-primary: var(--color-text-primary);            // Primary text (cool dark grey - sharp, readable)
+$color-text-secondary: var(--color-text-secondary);          // Secondary text (cool mid grey)
+$color-text-tertiary: var(--color-text-tertiary);           // Tertiary text (cool lighter grey)
+$color-text-heading: var(--color-text-heading);            // Headings (cool - clear hierarchy)
+$color-text-disabled: var(--color-text-disabled);           // Disabled text
+$color-text-inverse: var(--color-text-inverse);                       // Text on dark backgrounds
+$color-text-warm: var(--color-text-warm);               // Warm text variant (for use on cool backgrounds)
 
 // === BORDERS ===
-$color-border-default: $neutral-warm-200;          // Default borders (warm - soft)
-$color-border-subtle: $neutral-warm-200;           // Subtle borders (warm)
-$color-border-strong: $neutral-cool-400;           // Strong borders (cool - more visible)
-$color-border-hover: $neutral-cool-400;            // Border hover (cool - more defined)
-$color-border-cool: $slate-blue-200;               // Cool border variant
+$color-border-default: var(--color-border-default);          // Default borders (warm - soft)
+$color-border-subtle: var(--color-border-subtle);           // Subtle borders (warm)
+$color-border-strong: var(--color-border-strong);           // Strong borders (cool - more visible)
+$color-border-hover: var(--color-border-hover);            // Border hover (cool - more defined)
+$color-border-cool: var(--color-border-cool);               // Cool border variant
 
 // === INTERACTIVE ELEMENTS ===
 
 // === PRIMARY ACTIONS (Orange - Warm) ===
-$color-interactive-primary: $orange-600;           // Orange (warm) primary button
-$color-interactive-primary-hover: $orange-700;     // Orange hover
-$color-interactive-primary-active: $orange-800;    // Orange active
-$color-interactive-primary-text: $white;           // Text on primary buttons
-$color-interactive-primary-bg-subtle: $orange-50;  // Subtle primary background
-$color-interactive-primary-focus: $orange-600;     // Primary focus ring
+$color-interactive-primary: var(--color-interactive-primary);           // Orange (warm) primary button
+$color-interactive-primary-hover: var(--color-interactive-primary-hover);     // Orange hover
+$color-interactive-primary-active: var(--color-interactive-primary-active);    // Orange active
+$color-interactive-primary-text: var(--color-interactive-primary-text);           // Text on primary buttons
+$color-interactive-primary-bg-subtle: var(--color-interactive-primary-bg-subtle);  // Subtle primary background
+$color-interactive-primary-focus: var(--color-interactive-primary-focus);     // Primary focus ring
 
 // === SECONDARY ACTIONS (Warm - Terracotta) ===
-$color-interactive-secondary: $terracotta-600;     // Terracotta (warm) secondary
-$color-interactive-secondary-hover: $terracotta-700;
-$color-interactive-secondary-active: $terracotta-800;
-$color-interactive-secondary-text: $white;
-$color-interactive-secondary-bg: $terracotta-50;
+$color-interactive-secondary: var(--color-interactive-secondary);     // Terracotta (warm) secondary
+$color-interactive-secondary-hover: var(--color-interactive-secondary-hover);
+$color-interactive-secondary-active: var(--color-interactive-secondary-active);
+$color-interactive-secondary-text: var(--color-interactive-secondary-text);
+$color-interactive-secondary-bg: var(--color-interactive-secondary-bg);
 
 // === SECONDARY COOL VARIANT (Cool - Teal) ===
 // Use for cool secondary actions (technical actions, code-related buttons)
-$color-interactive-secondary-cool: $teal-600;      // Teal (cool) secondary
-$color-interactive-secondary-cool-hover: $teal-700;
-$color-interactive-secondary-cool-active: $teal-800;
-$color-interactive-secondary-cool-text: $white;
-$color-interactive-secondary-cool-bg: $teal-50;
+$color-interactive-secondary-cool: var(--color-interactive-secondary-cool);      // Teal (cool) secondary
+$color-interactive-secondary-cool-hover: var(--color-interactive-secondary-cool-hover);
+$color-interactive-secondary-cool-active: var(--color-interactive-secondary-cool-active);
+$color-interactive-secondary-cool-text: var(--color-interactive-secondary-cool-text);
+$color-interactive-secondary-cool-bg: var(--color-interactive-secondary-cool-bg);
 
 // === TERTIARY ACTIONS (Neutral) ===
-$color-interactive-tertiary: $neutral-100;         // Warm light grey background
-$color-interactive-tertiary-hover: $neutral-200;   // Warm border grey
-$color-interactive-tertiary-active: $neutral-300;
-$color-interactive-tertiary-text: $neutral-cool-700; // Cool text for clarity
-$color-interactive-tertiary-bg: $neutral-100;
+$color-interactive-tertiary: var(--color-interactive-tertiary);         // Warm light grey background
+$color-interactive-tertiary-hover: var(--color-interactive-tertiary-hover);   // Warm border grey
+$color-interactive-tertiary-active: var(--color-interactive-tertiary-active);
+$color-interactive-tertiary-text: var(--color-interactive-tertiary-text); // Cool text for clarity
+$color-interactive-tertiary-bg: var(--color-interactive-tertiary-bg);
 
 // === GHOST ACTIONS (Warm) ===
-$color-interactive-ghost: transparent;
-$color-interactive-ghost-hover: $orange-50;        // Warm orange hover
-$color-interactive-ghost-text: $orange-600;        // Orange text
-$color-interactive-ghost-text-hover: $orange-700;
+$color-interactive-ghost: var(--color-interactive-ghost);
+$color-interactive-ghost-hover: var(--color-interactive-ghost-hover);        // Warm orange hover
+$color-interactive-ghost-text: var(--color-interactive-ghost-text);        // Orange text
+$color-interactive-ghost-text-hover: var(--color-interactive-ghost-text-hover);
 
 // === LINKS (Warm primary, Cool variants) ===
-$color-link-default: $orange-600;                  // Orange (warm) default link
-$color-link-hover: $orange-700;                    // Orange hover
-$color-link-visited: $terracotta-700;              // Terracotta (warm) visited
-$color-link-active: $orange-800;                   // Orange active
+$color-link-default: var(--color-link-default);                  // Orange (warm) default link
+$color-link-hover: var(--color-link-hover);                    // Orange hover
+$color-link-visited: var(--color-link-visited);              // Terracotta (warm) visited
+$color-link-active: var(--color-link-active);                   // Orange active
 
 // Cool link variants (for cool sections like code docs)
-$color-link-cool: $teal-600;                       // Teal (cool) link
-$color-link-cool-hover: $teal-700;                 // Teal hover
-$color-link-cool-visited: $slate-blue-700;         // Slate blue (cool) visited
+$color-link-cool: var(--color-link-cool);                       // Teal (cool) link
+$color-link-cool-hover: var(--color-link-cool-hover);                 // Teal hover
+$color-link-cool-visited: var(--color-link-cool-visited);         // Slate blue (cool) visited
 
 // === SEMANTIC STATES ===
 
 // === SUCCESS (Sage - Balanced Warm-Cool) ===
 // Sage green naturally balances warm and cool
-$color-success-bg: $sage-100;
-$color-success-border: $sage-500;
-$color-success-text: $sage-600;
+$color-success-bg: var(--color-success-bg);
+$color-success-border: var(--color-success-border);
+$color-success-text: var(--color-success-text);
 
 // === WARNING (Mustard - Warm) ===
-$color-warning-bg: $mustard-100;
-$color-warning-border: $mustard-500;
-$color-warning-text: $mustard-700;
+$color-warning-bg: var(--color-warning-bg);
+$color-warning-border: var(--color-warning-border);
+$color-warning-text: var(--color-warning-text);
 
 // === ERROR (Red - Warm) ===
-$color-error-bg: $red-50;
-$color-error-border: $red-500;
-$color-error-text: $red-700;
+$color-error-bg: var(--color-error-bg);
+$color-error-border: var(--color-error-border);
+$color-error-text: var(--color-error-text);
 
 // === INFO (Cool - Dusty Blue) ===
-$color-info-bg: $dusty-blue-100;                   // Cool blue
-$color-info-border: $dusty-blue-200;
-$color-info-text: $dusty-blue-700;
+$color-info-bg: var(--color-info-bg);                   // Cool blue
+$color-info-border: var(--color-info-border);
+$color-info-text: var(--color-info-text);
 
 // === INFO COOL VARIANT (Slate Blue) ===
 // Use for very technical/structural info
-$color-info-cool-bg: $slate-blue-100;              // Cooler slate
-$color-info-cool-border: $slate-blue-200;
-$color-info-cool-text: $slate-blue-700;
+$color-info-cool-bg: var(--color-info-cool-bg);              // Cooler slate
+$color-info-cool-border: var(--color-info-cool-border);
+$color-info-cool-text: var(--color-info-cool-text);
 
 // === BADGES ===
 
 // === ARTICLE BADGES (Warm - Orange) ===
-$color-badge-article-bg: $orange-200;     // More saturated (was orange-100)
-$color-badge-article-text: $orange-700;
-$color-badge-article-border: $orange-300;  // Stronger border (was orange-200)
+$color-badge-article-bg: var(--color-badge-article-bg);     // More saturated (was orange-100)
+$color-badge-article-text: var(--color-badge-article-text);
+$color-badge-article-border: var(--color-badge-article-border);  // Stronger border (was orange-200)
 
 // === NOTE BADGES (Warm - Terracotta) ===
-$color-badge-note-bg: $terracotta-200;     // More saturated (was terracotta-100)
-$color-badge-note-text: $terracotta-700;
-$color-badge-note-border: $terracotta-300;  // Stronger border (was terracotta-200)
+$color-badge-note-bg: var(--color-badge-note-bg);     // More saturated (was terracotta-100)
+$color-badge-note-text: var(--color-badge-note-text);
+$color-badge-note-border: var(--color-badge-note-border);  // Stronger border (was terracotta-200)
 
 // === NOTE BADGES COOL VARIANT (Teal) ===
 // Alternative for cool sections
-$color-badge-note-cool-bg: $teal-100;
-$color-badge-note-cool-text: $teal-700;
-$color-badge-note-cool-border: $teal-200;
+$color-badge-note-cool-bg: var(--color-badge-note-cool-bg);
+$color-badge-note-cool-text: var(--color-badge-note-cool-text);
+$color-badge-note-cool-border: var(--color-badge-note-cool-border);
 
 // === TAGS ===
 
 // === ARTICLE TAGS (Cool - Dusty Blue) ===
 // Cool blue tags for articles - clearly interactive
-$color-tag-article-bg: $dusty-blue-100;
-$color-tag-article-text: $dusty-blue-700;
-$color-tag-article-border: $dusty-blue-300;
-$color-tag-article-hover-bg: $dusty-blue-200;
-$color-tag-article-hover-text: $dusty-blue-800;
-$color-tag-article-hover-border: $dusty-blue-400;
+$color-tag-article-bg: var(--color-tag-article-bg);
+$color-tag-article-text: var(--color-tag-article-text);
+$color-tag-article-border: var(--color-tag-article-border);
+$color-tag-article-hover-bg: var(--color-tag-article-hover-bg);
+$color-tag-article-hover-text: var(--color-tag-article-hover-text);
+$color-tag-article-hover-border: var(--color-tag-article-hover-border);
 
 // === NOTE TAGS (Cool - Teal) ===
 // Cool teal tags for notes - distinguishes from articles
-$color-tag-note-bg: $teal-100;
-$color-tag-note-text: $teal-700;
-$color-tag-note-border: $teal-300;
-$color-tag-note-hover-bg: $teal-200;
-$color-tag-note-hover-text: $teal-800;
-$color-tag-note-hover-border: $teal-400;
+$color-tag-note-bg: var(--color-tag-note-bg);
+$color-tag-note-text: var(--color-tag-note-text);
+$color-tag-note-border: var(--color-tag-note-border);
+$color-tag-note-hover-bg: var(--color-tag-note-hover-bg);
+$color-tag-note-hover-text: var(--color-tag-note-hover-text);
+$color-tag-note-hover-border: var(--color-tag-note-hover-border);
 
 // === FORM ELEMENTS ===
 // Strategy: Warm borders at rest, cool on hover (more defined), warm orange on focus (friendly)
-$color-input-bg: $white;
-$color-input-border: $neutral-warm-200;            // Warm border (soft)
-$color-input-border-hover: $neutral-cool-400;      // Cool hover (more visible)
-$color-input-border-focus: $orange-600;            // Orange focus (warm)
-$color-input-text: $neutral-cool-800;              // Cool text (readable)
-$color-input-placeholder: $neutral-cool-500;       // Cool placeholder
-$color-input-disabled-bg: $neutral-100;            // Warm disabled
-$color-input-disabled-text: $neutral-cool-500;
+$color-input-bg: var(--color-input-bg);
+$color-input-border: var(--color-input-border);            // Warm border (soft)
+$color-input-border-hover: var(--color-input-border-hover);      // Cool hover (more visible)
+$color-input-border-focus: var(--color-input-border-focus);            // Orange focus (warm)
+$color-input-text: var(--color-input-text);              // Cool text (readable)
+$color-input-placeholder: var(--color-input-placeholder);       // Cool placeholder
+$color-input-disabled-bg: var(--color-input-disabled-bg);            // Warm disabled
+$color-input-disabled-text: var(--color-input-disabled-text);
 
 // === QUICK LISTS (Note Categories) ===
 
 // === ORPHAN NOTES (Warm - Mustard) ===
 // Semantic: "Attention needed" (warm, urgent)
-$color-orphan-bg: $mustard-100;
-$color-orphan-border: $mustard-200;
-$color-orphan-text: $mustard-500;
-$color-orphan-heading: $mustard-700;
-$color-orphan-hover: $mustard-50;
+$color-orphan-bg: var(--color-orphan-bg);
+$color-orphan-border: var(--color-orphan-border);
+$color-orphan-text: var(--color-orphan-text);
+$color-orphan-heading: var(--color-orphan-heading);
+$color-orphan-hover: var(--color-orphan-hover);
 
 // === HUB NOTES (Cool - Dusty Blue) ===
 // Semantic: "Structure/navigation" (cool, organized)
-$color-hub-bg: $dusty-blue-100;
-$color-hub-border: $dusty-blue-200;
-$color-hub-text: $dusty-blue-600;
-$color-hub-heading: $dusty-blue-700;
-$color-hub-hover: $dusty-blue-50;
+$color-hub-bg: var(--color-hub-bg);
+$color-hub-border: var(--color-hub-border);
+$color-hub-text: var(--color-hub-text);
+$color-hub-heading: var(--color-hub-heading);
+$color-hub-hover: var(--color-hub-hover);
 
 // === CENTRAL CONCEPT NOTES (Warm - Terracotta) ===
 // Semantic: "Foundation/importance" (warm, grounded)
-$color-central-bg: $terracotta-100;
-$color-central-border: $terracotta-200;
-$color-central-text: $terracotta-600;
-$color-central-heading: $terracotta-700;
-$color-central-hover: $terracotta-50;
+$color-central-bg: var(--color-central-bg);
+$color-central-border: var(--color-central-border);
+$color-central-text: var(--color-central-text);
+$color-central-heading: var(--color-central-heading);
+$color-central-hover: var(--color-central-hover);
 
 // === STALE NOTES (Cool - Slate Blue) ===
 // Semantic: "Needs attention/review" (cool, contemplative)
-$color-stale-bg: $slate-blue-100;
-$color-stale-border: $slate-blue-200;
-$color-stale-text: $slate-blue-600;
-$color-stale-heading: $slate-blue-700;
-$color-stale-hover: $slate-blue-50;
+$color-stale-bg: var(--color-stale-bg);
+$color-stale-border: var(--color-stale-border);
+$color-stale-text: var(--color-stale-text);
+$color-stale-heading: var(--color-stale-heading);
+$color-stale-hover: var(--color-stale-hover);
 
 // === SOCIAL LINKS ===
-$color-social-github-bg: $neutral-900;
-$color-social-github-bg-hover: $neutral-800;
-$color-social-github-text: $white;
+$color-social-github-bg: var(--color-social-github-bg);
+$color-social-github-bg-hover: var(--color-social-github-bg-hover);
+$color-social-github-text: var(--color-social-github-text);
 
-$color-social-linkedin-bg: $blue-600;
-$color-social-linkedin-bg-hover: $blue-700;
-$color-social-linkedin-text: $white;
+$color-social-linkedin-bg: var(--color-social-linkedin-bg);
+$color-social-linkedin-bg-hover: var(--color-social-linkedin-bg-hover);
+$color-social-linkedin-text: var(--color-social-linkedin-text);
 
-$color-social-email-bg: $gray-100;
-$color-social-email-bg-hover: $neutral-200;
-$color-social-email-text: $neutral-900;
-$color-social-email-border: $neutral-300;
+$color-social-email-bg: var(--color-social-email-bg);
+$color-social-email-bg-hover: var(--color-social-email-bg-hover);
+$color-social-email-text: var(--color-social-email-text);
+$color-social-email-border: var(--color-social-email-border);
 
 // === DISABLED STATES ===
-$color-disabled-bg: $neutral-400;
-$color-disabled-text: $neutral-500;
+$color-disabled-bg: var(--color-disabled-bg);
+$color-disabled-text: var(--color-disabled-text);
 
 // ============================================================================
 // BACKWARD COMPATIBILITY ALIASES
@@ -425,29 +427,29 @@ $color-disabled-text: $neutral-500;
 // Keep these for now to avoid breaking existing code
 // TODO: Phase these out over time
 
-$color-bg-canvas: $color-surface-secondary;
-$color-bg-secondary: $color-surface-tertiary;
-$color-bg-card: $color-surface-default;
-$color-bg-cool: $color-page-bg;
-$color-border: $color-border-default;
-$color-primary: $color-interactive-primary;
-$color-primary-hover: $color-interactive-primary-hover;
-$color-primary-active: $color-interactive-primary-active;
-$color-primary-light: $orange-50;  // Updated to orange
-$color-primary-dark: $orange-700;  // Updated to orange
-$color-secondary: $color-interactive-secondary;
-$color-secondary-hover: $color-interactive-secondary-hover;
-$color-secondary-light: $terracotta-50;  // Updated to terracotta
-$color-accent-blue: $dusty-blue-600;     // Updated to dusty blue (cool accent)
-$color-accent-blue-light: $dusty-blue-50;
-$color-accent-blue-border: $dusty-blue-200;
-$color-accent-blue-dark: $dusty-blue-700;
-$color-accent-purple: $terracotta-600;   // Updated to terracotta (warm secondary)
-$color-accent-purple-light: $terracotta-50;
-$color-accent-purple-border: $terracotta-200;
-$color-accent-purple-dark: $terracotta-700;
-$color-disabled-bg: $neutral-400;
-$color-disabled-text: $neutral-500;
-$color-success: $color-success-text;
-$color-warning: $color-warning-text;
-$color-info: $color-info-text;
+$color-bg-canvas: var(--color-bg-canvas);
+$color-bg-secondary: var(--color-bg-secondary);
+$color-bg-card: var(--color-bg-card);
+$color-bg-cool: var(--color-bg-cool);
+$color-border: var(--color-border);
+$color-primary: var(--color-primary);
+$color-primary-hover: var(--color-primary-hover);
+$color-primary-active: var(--color-primary-active);
+$color-primary-light: var(--color-primary-light);  // Updated to orange
+$color-primary-dark: var(--color-primary-dark);  // Updated to orange
+$color-secondary: var(--color-secondary);
+$color-secondary-hover: var(--color-secondary-hover);
+$color-secondary-light: var(--color-secondary-light);  // Updated to terracotta
+$color-accent-blue: var(--color-accent-blue);     // Updated to dusty blue (cool accent)
+$color-accent-blue-light: var(--color-accent-blue-light);
+$color-accent-blue-border: var(--color-accent-blue-border);
+$color-accent-blue-dark: var(--color-accent-blue-dark);
+$color-accent-purple: var(--color-accent-purple);   // Updated to terracotta (warm secondary)
+$color-accent-purple-light: var(--color-accent-purple-light);
+$color-accent-purple-border: var(--color-accent-purple-border);
+$color-accent-purple-dark: var(--color-accent-purple-dark);
+$color-disabled-bg: var(--color-disabled-bg);
+$color-disabled-text: var(--color-disabled-text);
+$color-success: var(--color-success);
+$color-warning: var(--color-warning);
+$color-info: var(--color-info);

--- a/frontend/src/styles/design-tokens/_typography.scss
+++ b/frontend/src/styles/design-tokens/_typography.scss
@@ -13,16 +13,16 @@ $font-family-mono: var(--font-space-mono), 'SF Mono', 'Monaco', 'Inconsolata', '
   'Source Code Pro', monospace;
 
 // ===== FONT SIZES =====
-// Scaled down ~15% for more compact display
-$font-size-xs: 0.625rem; // 10px (was 12px)
-$font-size-sm: 0.75rem; // 12px (was 14px)
-$font-size-base: 0.875rem; // 14px (was 16px)
-$font-size-lg: 1rem; // 16px (was 18px)
-$font-size-xl: 1.125rem; // 18px (was 20px)
-$font-size-2xl: 1.3125rem; // 21px (was 24px)
-$font-size-3xl: 1.625rem; // 26px (was 30px)
-$font-size-4xl: 2rem; // 32px (was 36px)
-$font-size-5xl: 2.625rem; // 42px (was 48px)
+// Standard 16px base: long-form reading is the site's core job.
+$font-size-xs: 0.75rem; // 12px
+$font-size-sm: 0.875rem; // 14px
+$font-size-base: 1rem; // 16px
+$font-size-lg: 1.125rem; // 18px
+$font-size-xl: 1.25rem; // 20px
+$font-size-2xl: 1.5rem; // 24px
+$font-size-3xl: 1.875rem; // 30px
+$font-size-4xl: 2.25rem; // 36px
+$font-size-5xl: 3rem; // 48px
 
 // ===== FONT WEIGHTS =====
 $font-weight-normal: 400;

--- a/frontend/src/styles/globals.scss
+++ b/frontend/src/styles/globals.scss
@@ -5,6 +5,7 @@
 
 @use "design-tokens" as *;
 @use "mixins" as *;
+@use "themes";
 @use "utilities";
 
 // ===== CSS RESET =====
@@ -187,4 +188,23 @@ button {
 body,
 html {
   @include scrollbar-custom;
+}
+
+// ===== HIGHLIGHT MARKS =====
+// mark backgrounds stay light in both themes, so pin dark text explicitly
+mark {
+  background-color: $mustard-200;
+  color: $neutral-cool-800;
+}
+
+// ===== REDUCED MOTION =====
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/frontend/src/styles/mixins/_form-elements.scss
+++ b/frontend/src/styles/mixins/_form-elements.scss
@@ -31,7 +31,7 @@
   &:focus {
     outline: none;
     border-color: $color-input-border-focus;
-    box-shadow: 0 0 0 2px rgba($color-input-border-focus, 0.2);
+    box-shadow: 0 0 0 2px rgba($orange-600, 0.2);
   }
 
   &:disabled {
@@ -206,7 +206,7 @@
       border-color: $color-error-border;
 
       &:focus {
-        box-shadow: 0 0 0 2px rgba($color-error-border, 0.2);
+        box-shadow: 0 0 0 2px rgba($red-500, 0.2);
       }
     }
   }
@@ -271,7 +271,7 @@
   border-color: $color-success-border;
 
   &:focus {
-    box-shadow: 0 0 0 2px rgba($color-success-border, 0.2);
+    box-shadow: 0 0 0 2px rgba($sage-500, 0.2);
   }
 }
 
@@ -282,7 +282,7 @@
   border-color: $color-error-border;
 
   &:focus {
-    box-shadow: 0 0 0 2px rgba($color-error-border, 0.2);
+    box-shadow: 0 0 0 2px rgba($red-500, 0.2);
   }
 }
 
@@ -293,6 +293,6 @@
   border-color: $color-warning-border;
 
   &:focus {
-    box-shadow: 0 0 0 2px rgba($color-warning-border, 0.2);
+    box-shadow: 0 0 0 2px rgba($mustard-500, 0.2);
   }
 }

--- a/frontend/src/styles/mixins/_typography.scss
+++ b/frontend/src/styles/mixins/_typography.scss
@@ -137,3 +137,20 @@
   font-size: 0.9em;
   letter-spacing: $letter-spacing-tight;
 }
+
+// Metadata voice: dates, eyebrows, reading time, tag labels, note IDs.
+// Space Mono is the site's "terminal layer" - use this for every
+// machine-ish fact that sits next to human prose.
+@mixin text-meta-mono {
+  font-family: $font-family-mono;
+  font-size: $font-size-xs;
+  letter-spacing: $letter-spacing-wide;
+  color: $color-text-tertiary;
+}
+
+// Uppercase variant for eyebrows and category labels (ART / NOTE / REF).
+@mixin text-label-mono {
+  @include text-meta-mono;
+  text-transform: uppercase;
+  letter-spacing: $letter-spacing-wider;
+}

--- a/frontend/src/styles/themes.scss
+++ b/frontend/src/styles/themes.scss
@@ -1,0 +1,643 @@
+/**
+ * Theme definitions: light (default) and dark ("phosphor") palettes.
+ *
+ * The semantic tokens in design-tokens/_colors.scss resolve to the CSS
+ * custom properties defined here. Light is the default; dark applies when
+ * the user opts in via the theme toggle (html[data-theme="dark"]) or by
+ * OS preference when no explicit choice is stored.
+ */
+
+@use 'design-tokens' as *;
+
+:root {
+  color-scheme: light;
+  --color-page-bg: #{$neutral-warm-50};
+  --color-page-bg-gradient-start: #{$neutral-warm-50};
+  --color-page-bg-gradient-end: #{$indigo-50};
+  --color-page-bg-alt: #{$neutral-100};
+  --color-surface-default: #{$white};
+  --color-surface-secondary: #{$neutral-warm-50};
+  --color-surface-tertiary: #{$neutral-100};
+  --color-surface-elevated: #{$white};
+  --color-surface-hover: #{$neutral-warm-50};
+  --color-surface-cool: #{$slate-blue-50};
+  --color-surface-hover-cool: #{$teal-50};
+  --color-text-primary: #{$neutral-cool-800};
+  --color-text-secondary: #{$neutral-cool-600};
+  --color-text-tertiary: #{$neutral-cool-500};
+  --color-text-heading: #{$neutral-cool-700};
+  --color-text-disabled: #{$neutral-cool-500};
+  --color-text-inverse: #{$white};
+  --color-text-warm: #{$neutral-warm-300};
+  --color-border-default: #{$neutral-warm-200};
+  --color-border-subtle: #{$neutral-warm-200};
+  --color-border-strong: #{$neutral-cool-400};
+  --color-border-hover: #{$neutral-cool-400};
+  --color-border-cool: #{$slate-blue-200};
+  --color-interactive-primary: #{$orange-600};
+  --color-interactive-primary-hover: #{$orange-700};
+  --color-interactive-primary-active: #{$orange-800};
+  --color-interactive-primary-text: #{$white};
+  --color-interactive-primary-bg-subtle: #{$orange-50};
+  --color-interactive-primary-focus: #{$orange-600};
+  --color-interactive-secondary: #{$terracotta-600};
+  --color-interactive-secondary-hover: #{$terracotta-700};
+  --color-interactive-secondary-active: #{$terracotta-800};
+  --color-interactive-secondary-text: #{$white};
+  --color-interactive-secondary-bg: #{$terracotta-50};
+  --color-interactive-secondary-cool: #{$teal-600};
+  --color-interactive-secondary-cool-hover: #{$teal-700};
+  --color-interactive-secondary-cool-active: #{$teal-800};
+  --color-interactive-secondary-cool-text: #{$white};
+  --color-interactive-secondary-cool-bg: #{$teal-50};
+  --color-interactive-tertiary: #{$neutral-100};
+  --color-interactive-tertiary-hover: #{$neutral-200};
+  --color-interactive-tertiary-active: #{$neutral-300};
+  --color-interactive-tertiary-text: #{$neutral-cool-700};
+  --color-interactive-tertiary-bg: #{$neutral-100};
+  --color-interactive-ghost: #{transparent};
+  --color-interactive-ghost-hover: #{$orange-50};
+  --color-interactive-ghost-text: #{$orange-600};
+  --color-interactive-ghost-text-hover: #{$orange-700};
+  --color-link-default: #{$orange-600};
+  --color-link-hover: #{$orange-700};
+  --color-link-visited: #{$terracotta-700};
+  --color-link-active: #{$orange-800};
+  --color-link-cool: #{$teal-600};
+  --color-link-cool-hover: #{$teal-700};
+  --color-link-cool-visited: #{$slate-blue-700};
+  --color-success-bg: #{$sage-100};
+  --color-success-border: #{$sage-500};
+  --color-success-text: #{$sage-600};
+  --color-warning-bg: #{$mustard-100};
+  --color-warning-border: #{$mustard-500};
+  --color-warning-text: #{$mustard-700};
+  --color-error-bg: #{$red-50};
+  --color-error-border: #{$red-500};
+  --color-error-text: #{$red-700};
+  --color-info-bg: #{$dusty-blue-100};
+  --color-info-border: #{$dusty-blue-200};
+  --color-info-text: #{$dusty-blue-700};
+  --color-info-cool-bg: #{$slate-blue-100};
+  --color-info-cool-border: #{$slate-blue-200};
+  --color-info-cool-text: #{$slate-blue-700};
+  --color-badge-article-bg: #{$orange-200};
+  --color-badge-article-text: #{$orange-700};
+  --color-badge-article-border: #{$orange-300};
+  --color-badge-note-bg: #{$terracotta-200};
+  --color-badge-note-text: #{$terracotta-700};
+  --color-badge-note-border: #{$terracotta-300};
+  --color-badge-note-cool-bg: #{$teal-100};
+  --color-badge-note-cool-text: #{$teal-700};
+  --color-badge-note-cool-border: #{$teal-200};
+  --color-tag-article-bg: #{$dusty-blue-100};
+  --color-tag-article-text: #{$dusty-blue-700};
+  --color-tag-article-border: #{$dusty-blue-300};
+  --color-tag-article-hover-bg: #{$dusty-blue-200};
+  --color-tag-article-hover-text: #{$dusty-blue-800};
+  --color-tag-article-hover-border: #{$dusty-blue-400};
+  --color-tag-note-bg: #{$teal-100};
+  --color-tag-note-text: #{$teal-700};
+  --color-tag-note-border: #{$teal-300};
+  --color-tag-note-hover-bg: #{$teal-200};
+  --color-tag-note-hover-text: #{$teal-800};
+  --color-tag-note-hover-border: #{$teal-400};
+  --color-input-bg: #{$white};
+  --color-input-border: #{$neutral-warm-200};
+  --color-input-border-hover: #{$neutral-cool-400};
+  --color-input-border-focus: #{$orange-600};
+  --color-input-text: #{$neutral-cool-800};
+  --color-input-placeholder: #{$neutral-cool-500};
+  --color-input-disabled-bg: #{$neutral-100};
+  --color-input-disabled-text: #{$neutral-cool-500};
+  --color-orphan-bg: #{$mustard-100};
+  --color-orphan-border: #{$mustard-200};
+  --color-orphan-text: #{$mustard-500};
+  --color-orphan-heading: #{$mustard-700};
+  --color-orphan-hover: #{$mustard-50};
+  --color-hub-bg: #{$dusty-blue-100};
+  --color-hub-border: #{$dusty-blue-200};
+  --color-hub-text: #{$dusty-blue-600};
+  --color-hub-heading: #{$dusty-blue-700};
+  --color-hub-hover: #{$dusty-blue-50};
+  --color-central-bg: #{$terracotta-100};
+  --color-central-border: #{$terracotta-200};
+  --color-central-text: #{$terracotta-600};
+  --color-central-heading: #{$terracotta-700};
+  --color-central-hover: #{$terracotta-50};
+  --color-stale-bg: #{$slate-blue-100};
+  --color-stale-border: #{$slate-blue-200};
+  --color-stale-text: #{$slate-blue-600};
+  --color-stale-heading: #{$slate-blue-700};
+  --color-stale-hover: #{$slate-blue-50};
+  --color-social-github-bg: #{$neutral-900};
+  --color-social-github-bg-hover: #{$neutral-800};
+  --color-social-github-text: #{$white};
+  --color-social-linkedin-bg: #{$blue-600};
+  --color-social-linkedin-bg-hover: #{$blue-700};
+  --color-social-linkedin-text: #{$white};
+  --color-social-email-bg: #{$gray-100};
+  --color-social-email-bg-hover: #{$neutral-200};
+  --color-social-email-text: #{$neutral-900};
+  --color-social-email-border: #{$neutral-300};
+  --color-disabled-bg: #{$neutral-400};
+  --color-disabled-text: #{$neutral-500};
+  --color-bg-canvas: #{$color-surface-secondary};
+  --color-bg-secondary: #{$color-surface-tertiary};
+  --color-bg-card: #{$color-surface-default};
+  --color-bg-cool: #{$color-page-bg};
+  --color-border: #{$color-border-default};
+  --color-primary: #{$color-interactive-primary};
+  --color-primary-hover: #{$color-interactive-primary-hover};
+  --color-primary-active: #{$color-interactive-primary-active};
+  --color-primary-light: #{$orange-50};
+  --color-primary-dark: #{$orange-700};
+  --color-secondary: #{$color-interactive-secondary};
+  --color-secondary-hover: #{$color-interactive-secondary-hover};
+  --color-secondary-light: #{$terracotta-50};
+  --color-accent-blue: #{$dusty-blue-600};
+  --color-accent-blue-light: #{$dusty-blue-50};
+  --color-accent-blue-border: #{$dusty-blue-200};
+  --color-accent-blue-dark: #{$dusty-blue-700};
+  --color-accent-purple: #{$terracotta-600};
+  --color-accent-purple-light: #{$terracotta-50};
+  --color-accent-purple-border: #{$terracotta-200};
+  --color-accent-purple-dark: #{$terracotta-700};
+  --color-success: #{$color-success-text};
+  --color-warning: #{$color-warning-text};
+  --color-info: #{$color-info-text};
+  // === NEUTRAL RAMP ===
+  --neutral-50: #{$neutral-warm-50};
+  --neutral-100: #{$neutral-warm-100};
+  --neutral-200: #{$neutral-warm-200};
+  --neutral-300: #{$neutral-warm-300};
+  --neutral-400: #{$neutral-cool-400};
+  --neutral-500: #{$neutral-cool-500};
+  --neutral-600: #{$neutral-cool-600};
+  --neutral-700: #{$neutral-cool-700};
+  --neutral-800: #{$neutral-cool-800};
+  --neutral-900: #{$neutral-cool-900};
+  --white: #ffffff;
+  --gray-50: #f9fafb;
+  --gray-100: #f3f4f6;
+
+  // === KB HEADER ZONE ===
+  --color-header-bg-start: #{$slate-blue-200};
+  --color-header-bg-mid: #{$slate-blue-100};
+  --color-header-bg-end: #{rgba($slate-blue-50, 0.7)};
+  --color-header-border: #{$slate-blue-300};
+}
+
+// Dark theme: explicit user choice via the toggle
+:root[data-theme="dark"] {
+  color-scheme: dark;
+
+  // === PAGE STRUCTURE ===
+  --color-page-bg: #1B1D22;
+  --color-page-bg-gradient-start: #1B1D22;
+  --color-page-bg-gradient-end: #1E2127;
+  --color-page-bg-alt: #22252B;
+
+  // === SURFACES ===
+  --color-surface-default: #24272E;
+  --color-surface-secondary: #22252B;
+  --color-surface-tertiary: #2A2D34;
+  --color-surface-elevated: #282C34;
+  --color-surface-hover: #2C3038;
+  --color-surface-cool: #262B33;
+  --color-surface-hover-cool: #2A313A;
+
+  // === TEXT ===
+  --color-text-primary: #E8E9EC;
+  --color-text-secondary: #B4B7BE;
+  --color-text-tertiary: #8F929A;
+  --color-text-heading: #DDDEE2;
+  --color-text-disabled: #6E7178;
+  --color-text-inverse: #1B1D22;
+  --color-text-warm: #48453D;
+
+  // === BORDERS ===
+  --color-border-default: #34373F;
+  --color-border-subtle: #2E3138;
+  --color-border-strong: #565A64;
+  --color-border-hover: #6B7078;
+  --color-border-cool: #3A4250;
+
+  // === INTERACTIVE: PRIMARY (phosphor orange) ===
+  --color-interactive-primary: #{$orange-500};
+  --color-interactive-primary-hover: #{$orange-400};
+  --color-interactive-primary-active: #{$orange-300};
+  --color-interactive-primary-text: #1B1D22;
+  --color-interactive-primary-bg-subtle: #3A2A1E;
+  --color-interactive-primary-focus: #{$orange-400};
+
+  // === INTERACTIVE: SECONDARY ===
+  --color-interactive-secondary: #{$terracotta-500};
+  --color-interactive-secondary-hover: #{$terracotta-400};
+  --color-interactive-secondary-active: #{$terracotta-300};
+  --color-interactive-secondary-text: #1B1D22;
+  --color-interactive-secondary-bg: #362420;
+
+  --color-interactive-secondary-cool: #{$teal-500};
+  --color-interactive-secondary-cool-hover: #{$teal-400};
+  --color-interactive-secondary-cool-active: #{$teal-300};
+  --color-interactive-secondary-cool-text: #1B1D22;
+  --color-interactive-secondary-cool-bg: #1E2E2B;
+
+  // === INTERACTIVE: TERTIARY / GHOST ===
+  --color-interactive-tertiary: #2A2D34;
+  --color-interactive-tertiary-hover: #34373F;
+  --color-interactive-tertiary-active: #3E424B;
+  --color-interactive-tertiary-text: #D5D6DA;
+  --color-interactive-tertiary-bg: #2A2D34;
+
+  --color-interactive-ghost: transparent;
+  --color-interactive-ghost-hover: #3A2A1E;
+  --color-interactive-ghost-text: #{$orange-400};
+  --color-interactive-ghost-text-hover: #{$orange-300};
+
+  // === LINKS (phosphor amber) ===
+  --color-link-default: #{$orange-400};
+  --color-link-hover: #{$orange-300};
+  --color-link-visited: #{$terracotta-400};
+  --color-link-active: #{$orange-200};
+
+  --color-link-cool: #{$teal-400};
+  --color-link-cool-hover: #{$teal-300};
+  --color-link-cool-visited: #{$slate-blue-400};
+
+  // === SEMANTIC STATES ===
+  --color-success-bg: #24312A;
+  --color-success-border: #{$sage-600};
+  --color-success-text: #{$sage-400};
+
+  --color-warning-bg: #322B1C;
+  --color-warning-border: #{$mustard-600};
+  --color-warning-text: #{$mustard-400};
+
+  --color-error-bg: #33211F;
+  --color-error-border: #{$red-600};
+  --color-error-text: #E89B94;
+
+  --color-info-bg: #22303C;
+  --color-info-border: #{$dusty-blue-700};
+  --color-info-text: #{$dusty-blue-300};
+
+  --color-info-cool-bg: #262E3A;
+  --color-info-cool-border: #{$slate-blue-700};
+  --color-info-cool-text: #{$slate-blue-300};
+
+  // === BADGES ===
+  --color-badge-article-bg: #3A2A1E;
+  --color-badge-article-text: #{$orange-300};
+  --color-badge-article-border: #{$orange-800};
+
+  --color-badge-note-bg: #2A2D34;
+  --color-badge-note-text: #B4B7BE;
+  --color-badge-note-border: #565A64;
+
+  --color-badge-note-cool-bg: #1E2E2B;
+  --color-badge-note-cool-text: #{$teal-300};
+  --color-badge-note-cool-border: #{$teal-800};
+
+  // === TAGS ===
+  --color-tag-article-bg: #22303C;
+  --color-tag-article-text: #{$dusty-blue-300};
+  --color-tag-article-border: #{$dusty-blue-700};
+  --color-tag-article-hover-bg: #28394a;
+  --color-tag-article-hover-text: #{$dusty-blue-200};
+  --color-tag-article-hover-border: #{$dusty-blue-600};
+
+  --color-tag-note-bg: #1E2E2B;
+  --color-tag-note-text: #{$teal-300};
+  --color-tag-note-border: #{$teal-800};
+  --color-tag-note-hover-bg: #24413B;
+  --color-tag-note-hover-text: #{$teal-200};
+  --color-tag-note-hover-border: #{$teal-600};
+
+  // === FORM ELEMENTS ===
+  --color-input-bg: #22252B;
+  --color-input-border: #34373F;
+  --color-input-border-hover: #565A64;
+  --color-input-border-focus: #{$orange-400};
+  --color-input-text: #E8E9EC;
+  --color-input-placeholder: #8F929A;
+  --color-input-disabled-bg: #2A2D34;
+  --color-input-disabled-text: #6E7178;
+
+  // === QUICK LISTS ===
+  --color-orphan-bg: #322B1C;
+  --color-orphan-border: #4A4128;
+  --color-orphan-text: #{$mustard-400};
+  --color-orphan-heading: #{$mustard-300};
+  --color-orphan-hover: #3A3222;
+
+  --color-hub-bg: #22303C;
+  --color-hub-border: #2E4152;
+  --color-hub-text: #{$dusty-blue-400};
+  --color-hub-heading: #{$dusty-blue-300};
+  --color-hub-hover: #283848;
+
+  --color-central-bg: #362420;
+  --color-central-border: #4A322C;
+  --color-central-text: #{$terracotta-400};
+  --color-central-heading: #{$terracotta-300};
+  --color-central-hover: #3E2A25;
+
+  --color-stale-bg: #262E3A;
+  --color-stale-border: #364154;
+  --color-stale-text: #{$slate-blue-400};
+  --color-stale-heading: #{$slate-blue-300};
+  --color-stale-hover: #2C3542;
+
+  // === SOCIAL ===
+  --color-social-github-bg: #2A2D34;
+  --color-social-github-bg-hover: #34373F;
+  --color-social-github-text: #E8E9EC;
+  --color-social-linkedin-bg: #{$slate-blue-700};
+  --color-social-linkedin-bg-hover: #{$slate-blue-600};
+  --color-social-linkedin-text: #E8E9EC;
+  --color-social-email-bg: #2A2D34;
+  --color-social-email-bg-hover: #34373F;
+  --color-social-email-text: #E8E9EC;
+  --color-social-email-border: #454952;
+
+  // === DISABLED ===
+  --color-disabled-bg: #3E424B;
+  --color-disabled-text: #6E7178;
+
+  // === NEUTRAL RAMP (flipped) ===
+  --neutral-50: #22252B;
+  --neutral-100: #262A31;
+  --neutral-200: #34373F;
+  --neutral-300: #454952;
+  --neutral-400: #8A8E98;
+  --neutral-500: #A5A8B0;
+  --neutral-600: #C0C2C8;
+  --neutral-700: #D5D6DA;
+  --neutral-800: #E8E9EC;
+  --neutral-900: #F4F4F6;
+  --white: #24272E;
+  --gray-50: #22252B;
+  --gray-100: #262A31;
+
+  // === BACKWARD-COMPAT ALIASES ===
+  --color-bg-canvas: #1B1D22;
+  --color-bg-secondary: #2A2D34;
+  --color-bg-card: #24272E;
+  --color-bg-cool: #1B1D22;
+  --color-border: #34373F;
+  --color-primary: #{$orange-500};
+  --color-primary-hover: #{$orange-400};
+  --color-primary-active: #{$orange-300};
+  --color-primary-light: #3A2A1E;
+  --color-primary-dark: #{$orange-300};
+  --color-secondary: #{$terracotta-400};
+  --color-secondary-hover: #{$terracotta-300};
+  --color-secondary-light: #362420;
+  --color-accent-blue: #{$dusty-blue-400};
+  --color-accent-blue-light: #22303C;
+  --color-accent-blue-border: #2E4152;
+  --color-accent-blue-dark: #{$dusty-blue-300};
+  --color-accent-purple: #{$terracotta-400};
+  --color-accent-purple-light: #362420;
+  --color-accent-purple-border: #4A322C;
+  --color-accent-purple-dark: #{$terracotta-300};
+  --color-success: #{$sage-400};
+  --color-warning: #{$mustard-400};
+  --color-info: #{$dusty-blue-300};
+
+  // === KB HEADER ZONE ===
+  --color-header-bg-start: #262B33;
+  --color-header-bg-mid: #22262D;
+  --color-header-bg-end: #1E2127;
+  --color-header-border: #34373F;
+}
+
+// Dark theme: OS preference, when the user has not chosen explicitly
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) {
+    color-scheme: dark;
+  
+    // === PAGE STRUCTURE ===
+    --color-page-bg: #1B1D22;
+    --color-page-bg-gradient-start: #1B1D22;
+    --color-page-bg-gradient-end: #1E2127;
+    --color-page-bg-alt: #22252B;
+  
+    // === SURFACES ===
+    --color-surface-default: #24272E;
+    --color-surface-secondary: #22252B;
+    --color-surface-tertiary: #2A2D34;
+    --color-surface-elevated: #282C34;
+    --color-surface-hover: #2C3038;
+    --color-surface-cool: #262B33;
+    --color-surface-hover-cool: #2A313A;
+  
+    // === TEXT ===
+    --color-text-primary: #E8E9EC;
+    --color-text-secondary: #B4B7BE;
+    --color-text-tertiary: #8F929A;
+    --color-text-heading: #DDDEE2;
+    --color-text-disabled: #6E7178;
+    --color-text-inverse: #1B1D22;
+    --color-text-warm: #48453D;
+  
+    // === BORDERS ===
+    --color-border-default: #34373F;
+    --color-border-subtle: #2E3138;
+    --color-border-strong: #565A64;
+    --color-border-hover: #6B7078;
+    --color-border-cool: #3A4250;
+  
+    // === INTERACTIVE: PRIMARY (phosphor orange) ===
+    --color-interactive-primary: #{$orange-500};
+    --color-interactive-primary-hover: #{$orange-400};
+    --color-interactive-primary-active: #{$orange-300};
+    --color-interactive-primary-text: #1B1D22;
+    --color-interactive-primary-bg-subtle: #3A2A1E;
+    --color-interactive-primary-focus: #{$orange-400};
+  
+    // === INTERACTIVE: SECONDARY ===
+    --color-interactive-secondary: #{$terracotta-500};
+    --color-interactive-secondary-hover: #{$terracotta-400};
+    --color-interactive-secondary-active: #{$terracotta-300};
+    --color-interactive-secondary-text: #1B1D22;
+    --color-interactive-secondary-bg: #362420;
+  
+    --color-interactive-secondary-cool: #{$teal-500};
+    --color-interactive-secondary-cool-hover: #{$teal-400};
+    --color-interactive-secondary-cool-active: #{$teal-300};
+    --color-interactive-secondary-cool-text: #1B1D22;
+    --color-interactive-secondary-cool-bg: #1E2E2B;
+  
+    // === INTERACTIVE: TERTIARY / GHOST ===
+    --color-interactive-tertiary: #2A2D34;
+    --color-interactive-tertiary-hover: #34373F;
+    --color-interactive-tertiary-active: #3E424B;
+    --color-interactive-tertiary-text: #D5D6DA;
+    --color-interactive-tertiary-bg: #2A2D34;
+  
+    --color-interactive-ghost: transparent;
+    --color-interactive-ghost-hover: #3A2A1E;
+    --color-interactive-ghost-text: #{$orange-400};
+    --color-interactive-ghost-text-hover: #{$orange-300};
+  
+    // === LINKS (phosphor amber) ===
+    --color-link-default: #{$orange-400};
+    --color-link-hover: #{$orange-300};
+    --color-link-visited: #{$terracotta-400};
+    --color-link-active: #{$orange-200};
+  
+    --color-link-cool: #{$teal-400};
+    --color-link-cool-hover: #{$teal-300};
+    --color-link-cool-visited: #{$slate-blue-400};
+  
+    // === SEMANTIC STATES ===
+    --color-success-bg: #24312A;
+    --color-success-border: #{$sage-600};
+    --color-success-text: #{$sage-400};
+  
+    --color-warning-bg: #322B1C;
+    --color-warning-border: #{$mustard-600};
+    --color-warning-text: #{$mustard-400};
+  
+    --color-error-bg: #33211F;
+    --color-error-border: #{$red-600};
+    --color-error-text: #E89B94;
+  
+    --color-info-bg: #22303C;
+    --color-info-border: #{$dusty-blue-700};
+    --color-info-text: #{$dusty-blue-300};
+  
+    --color-info-cool-bg: #262E3A;
+    --color-info-cool-border: #{$slate-blue-700};
+    --color-info-cool-text: #{$slate-blue-300};
+  
+    // === BADGES ===
+    --color-badge-article-bg: #3A2A1E;
+    --color-badge-article-text: #{$orange-300};
+    --color-badge-article-border: #{$orange-800};
+  
+    --color-badge-note-bg: #2A2D34;
+    --color-badge-note-text: #B4B7BE;
+    --color-badge-note-border: #565A64;
+  
+    --color-badge-note-cool-bg: #1E2E2B;
+    --color-badge-note-cool-text: #{$teal-300};
+    --color-badge-note-cool-border: #{$teal-800};
+  
+    // === TAGS ===
+    --color-tag-article-bg: #22303C;
+    --color-tag-article-text: #{$dusty-blue-300};
+    --color-tag-article-border: #{$dusty-blue-700};
+    --color-tag-article-hover-bg: #28394a;
+    --color-tag-article-hover-text: #{$dusty-blue-200};
+    --color-tag-article-hover-border: #{$dusty-blue-600};
+  
+    --color-tag-note-bg: #1E2E2B;
+    --color-tag-note-text: #{$teal-300};
+    --color-tag-note-border: #{$teal-800};
+    --color-tag-note-hover-bg: #24413B;
+    --color-tag-note-hover-text: #{$teal-200};
+    --color-tag-note-hover-border: #{$teal-600};
+  
+    // === FORM ELEMENTS ===
+    --color-input-bg: #22252B;
+    --color-input-border: #34373F;
+    --color-input-border-hover: #565A64;
+    --color-input-border-focus: #{$orange-400};
+    --color-input-text: #E8E9EC;
+    --color-input-placeholder: #8F929A;
+    --color-input-disabled-bg: #2A2D34;
+    --color-input-disabled-text: #6E7178;
+  
+    // === QUICK LISTS ===
+    --color-orphan-bg: #322B1C;
+    --color-orphan-border: #4A4128;
+    --color-orphan-text: #{$mustard-400};
+    --color-orphan-heading: #{$mustard-300};
+    --color-orphan-hover: #3A3222;
+  
+    --color-hub-bg: #22303C;
+    --color-hub-border: #2E4152;
+    --color-hub-text: #{$dusty-blue-400};
+    --color-hub-heading: #{$dusty-blue-300};
+    --color-hub-hover: #283848;
+  
+    --color-central-bg: #362420;
+    --color-central-border: #4A322C;
+    --color-central-text: #{$terracotta-400};
+    --color-central-heading: #{$terracotta-300};
+    --color-central-hover: #3E2A25;
+  
+    --color-stale-bg: #262E3A;
+    --color-stale-border: #364154;
+    --color-stale-text: #{$slate-blue-400};
+    --color-stale-heading: #{$slate-blue-300};
+    --color-stale-hover: #2C3542;
+  
+    // === SOCIAL ===
+    --color-social-github-bg: #2A2D34;
+    --color-social-github-bg-hover: #34373F;
+    --color-social-github-text: #E8E9EC;
+    --color-social-linkedin-bg: #{$slate-blue-700};
+    --color-social-linkedin-bg-hover: #{$slate-blue-600};
+    --color-social-linkedin-text: #E8E9EC;
+    --color-social-email-bg: #2A2D34;
+    --color-social-email-bg-hover: #34373F;
+    --color-social-email-text: #E8E9EC;
+    --color-social-email-border: #454952;
+  
+    // === DISABLED ===
+    --color-disabled-bg: #3E424B;
+    --color-disabled-text: #6E7178;
+  
+    // === NEUTRAL RAMP (flipped) ===
+    --neutral-50: #22252B;
+    --neutral-100: #262A31;
+    --neutral-200: #34373F;
+    --neutral-300: #454952;
+    --neutral-400: #8A8E98;
+    --neutral-500: #A5A8B0;
+    --neutral-600: #C0C2C8;
+    --neutral-700: #D5D6DA;
+    --neutral-800: #E8E9EC;
+    --neutral-900: #F4F4F6;
+    --white: #24272E;
+    --gray-50: #22252B;
+    --gray-100: #262A31;
+  
+    // === BACKWARD-COMPAT ALIASES ===
+    --color-bg-canvas: #1B1D22;
+    --color-bg-secondary: #2A2D34;
+    --color-bg-card: #24272E;
+    --color-bg-cool: #1B1D22;
+    --color-border: #34373F;
+    --color-primary: #{$orange-500};
+    --color-primary-hover: #{$orange-400};
+    --color-primary-active: #{$orange-300};
+    --color-primary-light: #3A2A1E;
+    --color-primary-dark: #{$orange-300};
+    --color-secondary: #{$terracotta-400};
+    --color-secondary-hover: #{$terracotta-300};
+    --color-secondary-light: #362420;
+    --color-accent-blue: #{$dusty-blue-400};
+    --color-accent-blue-light: #22303C;
+    --color-accent-blue-border: #2E4152;
+    --color-accent-blue-dark: #{$dusty-blue-300};
+    --color-accent-purple: #{$terracotta-400};
+    --color-accent-purple-light: #362420;
+    --color-accent-purple-border: #4A322C;
+    --color-accent-purple-dark: #{$terracotta-300};
+    --color-success: #{$sage-400};
+    --color-warning: #{$mustard-400};
+    --color-info: #{$dusty-blue-300};
+  
+    // === KB HEADER ZONE ===
+    --color-header-bg-start: #262B33;
+    --color-header-bg-mid: #22262D;
+    --color-header-bg-end: #1E2127;
+    --color-header-border: #34373F;
+  }
+}

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,1 +1,17 @@
 import "@testing-library/jest-dom/vitest";
+import { vi } from "vitest";
+
+// jsdom does not implement matchMedia; ThemeToggle and theme resolution use it
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});


### PR DESCRIPTION
Closes #198

Implements the five approved design proposals from the design review ([artifact](https://claude.ai/code/artifact/795000cf-bfc4-4ab3-8151-1404794a917f)), plus a light/dark theme toggle.

## Changes

**P1 — Palette collapse (grey + orange + slate)**
- Legacy `$blue/$purple/$yellow/$amber/$green` scales now alias slate-blue/mustard/sage at the token tier, converging ~330 references in one move
- Orange is the single interactive accent: nav active states, links, focus rings, selected tag chips
- KB hub cards unified: white surface + grey border, featured card carries the orange left rule; one primary CTA per view, rest are ghosts

**P3 — Type scale + mono metadata layer**
- `$font-size-base` restored to 16px (long-form reading is the site's core job)
- New `text-meta-mono` / `text-label-mono` mixins; Space Mono is the metadata voice (dates, labels, note IDs, wikilinks)

**P4 — Mono label system + Phosphor icons**
- Emoji badges → uppercase mono labels (`ART` / `NOTE` / `REF`, dashed border = reference)
- Added `@phosphor-icons/react` for iconography (search, settings, theme toggle)

**P2 — Homepage hero**
- Blue gradient + floating card replaced by grounded typographic hero: mono eyebrow, orange rule, quiet mono social links

**P5 — Dark "phosphor" mode + toggle**
- Semantic color tier converted to CSS custom properties (`styles/themes.scss`)
- Warm dark-grey ground, orange reads as amber phosphor
- ThemeToggle in KB nav + homepage; defaults to `prefers-color-scheme`, persists explicit choice in localStorage, no-FOUC inline script (`suppressHydrationWarning` on `<html>` — also fixes the dev overlay that blocked clicks on the graph page)

**Accessibility / responsive**
- Unified orange focus rings, `prefers-reduced-motion` guard, `mark` contrast pinned in dark mode, active tag chip contrast fixed (old white-on-mid-blue failed WCAG)
- Verified at 390px: no horizontal overflow, nav wraps to two rows

## Verification
- ESLint, tsc, prettier clean; all 55 frontend unit tests pass
- Screenshotted home / KB hub / articles / graph in light + dark, desktop + mobile

## Known follow-ups (separate issues)
- Graph node selection should link to the note (currently selection-only)
- Graph's rainbow D3 tag colors clash with the collapsed palette
- Deeper pages (toolbox, inspire, editors, AI panels) still use static tier-1 colors and emoji in contextual copy