### PR TITLE
Design: graph interactions, consistency sweep, design-system docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -507,6 +507,7 @@ See existing tests for patterns.
 - `docs/ROADMAP.md` - Future features and TODOs
 
 **Development:**
+- `docs/DESIGN.md` - Design system: grey/orange palette, theme-aware tokens, dark mode, mono conventions
 - `docs/TESTING.md` - Testing tools and commands
 - `docs/PROFILING.md` - Performance profiling tools
 - `docs/DEPENDENCIES.md` - Dependency structure

--- a/docs/COLOR_PALETTE.md
+++ b/docs/COLOR_PALETTE.md
@@ -19,7 +19,10 @@ The design system uses a **two-tier color architecture**:
 
 This architecture makes theming easy—change Tier 1 to swap the entire palette while maintaining semantic consistency.
 
-**Current Theme**: Clean blue-purple system with Tailwind defaults
+**Current Theme**: Grey/orange "future-retro" with phosphor dark mode — see
+**[DESIGN.md](DESIGN.md)**. The tables below predate [PR #199](https://github.com/DEGoodman/mongado/pull/199)
+and are partially stale; `frontend/src/styles/design-tokens/_colors.scss` and
+`frontend/src/styles/themes.scss` are the source of truth.
 
 ## Base Palette
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,113 @@
+# Design System
+
+Mongado's visual identity: **future-retro, grey and orange**. Warm paper-grey
+surfaces, cool grey text, a single orange interactive accent, Space Grotesk
+for prose, Space Mono as the "terminal layer" for metadata. Dark mode is a
+warm dark-grey ground where the orange reads as amber phosphor.
+
+Established in [#198](https://github.com/DEGoodman/mongado/issues/198) /
+[PR #199](https://github.com/DEGoodman/mongado/pull/199).
+
+## Token architecture
+
+Three layers, defined in `frontend/src/styles/`:
+
+```
+design-tokens/_colors.scss   Tier 1: raw scales (hex) + Tier 2: semantic tokens
+themes.scss                  CSS custom properties: light + dark values
+mixins/                      Typography, buttons, cards built on Tier 2
+```
+
+**Tier 1 — scales** (`$orange-500`, `$slate-blue-200`, …) are plain Sass hex
+values. Safe inside `rgba()` and other Sass color functions. The legacy
+Tailwind names (`$blue-*`, `$purple-*`, `$yellow-*`, `$amber-*`, `$green-*`)
+still exist but are **aliases** into the collapsed palette (slate-blue /
+mustard / sage). Don't use them in new code.
+
+**Tier 2 — semantic tokens** (`$color-text-primary`, `$color-surface-default`,
+`$color-interactive-primary`, …) resolve to `var(--color-*)` and are
+**theme-aware**. Always prefer these. Because they are CSS variables at
+runtime, they cannot be passed to Sass color functions — `rgba($color-x, .2)`
+will not compile. Use a Tier 1 hex there instead.
+
+**Themes** (`themes.scss`) define every custom property twice: on `:root`
+(light) and under `:root[data-theme="dark"]` plus a
+`prefers-color-scheme: dark` block for users with no stored choice.
+
+### The `$white` caveat
+
+`$white` is a **surface** color: it resolves to `var(--white)` and flips to a
+dark surface in dark mode. Use it for card/input backgrounds. For text that
+must stay white regardless of theme (e.g. on an orange button), use
+`$color-interactive-primary-text` or literal `#fff`.
+
+### The neutral ramp flips
+
+`$neutral-50 … $neutral-900` invert in dark mode (50 stays "background-ish",
+900 stays "text-ish"). Code written as "light background, dark text" with
+neutrals is automatically correct in both themes.
+
+## Color roles
+
+| Role | Token | Rule |
+|---|---|---|
+| Interactive accent | `$color-interactive-primary` (orange) | Orange means "interact here" — one primary CTA per view, everything else is a ghost |
+| Links | `$color-link-default` / `-hover` | Orange; never blue |
+| Cool accent | slate-blue | Informational surfaces only (KB headers, info panels) |
+| States | sage = success, mustard = warning, red = error, dusty-blue = info | Semantic only, never decorative |
+| Category identity | typography, not hue | See mono labels below |
+
+Selected/active chips use `$orange-700` background with `#fff` text (≥4.5:1
+in both themes).
+
+## Typography
+
+- **Space Grotesk** (`$font-family-primary`) — headings and body. 16px base
+  (`$font-size-base`); long-form reading is the site's core job, don't shrink it.
+- **Space Mono** (`$font-family-mono`) — the metadata voice. Dates, reading
+  time, note IDs, wikilinks, eyebrows, category labels. Mixins:
+  - `@include text-meta-mono` — small mono metadata (dates, counts)
+  - `@include text-label-mono` — uppercase mono labels (eyebrows, badges)
+
+## Labels and icons
+
+- Content types are uppercase mono chips, not emoji: `ART` (orange outline),
+  `NOTE` (grey outline), `REF` (grey **dashed** outline = reference material).
+- Icons come from [`@phosphor-icons/react`](https://phosphoricons.com/)
+  (weight: regular, ~16–18px). No emoji in UI chrome; emoji in prose content
+  is fine.
+
+## Dark mode / theme toggle
+
+- `ThemeToggle` (in `TopNavigation` and the homepage corner) sets
+  `data-theme="light" | "dark"` on `<html>` and persists to
+  `localStorage("theme")`. No stored choice → OS preference applies.
+- An inline script in `app/layout.tsx` applies the stored theme before first
+  paint. `<html>` carries `suppressHydrationWarning` because that attribute
+  intentionally differs from the server render — removing it resurfaces a
+  hydration error whose dev overlay swallows all page clicks.
+- KB page headers share one gradient via `--color-header-bg-start/mid/end`
+  and `--color-header-border`.
+- The notes graph draws with hex constants for node/tag colors (chosen from
+  the Tier 1 scales) and CSS variables for labels; if you add graph colors,
+  pick from the scales in `_colors.scss`.
+
+## Accessibility baseline
+
+- Focus: `$shadow-focus-primary` ring or `outline` on `:focus-visible` —
+  orange, visible in both themes.
+- `prefers-reduced-motion` globally disables transitions/animations
+  (`globals.scss`).
+- `mark` highlights pin dark text explicitly (their background stays light in
+  both themes).
+- Body text ≥16px; mono metadata ≥12px; touch targets ~38px+.
+
+## Checklist for new UI
+
+1. Colors: Tier 2 semantic tokens only; no `$blue-*`/`$purple-*`, no literal
+   light hexes for surfaces (they strand light panels on dark backgrounds).
+2. One orange primary action per view; secondary actions are ghosts.
+3. Metadata in mono via the mixins; category identity via labels, not hue.
+4. Icons from Phosphor; no emoji in chrome.
+5. Verify in **both themes** (toggle or `--color-scheme=dark` in Playwright)
+   and at 390px width.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -76,6 +76,12 @@ in both themes).
 - Icons come from [`@phosphor-icons/react`](https://phosphoricons.com/)
   (weight: regular, ~16–18px). No emoji in UI chrome; emoji in prose content
   is fine.
+- **Keep `optimizePackageImports: ['@phosphor-icons/react']` in both
+  `next.config.mjs` and `next.config.production.mjs`.** Without it, the
+  package's barrel import drags all ~9,000 icons into every route that
+  renders the nav (10k+ webpack modules, 10s+ dev compiles). Import icons
+  from the package root as usual — the config rewrites them to per-icon
+  entry points.
 
 ## Dark mode / theme toggle
 

--- a/docs/DESIGN_TOKENS.md
+++ b/docs/DESIGN_TOKENS.md
@@ -31,11 +31,16 @@ See **[COLOR_PALETTE.md](COLOR_PALETTE.md)** for the complete color system docum
 - Usage guidelines
 - Accessibility standards
 
+> **Note**: the palette was overhauled in [PR #199](https://github.com/DEGoodman/mongado/pull/199)
+> — grey/orange future-retro with a phosphor dark mode. **[DESIGN.md](DESIGN.md)** is the
+> authoritative guide; details below that conflict with it are stale.
+
 **Quick reference**:
-- Primary: Blue (`$blue-600` = `#2563eb`)
-- Secondary: Purple (`$purple-600` = `#9333ea`)
-- Neutrals: Gray scale (`$neutral-50` to `$neutral-900`)
-- States: Green (success), Red (error), Amber (warning), Yellow (highlights)
+- Primary / interactive: Orange (`$orange-600` = `#D96D32`)
+- Cool accent (informational): Slate blue (`$slate-blue-600` = `#5B6F8F`)
+- Neutrals: warm surfaces / cool text (`$neutral-50` to `$neutral-900`, ramp flips in dark mode)
+- States: Sage (success), Red (error), Mustard (warning/highlights), Dusty blue (info)
+- Semantic tokens are CSS custom properties (theme-aware); raw scales stay Sass hex
 
 ## Typography
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,7 @@ The Knowledge Base is a separate subproject with its own documentation:
 ### UI/Design System
 
 - **[UI_MIGRATION_GUIDE.md](UI_MIGRATION_GUIDE.md)** - SCSS module system (replaced Tailwind)
+- **[DESIGN.md](DESIGN.md)** - Design system guide: palette, theming, typography, checklist
 - **[DESIGN_TOKENS.md](DESIGN_TOKENS.md)** - Color, spacing, typography tokens
 - **[COLOR_PALETTE.md](COLOR_PALETTE.md)** - Color scheme documentation
 - **[COMPONENT_REFERENCE.md](COMPONENT_REFERENCE.md)** - Component styling patterns

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -2,6 +2,13 @@
 const nextConfig = {
   reactStrictMode: true,
   output: 'standalone',
+
+  // Rewrite @phosphor-icons/react barrel imports to per-icon imports.
+  // Without this, webpack compiles all ~9,000 icons into every route that
+  // renders the nav (10k+ modules, 10s+ dev compiles).
+  experimental: {
+    optimizePackageImports: ['@phosphor-icons/react'],
+  },
 };
 
 export default nextConfig;

--- a/frontend/next.config.production.mjs
+++ b/frontend/next.config.production.mjs
@@ -7,6 +7,11 @@ const nextConfig = {
   compress: true,
   poweredByHeader: false,
 
+  // Rewrite @phosphor-icons/react barrel imports to per-icon imports
+  experimental: {
+    optimizePackageImports: ["@phosphor-icons/react"],
+  },
+
   // Bundle analyzer (enable with ANALYZE=true)
   ...(process.env.ANALYZE === "true" && {
     webpack: (config) => {

--- a/frontend/src/app/knowledge-base/articles/page.module.scss
+++ b/frontend/src/app/knowledge-base/articles/page.module.scss
@@ -137,8 +137,8 @@
 // Tag Filter Section
 .tagFilterSection {
   padding: $spacing-4;
-  background-color: $blue-50;
-  border: $border-width-thin solid $blue-200;
+  background-color: $color-surface-tertiary;
+  border: $border-width-thin solid $color-border-default;
   border-radius: $border-radius-md;
 
   .tagFilterHeader {
@@ -147,7 +147,7 @@
     .tagFilterLabel {
       @include text-secondary;
       font-weight: $font-weight-medium;
-      color: $blue-900;
+      color: $color-text-heading;
     }
   }
 
@@ -161,18 +161,18 @@
       align-items: center;
       padding: $spacing-2 $spacing-3;
       background-color: $white;
-      border: $border-width-thin solid $blue-200;
+      border: $border-width-thin solid $color-border-default;
       border-radius: $border-radius-full;
       @include text-secondary;
       font-weight: $font-weight-medium;
-      color: $blue-700;
+      color: $color-text-secondary;
       cursor: pointer;
       transition: all 0.2s ease;
 
       &:hover {
-        background-color: $blue-100;
-        border-color: $blue-300;
-        color: $blue-800;
+        background-color: $color-surface-hover;
+        border-color: $color-border-hover;
+        color: $color-text-primary;
       }
 
       &.tagBadgeActive {
@@ -254,7 +254,7 @@
   .articleCountSection {
     .activeFilters {
       @include text-secondary;
-      color: $blue-700;
+      color: $color-text-secondary;
       font-weight: $font-weight-medium;
       margin-bottom: $spacing-1;
     }

--- a/frontend/src/app/knowledge-base/inspire/page.module.scss
+++ b/frontend/src/app/knowledge-base/inspire/page.module.scss
@@ -74,11 +74,11 @@
     }
 
     .backLink {
-      color: $blue-600;
+      color: $color-link-default;
       text-decoration: none;
 
       &:hover {
-        color: $blue-700;
+        color: $color-text-secondary;
         text-decoration: underline;
       }
     }
@@ -89,11 +89,11 @@
 .header {
   background: linear-gradient(
     to bottom,
-    $teal-100 0%,
-    $teal-50 50%,
-    rgba($teal-50, 0.5) 100%
+    var(--color-header-bg-start) 0%,
+    var(--color-header-bg-mid) 50%,
+    var(--color-header-bg-end) 100%
   );
-  border-bottom: 1px solid $teal-200;
+  border-bottom: 1px solid var(--color-header-border);
   box-shadow: $shadow-card-sm;
 
   .headerContent {
@@ -321,7 +321,7 @@
       background-color: $color-orphan-text;
 
       &:hover {
-        background-color: $purple-700;
+        background-color: $color-text-secondary;
       }
     }
   }
@@ -338,7 +338,7 @@
       background-color: $color-hub-text;
 
       &:hover {
-        background-color: $blue-700;
+        background-color: $color-text-secondary;
       }
     }
   }

--- a/frontend/src/app/knowledge-base/notes/[id]/page.module.scss
+++ b/frontend/src/app/knowledge-base/notes/[id]/page.module.scss
@@ -65,11 +65,11 @@
   }
 
   .backLink {
-    color: $blue-600;
+    color: $color-link-default;
     text-decoration: none;
 
     &:hover {
-      color: $blue-700;
+      color: $color-text-secondary;
       text-decoration: underline;
     }
   }
@@ -137,8 +137,8 @@
     .referenceBadge {
       display: inline-block;
       padding: 2px 8px;
-      background-color: $amber-100;
-      color: $amber-800;
+      background-color: $color-surface-hover;
+      color: $color-text-primary;
       border-radius: $border-radius-sm;
       font-size: 11px;
       font-weight: $font-weight-medium;
@@ -420,7 +420,7 @@
   .checkbox {
     width: 16px;
     height: 16px;
-    accent-color: $blue-600;
+    accent-color: $color-link-default;
   }
 
   .checkboxText {
@@ -440,14 +440,14 @@
   padding: $spacing-6 $spacing-6;
   border-radius: $border-radius-button;
   border: $border-width-thin solid $blue-600;
-  background-color: $blue-50;
-  color: $blue-700;
+  background-color: $color-surface-tertiary;
+  color: $color-text-secondary;
   font-weight: $font-weight-medium;
   cursor: pointer;
   transition: all 0.2s ease;
 
   &:hover {
-    background-color: $blue-100;
+    background-color: $color-surface-hover;
   }
 }
 
@@ -522,11 +522,11 @@
     border: none;
 
     &.primary {
-      background-color: $blue-600;
+      background-color: $color-link-default;
       color: $white;
 
       &:hover {
-        background-color: $blue-700;
+        background-color: $color-text-secondary;
       }
     }
 

--- a/frontend/src/app/knowledge-base/notes/graph/page.module.scss
+++ b/frontend/src/app/knowledge-base/notes/graph/page.module.scss
@@ -106,12 +106,12 @@
   .backLink {
     display: inline-block;
     margin-top: $spacing-4;
-    color: $blue-600;
+    color: $color-link-default;
     text-decoration: none;
     @include text-secondary;
 
     &:hover {
-      color: $blue-700;
+      color: $color-link-hover;
       text-decoration: underline;
     }
   }
@@ -126,12 +126,12 @@
   .backLink {
     display: inline-block;
     margin-bottom: $spacing-6;
-    color: $blue-600;
+    color: $color-link-default;
     @include text-secondary;
     text-decoration: none;
 
     &:hover {
-      color: $blue-700;
+      color: $color-link-hover;
       text-decoration: underline;
     }
   }
@@ -145,15 +145,15 @@
     display: inline-block;
     margin-top: $spacing-4;
     padding: $spacing-2 $spacing-4;
-    background-color: $blue-600;
-    color: white;
+    background-color: $color-interactive-primary;
+    color: $color-interactive-primary-text;
     border-radius: $border-radius-button;
     font-weight: $font-weight-medium;
     text-decoration: none;
     transition: all 0.2s ease;
 
     &:hover {
-      background-color: $blue-700;
+      background-color: $color-link-hover;
     }
   }
 }
@@ -187,11 +187,11 @@
 
       .breadcrumbLink {
         font-size: 13px;
-        color: $blue-600;
+        color: $color-link-default;
         text-decoration: none;
 
         &:hover {
-          color: $blue-700;
+          color: $color-link-hover;
           text-decoration: underline;
         }
       }
@@ -291,7 +291,7 @@
       }
 
       &.active {
-        background: white;
+        background: $color-surface-default;
         color: $neutral-900;
         box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
       }
@@ -314,7 +314,7 @@
     width: 100%;
     padding: 6px $spacing-2;
     border: 1px solid $color-border;
-    background-color: white;
+    background-color: $color-surface-default;
     border-radius: $border-radius-sm;
     cursor: pointer;
     font-size: 12px;
@@ -324,7 +324,7 @@
     text-align: left;
 
     &:hover {
-      border-color: #cbd5e1;
+      border-color: $color-border-hover;
       background-color: $gray-50;
     }
 
@@ -359,7 +359,7 @@
   .clearButton {
     padding: 4px $spacing-2;
     border: 1px solid $color-border;
-    background-color: white;
+    background-color: $color-surface-default;
     border-radius: $border-radius-sm;
     cursor: pointer;
     font-size: 11px;
@@ -376,8 +376,9 @@
 // ===== SELECTED NODE PANEL =====
 .selectedNodePanel {
   padding: $spacing-4;
-  background-color: $purple-50;
-  border: $border-width-thin solid $purple-200;
+  background-color: $color-surface-default;
+  border: $border-width-thin solid $color-border-default;
+  border-left: $border-width-thick solid $color-interactive-primary;
   border-radius: $border-radius-md;
   box-shadow: $shadow-card-sm;
   flex-shrink: 0;
@@ -385,7 +386,7 @@
   .nodeTitle {
     margin-bottom: $spacing-2;
     font-weight: $font-weight-semibold;
-    color: $purple-900;
+    color: $color-text-heading;
   }
 
   .nodeMeta {
@@ -394,11 +395,12 @@
     gap: $spacing-3;
     flex-wrap: wrap;
     font-size: 13px;
-    color: $purple-800;
+    color: $color-text-secondary;
 
     .nodeId {
       padding: 2px $spacing-2;
-      background-color: $purple-100;
+      background-color: $color-interactive-primary-bg-subtle;
+      color: $color-link-hover;
       border-radius: $border-radius-sm;
       font-family: $font-family-mono;
       font-size: 12px;
@@ -407,6 +409,7 @@
     .nodeConnections {
       color: $color-text-tertiary;
       font-size: 12px;
+      font-family: $font-family-mono;
     }
   }
 
@@ -418,10 +421,11 @@
 
     .tag {
       padding: $spacing-1 $spacing-3;
-      background-color: $purple-100;
+      background-color: $color-surface-tertiary;
+      border: $border-width-thin solid $color-border-default;
       border-radius: 9999px;
       @include text-tertiary;
-      color: $purple-800;
+      color: $color-text-secondary;
     }
   }
 
@@ -431,8 +435,8 @@
 
     .viewButton {
       padding: $spacing-2 $spacing-4;
-      background-color: $purple-600;
-      color: white;
+      background-color: $color-interactive-primary;
+      color: $color-interactive-primary-text;
       border-radius: $border-radius-button;
       font-size: 14px;
       font-weight: $font-weight-semibold;
@@ -440,23 +444,23 @@
       transition: all 0.2s ease;
 
       &:hover {
-        background-color: $purple-700;
-        color: white;
+        background-color: $color-interactive-primary-hover;
+        color: $color-interactive-primary-text;
       }
     }
 
     .deselectButton {
       padding: $spacing-2 $spacing-4;
       background-color: transparent;
-      color: $purple-700;
-      border: $border-width-thin solid $purple-300;
+      color: $color-text-secondary;
+      border: $border-width-thin solid $color-border-strong;
       border-radius: $border-radius-button;
       @include text-secondary;
       cursor: pointer;
       transition: all 0.2s ease;
 
       &:hover {
-        background-color: $purple-50;
+        background-color: $color-surface-hover;
       }
     }
   }

--- a/frontend/src/app/knowledge-base/notes/graph/page.tsx
+++ b/frontend/src/app/knowledge-base/notes/graph/page.tsx
@@ -31,19 +31,31 @@ interface GraphData {
 }
 
 // Tag color map - module-level constant for consistent coloring
+// Colors drawn from the design-system scales (orange/terracotta/mustard/
+// teal/slate/dusty-blue/sage) so the graph reads as part of the site.
 const TAG_COLOR_MAP: Record<string, string> = {
-  ml: "#8b5cf6",
-  testing: "#3b82f6",
-  experimentation: "#10b981",
-  sre: "#f59e0b",
-  management: "#ef4444",
-  saas: "#ec4899",
-  writing: "#06b6d4",
-  productivity: "#84cc16",
-  "incident-management": "#dc2626",
-  culture: "#7c3aed",
-  rollouts: "#0ea5e9",
-  "technical-debt": "#f97316",
+  ml: "#5B6F8F", // slate-blue-600
+  testing: "#4278A8", // dusty-blue-600
+  experimentation: "#3A8A7D", // teal-600
+  sre: "#D4A748", // mustard-500
+  management: "#C4624F", // terracotta-600
+  saas: "#D18573", // terracotta-500
+  writing: "#6BB8AB", // teal-400
+  productivity: "#7B9E7A", // sage-500
+  "incident-management": "#B91C1C", // red-700
+  culture: "#91A4BF", // slate-blue-400
+  rollouts: "#5790BF", // dusty-blue-500
+  "technical-debt": "#D96D32", // orange-600
+  operations: "#7388A8", // slate-blue-500
+  architecture: "#4A5A74", // slate-blue-700
+  leadership: "#9CB89B", // sage-400
+  "system-design": "#A8503E", // terracotta-700
+  engineering: "#E8773C", // orange-500
+  "data-engineering": "#4A9D8E", // teal-500
+  "best-practices": "#B8903D", // mustard-600
+  api: "#D99B8D", // terracotta-400
+  "ci-cd": "#6B8B6B", // sage-600
+  git: "#73A5CD", // dusty-blue-400
 };
 
 function NotesGraphContent() {
@@ -158,7 +170,7 @@ function NotesGraphContent() {
       hash = tag.charCodeAt(i) + ((hash << 5) - hash);
     }
     const hue = hash % 360;
-    return `hsl(${hue}, 65%, 55%)`;
+    return `hsl(${hue}, 35%, 55%)`;
   }, []);
 
   const getNodeColor = useCallback(
@@ -301,9 +313,9 @@ function NotesGraphContent() {
       .attr("filter", "url(#textShadow)")
       .style("font-size", "13px")
       .style("font-weight", "500")
-      .style("fill", "#1f2937")
+      .style("fill", "var(--color-text-primary)")
       .style("paint-order", "stroke")
-      .style("stroke", "#ffffff")
+      .style("stroke", "var(--color-surface-default)")
       .style("stroke-width", "4px")
       .style("stroke-linejoin", "round")
       .style("opacity", 0)
@@ -347,7 +359,7 @@ function NotesGraphContent() {
           if (d.id === currentSelectedId) return (d.radius || 10) * 1.4;
           return d.radius || 10;
         })
-        .attr("stroke", (d) => (d.id === currentSelectedId ? "#9333ea" : "#374151"))
+        .attr("stroke", (d) => (d.id === currentSelectedId ? "#D96D32" : "#374151"))
         .attr("stroke-width", (d) => (d.id === currentSelectedId ? 4 : 1))
         .attr("filter", null);
 
@@ -370,7 +382,7 @@ function NotesGraphContent() {
           const sourceId = typeof d.source === "string" ? d.source : d.source.id;
           const targetId = typeof d.target === "string" ? d.target : d.target.id;
           const isConnected = sourceId === currentSelectedId || targetId === currentSelectedId;
-          return isConnected ? "#9333ea" : "#9ca3af";
+          return isConnected ? "#D96D32" : "#9ca3af";
         });
 
       labelElements
@@ -462,7 +474,7 @@ function NotesGraphContent() {
           const sourceId = typeof d.source === "string" ? d.source : d.source.id;
           const targetId = typeof d.target === "string" ? d.target : d.target.id;
           const isConnected = sourceId === hoveredNode.id || targetId === hoveredNode.id;
-          return isConnected ? "#2563eb" : "#9ca3af";
+          return isConnected ? "#E8773C" : "#9ca3af";
         });
 
       // Show labels for hovered cluster
@@ -490,11 +502,16 @@ function NotesGraphContent() {
       setSelectedNode(clickedNode);
     }
 
+    function handleNodeDoubleClick(_event: MouseEvent, clickedNode: GraphNode) {
+      router.push(`/knowledge-base/notes/${clickedNode.id}`);
+    }
+
     // Attach event handlers
     nodeElements
       .on("mouseenter", handleNodeHover)
       .on("mouseleave", handleNodeLeave)
-      .on("click", handleNodeClick);
+      .on("click", handleNodeClick)
+      .on("dblclick", handleNodeDoubleClick);
 
     // Enable dragging
     const drag = d3
@@ -576,7 +593,7 @@ function NotesGraphContent() {
     return () => {
       simulation.stop();
     };
-  }, [graphData, getNodeColor]);
+  }, [graphData, getNodeColor, router]);
 
   // Separate effect for visual updates (selection, filters) without recreating simulation
   useEffect(() => {
@@ -625,7 +642,7 @@ function NotesGraphContent() {
           if (d.id === selectedNodeId) return (d.radius || 10) * 1.4;
           return d.radius || 10;
         })
-        .attr("stroke", (d) => (d.id === selectedNodeId ? "#9333ea" : "#374151"))
+        .attr("stroke", (d) => (d.id === selectedNodeId ? "#D96D32" : "#374151"))
         .attr("stroke-width", (d) => (d.id === selectedNodeId ? 4 : 1))
         .attr("filter", null);
 
@@ -648,7 +665,7 @@ function NotesGraphContent() {
           const sourceId = typeof d.source === "string" ? d.source : d.source.id;
           const targetId = typeof d.target === "string" ? d.target : d.target.id;
           const isConnected = sourceId === selectedNodeId || targetId === selectedNodeId;
-          return isConnected ? "#9333ea" : "#9ca3af";
+          return isConnected ? "#D96D32" : "#9ca3af";
         });
 
       labelElements
@@ -681,7 +698,7 @@ function NotesGraphContent() {
         .attr("stroke", (d) => {
           const matchedTags = selectedTagsArray.filter((tag) => d.tags?.includes(tag));
           if (filterLogic === "AND" && matchedTags.length === selectedTagsArray.length) {
-            return "#9333ea";
+            return "#D96D32";
           }
           return "#374151";
         })
@@ -836,8 +853,8 @@ function NotesGraphContent() {
               aria-label={`Interactive graph visualization showing ${graphData.count.nodes} notes and ${graphData.count.edges} connections. Use mouse to hover, click, and drag nodes.`}
             />
             <div className={styles.instructions}>
-              Hover over nodes to see titles and connections · Drag nodes to reposition · Larger
-              nodes = hub notes with more links
+              Click a node to select it · Double-click to open the note · Drag to reposition ·
+              Larger nodes = hub notes with more links
             </div>
           </div>
 

--- a/frontend/src/app/knowledge-base/notes/new/page.module.scss
+++ b/frontend/src/app/knowledge-base/notes/new/page.module.scss
@@ -32,11 +32,11 @@
 
       .breadcrumbLink {
         @include text-secondary;
-        color: $blue-600;
+        color: $color-link-default;
         text-decoration: none;
 
         &:hover {
-          color: $blue-700;
+          color: $color-text-secondary;
           text-decoration: underline;
         }
       }
@@ -135,11 +135,11 @@
   }
 
   .saveButton {
-    background-color: $blue-600;
+    background-color: $color-link-default;
     color: white;
 
     &:hover:not(:disabled) {
-      background-color: $blue-700;
+      background-color: $color-text-secondary;
     }
   }
 
@@ -154,12 +154,12 @@
   }
 
   .aiButton {
-    background-color: $blue-50;
-    color: $blue-600;
-    border: $border-width-thin solid $blue-200;
+    background-color: $color-surface-tertiary;
+    color: $color-link-default;
+    border: $border-width-thin solid $color-border-default;
 
     &:hover:not(:disabled) {
-      background-color: $blue-100;
+      background-color: $color-surface-hover;
     }
   }
 }
@@ -197,8 +197,8 @@
 .tipBox {
   padding: $spacing-4;
   border-radius: $border-radius-md;
-  border: $border-width-thin solid $blue-200;
-  background-color: $blue-50;
+  border: $border-width-thin solid $color-border-default;
+  background-color: $color-surface-tertiary;
   margin-bottom: $spacing-4;
 
   .tipHeader {
@@ -207,7 +207,7 @@
     .tipTitle {
       @include text-secondary;
       font-weight: $font-weight-semibold;
-      color: $blue-900;
+      color: $color-text-heading;
       margin-bottom: $spacing-1;
     }
 
@@ -221,7 +221,7 @@
       transition: color 0.2s ease;
 
       &:hover {
-        color: $blue-600;
+        color: $color-link-default;
       }
 
       svg {
@@ -233,12 +233,12 @@
 
   .tipContent {
     @include text-secondary;
-    color: $blue-800;
+    color: $color-text-primary;
   }
 
   .tipExamples {
     @include text-tertiary;
-    color: $blue-700;
+    color: $color-text-secondary;
   }
 }
 
@@ -328,7 +328,7 @@
   .checkbox {
     width: 16px;
     height: 16px;
-    accent-color: $blue-600;
+    accent-color: $color-link-default;
   }
 
   .checkboxText {
@@ -436,7 +436,7 @@
   margin-bottom: $spacing-4;
   padding: $spacing-3;
   border-radius: $border-radius-md;
-  background-color: $blue-50;
+  background-color: $color-surface-tertiary;
   font-size: $font-size-sm;
   color: $color-text-secondary;
 
@@ -464,11 +464,11 @@
     border: none;
 
     &.primary {
-      background-color: $blue-600;
+      background-color: $color-link-default;
       color: $white;
 
       &:hover {
-        background-color: $blue-700;
+        background-color: $color-text-secondary;
       }
     }
 

--- a/frontend/src/app/knowledge-base/notes/page.module.scss
+++ b/frontend/src/app/knowledge-base/notes/page.module.scss
@@ -164,7 +164,7 @@
     }
 
     &:hover {
-      border-color: $blue-300;
+      border-color: $color-border-hover;
     }
   }
 }
@@ -199,13 +199,13 @@
 
     &:hover:not(.typeButtonActive) {
       background-color: $neutral-50;
-      border-color: $blue-300;
+      border-color: $color-border-hover;
     }
 
     &.typeButtonActive {
-      background-color: $blue-50;
-      border-color: $blue-500;
-      color: $blue-700;
+      background-color: $color-surface-tertiary;
+      border-color: $color-input-border-focus;
+      color: $color-text-secondary;
     }
   }
 }
@@ -213,8 +213,8 @@
 // Tag Filter Section
 .tagFilterSection {
   padding: $spacing-4;
-  background-color: $blue-50;
-  border: $border-width-thin solid $blue-200;
+  background-color: $color-surface-tertiary;
+  border: $border-width-thin solid $color-border-default;
   border-radius: $border-radius-md;
 
   .tagFilterHeader {
@@ -223,7 +223,7 @@
     .tagFilterLabel {
       @include text-secondary;
       font-weight: $font-weight-medium;
-      color: $blue-900;
+      color: $color-text-heading;
     }
   }
 
@@ -237,28 +237,28 @@
       align-items: center;
       padding: $spacing-2 $spacing-3;
       background-color: $white;
-      border: $border-width-thin solid $blue-200;
+      border: $border-width-thin solid $color-border-default;
       border-radius: $border-radius-full;
       @include text-secondary;
       font-weight: $font-weight-medium;
-      color: $blue-700;
+      color: $color-text-secondary;
       cursor: pointer;
       transition: all 0.2s ease;
 
       &:hover {
-        background-color: $blue-100;
-        border-color: $blue-300;
-        color: $blue-800;
+        background-color: $color-surface-hover;
+        border-color: $color-border-hover;
+        color: $color-text-primary;
       }
 
       &.tagBadgeActive {
-        background-color: $blue-500;
-        border-color: $blue-600;
+        background-color: $color-interactive-primary;
+        border-color: $color-link-default;
         color: $white;
 
         &:hover {
-          background-color: $blue-600;
-          border-color: $blue-700;
+          background-color: $color-link-default;
+          border-color: $color-text-secondary;
         }
       }
 
@@ -283,13 +283,13 @@
   .showMoreButton {
     margin-top: $spacing-3;
     @include text-secondary;
-    color: $blue-600;
+    color: $color-link-default;
     cursor: pointer;
     font-weight: $font-weight-medium;
     transition: all 0.2s ease;
 
     &:hover {
-      color: $blue-800;
+      color: $color-text-primary;
       text-decoration: underline;
     }
   }
@@ -300,18 +300,18 @@
   width: 100%;
   padding: $spacing-3 $spacing-4;
   background-color: $white;
-  border: $border-width-thin solid $blue-300;
+  border: $border-width-thin solid $orange-300;
   border-radius: $border-radius-button;
   @include text-secondary;
-  color: $blue-600;
+  color: $color-link-default;
   font-weight: $font-weight-medium;
   cursor: pointer;
   transition: all 0.2s ease;
 
   &:hover {
-    background-color: $blue-50;
-    border-color: $blue-400;
-    color: $blue-700;
+    background-color: $color-surface-tertiary;
+    border-color: $orange-400;
+    color: $color-text-secondary;
   }
 }
 
@@ -327,7 +327,7 @@
   .noteCountSection {
     .activeFilters {
       @include text-secondary;
-      color: $blue-700;
+      color: $color-text-secondary;
       font-weight: $font-weight-medium;
       margin-bottom: $spacing-1;
     }
@@ -423,9 +423,9 @@
       .graphButton {
         padding: $spacing-2 $spacing-4;
         border-radius: $border-radius-button;
-        border: $border-width-thin solid $dusty-blue-600;
-        background-color: $white;
-        color: $dusty-blue-600;
+        border: $border-width-thin solid $orange-300;
+        background-color: transparent;
+        color: $color-link-default;
         font-family: $font-family-primary;
         font-weight: $font-weight-medium;
         text-decoration: none;
@@ -440,16 +440,16 @@
         }
 
         &:hover {
-          background-color: $dusty-blue-50;
+          background-color: $color-interactive-primary-bg-subtle;
         }
       }
 
       .randomButton {
         padding: $spacing-2 $spacing-4;
         border-radius: $border-radius-button;
-        border: $border-width-thin solid $blue-600;
-        background-color: $white;
-        color: $blue-600;
+        border: $border-width-thin solid $orange-300;
+        background-color: transparent;
+        color: $color-link-default;
         font-family: $font-family-primary;
         font-weight: $font-weight-medium;
         cursor: pointer;
@@ -462,7 +462,7 @@
         }
 
         &:hover:not(:disabled) {
-          background-color: $blue-50;
+          background-color: $color-surface-tertiary;
         }
 
         &:disabled {
@@ -474,8 +474,8 @@
       .newNoteButton {
         padding: $spacing-2 $spacing-4;
         border-radius: $border-radius-button;
-        background-color: $blue-600;
-        color: white;
+        background-color: $color-interactive-primary;
+        color: $color-interactive-primary-text;
         font-weight: $font-weight-medium;
         text-decoration: none;
         transition: all 0.2s ease;
@@ -488,7 +488,7 @@
         }
 
         &:hover {
-          background-color: $blue-700;
+          background-color: $color-interactive-primary-hover;
         }
       }
     }
@@ -500,8 +500,8 @@
   margin-bottom: $spacing-6;
   @include flex-between;
   padding: $spacing-4;
-  background-color: $purple-50;
-  border: $border-width-thin solid $purple-200;
+  background-color: $color-surface-tertiary;
+  border: $border-width-thin solid $color-border-default;
   border-radius: $border-radius-md;
 
   .filterInfo {
@@ -511,30 +511,30 @@
     .filterLabel {
       @include text-secondary;
       font-weight: $font-weight-medium;
-      color: $purple-900;
+      color: $color-text-heading;
     }
 
     .tagPill {
       display: inline-flex;
       align-items: center;
       padding: $spacing-1 $spacing-3;
-      background-color: $purple-100;
+      background-color: $color-surface-hover;
       border-radius: $border-radius-full;
       @include text-secondary;
       font-weight: $font-weight-medium;
-      color: $purple-800;
+      color: $color-text-primary;
     }
   }
 
   .clearButton {
     @include text-secondary;
-    color: $purple-600;
+    color: $color-link-default;
     cursor: pointer;
     text-decoration: none;
     transition: all 0.2s ease;
 
     &:hover {
-      color: $purple-800;
+      color: $color-text-primary;
       text-decoration: underline;
     }
   }
@@ -576,7 +576,7 @@
     margin-top: $spacing-6;
     padding: $spacing-2 $spacing-4;
     border-radius: $border-radius-button;
-    background-color: $blue-600;
+    background-color: $color-link-default;
     color: white;
     @include text-secondary;
     font-weight: $font-weight-medium;
@@ -585,7 +585,7 @@
     transition: all 0.2s ease;
 
     &:hover {
-      background-color: $blue-700;
+      background-color: $color-text-secondary;
       box-shadow: $shadow-button-hover;
     }
   }
@@ -755,13 +755,13 @@
   }
 
   &.active {
-    background-color: $blue-500;
-    border-color: $blue-500;
+    background-color: $color-interactive-primary;
+    border-color: $color-input-border-focus;
     color: white;
 
     &:hover {
-      background-color: $blue-600;
-      border-color: $blue-600;
+      background-color: $color-link-default;
+      border-color: $color-link-default;
     }
   }
 }

--- a/frontend/src/app/knowledge-base/toolbox/page.module.scss
+++ b/frontend/src/app/knowledge-base/toolbox/page.module.scss
@@ -74,11 +74,11 @@
     }
 
     .backLink {
-      color: $blue-600;
+      color: $color-link-default;
       text-decoration: none;
 
       &:hover {
-        color: $blue-700;
+        color: $color-text-secondary;
         text-decoration: underline;
       }
     }
@@ -89,11 +89,11 @@
 .header {
   background: linear-gradient(
     to bottom,
-    $amber-100 0%,
-    $amber-50 50%,
-    rgba($amber-50, 0.5) 100%
+    var(--color-header-bg-start) 0%,
+    var(--color-header-bg-mid) 50%,
+    var(--color-header-bg-end) 100%
   );
-  border-bottom: 1px solid $amber-200;
+  border-bottom: 1px solid var(--color-header-border);
   box-shadow: $shadow-card-sm;
 
   .headerContent {
@@ -119,7 +119,7 @@
       .title {
         @include heading-h1;
         margin: 0;
-        color: $amber-900;
+        color: $color-text-heading;
 
         @media (max-width: 640px) {
           font-size: $font-size-2xl;
@@ -128,7 +128,7 @@
 
       .subtitle {
         margin-top: $spacing-2;
-        color: $amber-700;
+        color: $color-text-secondary;
         font-size: $font-size-lg;
 
         @media (max-width: 640px) {
@@ -151,7 +151,7 @@
       .newReferenceButton {
         padding: $spacing-2 $spacing-4;
         border-radius: $border-radius-button;
-        background-color: $amber-600;
+        background-color: $color-link-default;
         color: white;
         font-weight: $font-weight-medium;
         text-decoration: none;
@@ -165,7 +165,7 @@
         }
 
         &:hover {
-          background-color: $amber-700;
+          background-color: $color-text-secondary;
         }
       }
     }
@@ -222,8 +222,8 @@
 
     &:focus {
       outline: none;
-      border-color: $amber-500;
-      box-shadow: 0 0 0 2px rgba($amber-500, 0.2);
+      border-color: $color-input-border-focus;
+      box-shadow: $shadow-focus-primary;
     }
 
     &::placeholder {
@@ -235,8 +235,8 @@
 // Category Filter Section
 .categoryFilterSection {
   padding: $spacing-4;
-  background-color: $amber-50;
-  border: $border-width-thin solid $amber-200;
+  background-color: $color-surface-tertiary;
+  border: $border-width-thin solid $color-border-default;
   border-radius: $border-radius-md;
 
   .categoryFilterHeader {
@@ -245,7 +245,7 @@
     .categoryFilterLabel {
       @include text-secondary;
       font-weight: $font-weight-medium;
-      color: $amber-900;
+      color: $color-text-heading;
     }
   }
 
@@ -259,28 +259,28 @@
       align-items: center;
       padding: $spacing-2 $spacing-3;
       background-color: $white;
-      border: $border-width-thin solid $amber-200;
+      border: $border-width-thin solid $color-border-default;
       border-radius: $border-radius-full;
       @include text-secondary;
       font-weight: $font-weight-medium;
-      color: $amber-700;
+      color: $color-text-secondary;
       cursor: pointer;
       transition: all 0.2s ease;
 
       &:hover {
-        background-color: $amber-100;
-        border-color: $amber-300;
-        color: $amber-800;
+        background-color: $color-surface-hover;
+        border-color: $color-border-hover;
+        color: $color-text-primary;
       }
 
       &.categoryBadgeActive {
-        background-color: $amber-500;
-        border-color: $amber-600;
-        color: $white;
+        background-color: $orange-700;
+        border-color: $orange-800;
+        color: #fff;
 
         &:hover {
-          background-color: $amber-600;
-          border-color: $amber-700;
+          background-color: $orange-800;
+          border-color: $orange-900;
         }
       }
     }
@@ -292,18 +292,18 @@
   width: 100%;
   padding: $spacing-3 $spacing-4;
   background-color: $white;
-  border: $border-width-thin solid $amber-300;
+  border: $border-width-thin solid $orange-300;
   border-radius: $border-radius-button;
   @include text-secondary;
-  color: $amber-600;
+  color: $color-link-default;
   font-weight: $font-weight-medium;
   cursor: pointer;
   transition: all 0.2s ease;
 
   &:hover {
-    background-color: $amber-50;
-    border-color: $amber-400;
-    color: $amber-700;
+    background-color: $color-surface-tertiary;
+    border-color: $orange-400;
+    color: $color-text-secondary;
   }
 }
 
@@ -319,7 +319,7 @@
   .referenceCountSection {
     .activeFilters {
       @include text-secondary;
-      color: $amber-700;
+      color: $color-text-secondary;
       font-weight: $font-weight-medium;
       margin-bottom: $spacing-1;
     }
@@ -337,8 +337,8 @@
   padding: $spacing-12;
   text-align: center;
   @include card;
-  border: $border-width-medium dashed $amber-300;
-  background-color: $amber-50;
+  border: $border-width-medium dashed $color-border-strong;
+  background-color: $color-surface-tertiary;
 
   .emptyIcon {
     font-size: 3rem;
@@ -348,18 +348,18 @@
   .emptyTitle {
     @include heading-h3;
     margin-bottom: $spacing-2;
-    color: $amber-900;
+    color: $color-text-heading;
   }
 
   .emptyMessage {
     @include text-secondary;
-    color: $amber-700;
+    color: $color-text-secondary;
     margin-bottom: $spacing-2;
   }
 
   .emptyHint {
     @include text-tertiary;
-    color: $amber-600;
+    color: $color-link-default;
     margin-bottom: $spacing-6;
   }
 
@@ -368,7 +368,7 @@
     align-items: center;
     padding: $spacing-3 $spacing-6;
     border-radius: $border-radius-button;
-    background-color: $amber-600;
+    background-color: $color-link-default;
     color: white;
     font-weight: $font-weight-medium;
     text-decoration: none;
@@ -376,7 +376,7 @@
     transition: all 0.2s ease;
 
     &:hover {
-      background-color: $amber-700;
+      background-color: $color-text-secondary;
       box-shadow: $shadow-button-hover;
     }
   }
@@ -398,14 +398,14 @@
     border: $border-default;
     border-radius: $border-radius-button;
     background-color: $white;
-    color: $amber-600;
+    color: $color-link-default;
     font-weight: $font-weight-medium;
     cursor: pointer;
     transition: all 0.2s ease;
 
     &:hover {
-      background-color: $amber-50;
-      border-color: $amber-300;
+      background-color: $color-surface-tertiary;
+      border-color: $color-border-hover;
     }
   }
 }
@@ -417,13 +417,15 @@
   .categoryTitle {
     @include heading-h3;
     margin-bottom: $spacing-4;
-    color: $amber-800;
-    border-bottom: 2px solid $amber-200;
+    color: $color-text-primary;
+    border-bottom: 2px solid $color-border-default;
     padding-bottom: $spacing-2;
 
     .categoryCount {
       font-weight: $font-weight-normal;
-      color: $amber-500;
+      font-family: $font-family-mono;
+      font-size: 0.8em;
+      color: $color-link-default;
     }
   }
 }
@@ -442,7 +444,7 @@
   transition: all 0.2s ease;
 
   &:hover {
-    border-color: $amber-300;
+    border-color: $color-border-hover;
     box-shadow: $shadow-card-lg;
     transform: translateY(-1px);
   }
@@ -468,22 +470,25 @@
       .cardId {
         display: inline-block;
         padding: 2px 6px;
-        background-color: rgba($amber-500, 0.1);
+        background-color: $color-interactive-primary-bg-subtle;
         border-radius: $border-radius-sm;
         font-family: $font-family-mono;
         font-size: $font-size-xs;
-        color: $amber-700;
+        color: $color-text-secondary;
       }
 
       .referenceBadge {
         display: inline-block;
         padding: 2px 8px;
-        background-color: $amber-200;
-        border: 1px solid $amber-300;
-        border-radius: $border-radius-full;
+        background-color: transparent;
+        border: 1px dashed $color-border-strong;
+        border-radius: $border-radius-sm;
         font-size: $font-size-xs;
         font-weight: $font-weight-medium;
-        color: $amber-700;
+        font-family: $font-family-mono;
+        letter-spacing: $letter-spacing-wide;
+        text-transform: uppercase;
+        color: $color-text-secondary;
       }
 
       .cardTitle {
@@ -524,7 +529,7 @@
       flex-shrink: 0;
       width: 1.5rem;
       height: 1.5rem;
-      color: $amber-500;
+      color: $color-link-default;
       margin-top: $spacing-1;
       transition: transform 0.2s ease;
     }

--- a/frontend/src/app/login/page.module.scss
+++ b/frontend/src/app/login/page.module.scss
@@ -178,7 +178,7 @@
 .submitButton {
   width: 100%;
   padding: $spacing-2 $spacing-4;
-  background-color: $blue-600;
+  background-color: $color-link-default;
   color: $white;
   border: none;
   border-radius: $border-radius-button;
@@ -189,7 +189,7 @@
   transition: all 0.2s ease;
 
   &:hover:not(:disabled) {
-    background-color: $blue-700;
+    background-color: $color-text-secondary;
   }
 
   &:focus {


### PR DESCRIPTION
Follow-up to #199 (this commit was pushed to the old branch after the merge, so it missed the train).

## Graph (see also the open bug filed separately — navigation still needs verification)
- Double-click a node opens the note; instructions updated
- Selection/hover accents: purple/blue → orange
- Tag colors drawn from the design-system scales, map extended to the real tag set, desaturated hash fallback
- Node labels theme-aware; sidebar tag rows/filter toggle no longer hardcoded white (were unreadable in dark mode)
- Selected-node panel: orange left rule, orange primary "View note", mono note ID + connection count

## Consistency sweep (notes, toolbox, inspire, note detail/new, login)
- Toolbox de-ambered: shared KB header, orange primary CTA, dashed mono REFERENCE badges, mono category counts
- Inspire teal header → shared KB header treatment
- Accent-tinted filter panels/chips → semantic surface/border tokens (fixes light panels stranded on dark backgrounds)
- Notes header: one orange primary (+ New Note), ghost View Graph / Random Note

## Documentation
- **docs/DESIGN.md**: authoritative design-system guide — token architecture (Tier 1 hex vs theme-aware Tier 2 CSS variables), the `$white` surface caveat, flipping neutral ramp, color roles, mono conventions, dark-mode mechanics, a11y baseline, new-UI checklist
- DESIGN_TOKENS.md / COLOR_PALETTE.md stale blue/purple references corrected with pointers
- Indexed in docs/README.md and CLAUDE.md

## Verification
- 55/55 frontend tests, ESLint, tsc, prettier clean (ran before the original push of the code commit)
- Screenshots in light + dark: graph, toolbox, notes