### PR TITLE
Design: finish consistency sweep, graph deselect fixes, Graph nav link (fixes #202, #203)

### DIFF
--- a/frontend/src/app/admin/page.module.scss
+++ b/frontend/src/app/admin/page.module.scss
@@ -3,12 +3,16 @@
  * Minimal layout matching the login page's header/card pattern
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 .container {
   min-height: 100vh;
-  background: linear-gradient(to bottom right, $color-page-bg-gradient-start, $color-page-bg-gradient-end);
+  background: linear-gradient(
+    to bottom right,
+    $color-page-bg-gradient-start,
+    $color-page-bg-gradient-end
+  );
 }
 
 .header {
@@ -156,7 +160,7 @@
 }
 
 .toggleOn {
-  background-color: $blue-600;
+  background-color: $color-interactive-primary;
 
   .toggleKnob {
     transform: translateX(1.25rem);

--- a/frontend/src/app/knowledge-base/articles/[id]/page.module.scss
+++ b/frontend/src/app/knowledge-base/articles/[id]/page.module.scss
@@ -88,17 +88,14 @@
 
 // ===== HEADER =====
 .header {
-  // Cool slate blue header zone (contrasts with warm content)
-  // Slightly bluer at top, more transparent at bottom for badge visibility
+  // Shared KB header gradient (theme-aware, see docs/DESIGN.md)
   background: linear-gradient(
     to bottom,
-    $slate-blue-200 0%,
-    // Bluer, more saturated top
-    $slate-blue-100 50%,
-    // Transition to lighter
-    rgba($slate-blue-50, 0.7) 100% // More transparent bottom
+    var(--color-header-bg-start) 0%,
+    var(--color-header-bg-mid) 50%,
+    var(--color-header-bg-end) 100%
   );
-  border-bottom: 1px solid $slate-blue-300; // Refined 1px border
+  border-bottom: 1px solid var(--color-header-border);
   box-shadow: $shadow-card-sm;
   padding-top: $spacing-3;
   padding-bottom: $spacing-3;
@@ -199,8 +196,8 @@
       align-items: center;
       gap: $spacing-2;
       padding: $spacing-2 $spacing-4;
-      background-color: $green-500;
-      color: white;
+      background-color: $color-interactive-primary;
+      color: $color-interactive-primary-text;
       border-radius: $border-radius-md;
       font-size: $font-size-sm;
       font-weight: $font-weight-medium;
@@ -208,7 +205,7 @@
       transition: background-color 0.15s ease;
 
       &:hover {
-        background-color: $green-700;
+        background-color: $color-interactive-primary-hover;
       }
     }
   }
@@ -343,8 +340,8 @@
     transition: all 0.15s ease;
 
     &:hover {
-      border-color: $color-primary;
-      background-color: $blue-50;
+      border-color: $color-interactive-primary;
+      background-color: $color-interactive-ghost-hover;
     }
 
     .noteTitle {
@@ -489,8 +486,8 @@
     display: inline-block;
     padding: 0 $spacing-1;
     border-radius: $border-radius-sm;
-    background-color: $blue-50;
-    color: $blue-600;
+    background-color: $color-interactive-primary-bg-subtle;
+    color: $color-link-hover;
     text-decoration: none;
     font-family: $font-family-mono;
     font-size: 0.9em;

--- a/frontend/src/app/knowledge-base/articles/[id]/page.tsx
+++ b/frontend/src/app/knowledge-base/articles/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { CalendarBlank, PencilSimple, NotePencil } from "@phosphor-icons/react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import MarkdownWithWikilinks from "@/components/MarkdownWithWikilinks";
@@ -162,7 +163,7 @@ export default function ArticleDetailPage() {
           {/* Metadata */}
           <div className={styles.metadata}>
             <div className={styles.metaItem}>
-              <span aria-hidden="true">📅</span>
+              <CalendarBlank size={14} aria-hidden="true" />
               <span>
                 Published{" "}
                 <time dateTime={article.published_date || article.created_at}>
@@ -179,7 +180,7 @@ export default function ArticleDetailPage() {
             </div>
             {article.updated_date && article.updated_date !== article.published_date && (
               <div className={styles.metaItem}>
-                <span aria-hidden="true">✏️</span>
+                <PencilSimple size={14} aria-hidden="true" />
                 <span>
                   Last updated{" "}
                   <time dateTime={article.updated_date}>
@@ -212,7 +213,7 @@ export default function ArticleDetailPage() {
               href={`/knowledge-base/notes/new?from_article=${article.id}&title=Notes on: ${encodeURIComponent(article.title)}&content=${encodeURIComponent(`See [[article:${article.id}]] for the full article.\n\n## Key Takeaways\n\n- `)}`}
               className={styles.createNoteButton}
             >
-              📝 Create Note from Article
+              <NotePencil size={16} aria-hidden="true" /> Create Note from Article
             </Link>
           </div>
         </div>
@@ -270,7 +271,7 @@ export default function ArticleDetailPage() {
             {/* Related Notes Section */}
             {(relatedNotes.length > 0 || loadingRelated) && (
               <div className={styles.relatedNotes}>
-                <h3 className={styles.relatedNotesTitle}>📝 Related Notes</h3>
+                <h3 className={styles.relatedNotesTitle}>Related Notes</h3>
                 {loadingRelated ? (
                   <div className={styles.loadingNotes}>Finding related notes...</div>
                 ) : (

--- a/frontend/src/app/knowledge-base/articles/page.module.scss
+++ b/frontend/src/app/knowledge-base/articles/page.module.scss
@@ -3,12 +3,16 @@
  * Matches production Tailwind design with blue theme
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 .container {
   min-height: 100vh;
-  background: linear-gradient(to bottom right, $color-page-bg-gradient-start, $color-page-bg-gradient-end);
+  background: linear-gradient(
+    to bottom right,
+    $color-page-bg-gradient-start,
+    $color-page-bg-gradient-end
+  );
 }
 
 // ===== HEADER =====

--- a/frontend/src/app/knowledge-base/inspire/page.module.scss
+++ b/frontend/src/app/knowledge-base/inspire/page.module.scss
@@ -3,12 +3,16 @@
  * Content suggestions for knowledge base improvement
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 .container {
   min-height: 100vh;
-  background: linear-gradient(to bottom right, $color-page-bg-gradient-start, $color-page-bg-gradient-end);
+  background: linear-gradient(
+    to bottom right,
+    $color-page-bg-gradient-start,
+    $color-page-bg-gradient-end
+  );
 }
 
 // ===== LOADING STATE =====
@@ -42,7 +46,8 @@
 }
 
 @keyframes pulse {
-  0%, 100% {
+  0%,
+  100% {
     opacity: 1;
   }
   50% {
@@ -119,7 +124,7 @@
       .title {
         @include heading-h1;
         margin: 0;
-        color: $teal-900;
+        color: $color-text-heading;
 
         @media (max-width: 640px) {
           font-size: $font-size-2xl;
@@ -128,7 +133,7 @@
 
       .subtitle {
         margin-top: $spacing-2;
-        color: $teal-700;
+        color: $color-text-secondary;
         font-size: $font-size-lg;
 
         @media (max-width: 640px) {
@@ -150,8 +155,8 @@
         padding: $spacing-2 $spacing-4;
         border: none;
         border-radius: $border-radius-button;
-        background-color: $teal-600;
-        color: white;
+        background-color: $color-interactive-primary;
+        color: $color-interactive-primary-text;
         font-weight: $font-weight-medium;
         cursor: pointer;
         transition: all 0.2s ease;
@@ -163,7 +168,7 @@
         }
 
         &:hover:not(:disabled) {
-          background-color: $teal-700;
+          background-color: $color-interactive-primary-hover;
         }
 
         &:disabled {
@@ -192,15 +197,11 @@
     align-items: center;
     gap: $spacing-2;
     padding: $spacing-2 $spacing-4;
-    background-color: $teal-100;
-    border: 1px solid $teal-200;
+    background-color: $color-info-cool-bg;
+    border: 1px solid $color-info-cool-border;
     border-radius: $border-radius-full;
     font-size: $font-size-sm;
-    color: $teal-700;
-
-    &::before {
-      content: "✨";
-    }
+    color: $color-info-cool-text;
   }
 
   .aiDisabled {
@@ -220,17 +221,17 @@
     align-items: center;
     gap: $spacing-2;
     padding: $spacing-2 $spacing-4;
-    background-color: $teal-50;
-    border: 1px solid $teal-200;
+    background-color: $color-info-cool-bg;
+    border: 1px solid $color-info-cool-border;
     border-radius: $border-radius-full;
     font-size: $font-size-sm;
-    color: $teal-700;
+    color: $color-info-cool-text;
 
     .spinner {
       width: 14px;
       height: 14px;
-      border: 2px solid $teal-200;
-      border-top-color: $teal-600;
+      border: 2px solid $color-info-cool-border;
+      border-top-color: $color-info-cool-text;
       border-radius: 50%;
       animation: spin 0.8s linear infinite;
     }
@@ -248,8 +249,8 @@
   padding: $spacing-12;
   text-align: center;
   @include card;
-  border: $border-width-medium dashed $teal-300;
-  background-color: $teal-50;
+  border: $border-width-medium dashed $color-border-strong;
+  background-color: $color-surface-tertiary;
 
   .emptyIcon {
     font-size: 3rem;
@@ -259,12 +260,12 @@
   .emptyTitle {
     @include heading-h3;
     margin-bottom: $spacing-2;
-    color: $teal-900;
+    color: $color-text-heading;
   }
 
   .emptyMessage {
     @include text-secondary;
-    color: $teal-700;
+    color: $color-text-secondary;
     margin-bottom: $spacing-6;
     max-width: 400px;
     margin-left: auto;
@@ -276,15 +277,15 @@
     align-items: center;
     padding: $spacing-3 $spacing-6;
     border-radius: $border-radius-button;
-    background-color: $teal-600;
-    color: white;
+    background-color: $color-interactive-primary;
+    color: $color-interactive-primary-text;
     font-weight: $font-weight-medium;
     text-decoration: none;
     box-shadow: $shadow-button;
     transition: all 0.2s ease;
 
     &:hover {
-      background-color: $teal-700;
+      background-color: $color-interactive-primary-hover;
       box-shadow: $shadow-button-hover;
     }
   }
@@ -454,7 +455,9 @@
     gap: $spacing-3;
 
     .helpIcon {
-      font-size: $font-size-xl;
+      display: inline-flex;
+      align-items: center;
+      color: $color-text-secondary;
       flex-shrink: 0;
     }
 

--- a/frontend/src/app/knowledge-base/inspire/page.tsx
+++ b/frontend/src/app/knowledge-base/inspire/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { NotePencil, LinkSimple, Sparkle } from "@phosphor-icons/react";
 import Link from "next/link";
 import {
   getSuggestions,
@@ -181,7 +182,9 @@ export default function InspirePage() {
               AI is enhancing suggestions...
             </span>
           ) : hasLlm ? (
-            <span className={styles.aiEnabled}>AI-powered suggestions</span>
+            <span className={styles.aiEnabled}>
+              <Sparkle size={14} aria-hidden="true" /> AI-powered suggestions
+            </span>
           ) : loadingPhase === "complete" ? (
             <span className={styles.aiDisabled}>Basic suggestions (AI unavailable)</span>
           ) : (
@@ -210,7 +213,7 @@ export default function InspirePage() {
               <div key={index} className={`${styles.suggestionCard} ${styles[suggestion.type]}`}>
                 <div className={styles.cardHeader}>
                   <span className={styles.typeBadge}>
-                    {suggestion.type === "gap" ? "📝 Gap" : "🔗 Connection"}
+                    {suggestion.type === "gap" ? "Gap" : "Connection"}
                   </span>
                 </div>
 
@@ -260,14 +263,18 @@ export default function InspirePage() {
           <h4 className={styles.helpTitle}>How it works</h4>
           <div className={styles.helpGrid}>
             <div className={styles.helpItem}>
-              <span className={styles.helpIcon}>📝</span>
+              <span className={styles.helpIcon} aria-hidden="true">
+                <NotePencil size={20} />
+              </span>
               <div>
                 <strong>Gap suggestions</strong>
                 <p>Notes that are short or have few connections. Consider expanding them.</p>
               </div>
             </div>
             <div className={styles.helpItem}>
-              <span className={styles.helpIcon}>🔗</span>
+              <span className={styles.helpIcon} aria-hidden="true">
+                <LinkSimple size={20} />
+              </span>
               <div>
                 <strong>Connection suggestions</strong>
                 <p>Similar notes that aren&apos;t linked. Consider adding wikilinks.</p>

--- a/frontend/src/app/knowledge-base/notes/[id]/page.module.scss
+++ b/frontend/src/app/knowledge-base/notes/[id]/page.module.scss
@@ -4,12 +4,16 @@
  * Supports view and edit modes, AI features, links/backlinks
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 .container {
   min-height: 100vh;
-  background: linear-gradient(to bottom right, $color-page-bg-gradient-start, $color-page-bg-gradient-end);
+  background: linear-gradient(
+    to bottom right,
+    $color-page-bg-gradient-start,
+    $color-page-bg-gradient-end
+  );
 }
 
 // ===== LOADING & ERROR STATES =====
@@ -39,7 +43,8 @@
 }
 
 @keyframes pulse {
-  0%, 100% {
+  0%,
+  100% {
     opacity: 1;
   }
   50% {
@@ -103,7 +108,7 @@
     var(--color-header-bg-mid) 50%,
     var(--color-header-bg-end) 100%
   );
-  border-bottom: 1px solid var(--color-header-border);  // Refined 1px border
+  border-bottom: 1px solid var(--color-header-border); // Refined 1px border
   padding: $spacing-3xl $spacing-2xl $spacing-xl;
   margin-bottom: $spacing-2xl;
 
@@ -184,7 +189,7 @@
 
     .viewGraphButton {
       background-color: transparent;
-      color: $dusty-blue-600;               // Cool info action
+      color: $dusty-blue-600; // Cool info action
       border: 2px solid $dusty-blue-600;
       text-decoration: none;
       display: inline-block;
@@ -197,7 +202,7 @@
     }
 
     .editButton {
-      background-color: $orange-600;        // Warm primary action
+      background-color: $orange-600; // Warm primary action
       color: white;
 
       &:hover:not(:disabled) {
@@ -207,8 +212,8 @@
 
     .deleteButton {
       background-color: transparent;
-      color: $red-600;                      // Red destructive action
-      border: 2px solid $red-600;           // Stronger outlined style
+      color: $red-600; // Red destructive action
+      border: 2px solid $red-600; // Stronger outlined style
 
       &:hover:not(:disabled) {
         background-color: $red-50;
@@ -218,7 +223,7 @@
     }
 
     .aiSuggestionsButton {
-      background-color: $teal-600;          // Cool technical action
+      background-color: $teal-600; // Cool technical action
       color: white;
 
       &:hover:not(:disabled) {
@@ -242,17 +247,17 @@
   .zeroLinksWarning {
     margin-bottom: $spacing-4;
     padding: $spacing-3;
-    background-color: rgba(212, 167, 72, 0.1);
-    border: $border-width-thin solid rgba(212, 167, 72, 0.3);
+    background-color: $color-warning-bg;
+    border: $border-width-thin solid $color-warning-border;
     border-radius: $border-radius-md;
     @include text-secondary;
-    color: #9b6b28;
+    color: $color-warning-text;
   }
 
   .backLink {
     display: inline-flex;
     margin-top: $spacing-4;
-    color: $orange-600;                 // Warm orange link
+    color: $orange-600; // Warm orange link
     text-decoration: none;
     @include text-secondary;
 
@@ -276,7 +281,7 @@
     .sectionTitle {
       @include heading-h4;
       margin-bottom: $spacing-3;
-      color: $terracotta-600;             // Warm terracotta instead of purple
+      color: $terracotta-600; // Warm terracotta instead of purple
     }
 
     .linksList {
@@ -292,7 +297,7 @@
         transition: all 0.2s ease;
 
         &:hover {
-          background-color: $terracotta-50;  // Warm terracotta hover
+          background-color: $terracotta-50; // Warm terracotta hover
           color: $terracotta-600;
         }
 
@@ -325,7 +330,7 @@
   @include flex-between;
   margin-bottom: $spacing-4;
   padding: $spacing-3;
-  background-color: $orange-50;           // Warm background for primary action area
+  background-color: $orange-50; // Warm background for primary action area
   border-radius: $border-radius-md;
   border: $border-width-thin solid $orange-200;
 
@@ -335,7 +340,7 @@
 
     .saveButton {
       padding: $spacing-2 $spacing-4;
-      background-color: $orange-600;      // Warm primary action
+      background-color: $orange-600; // Warm primary action
       color: white;
       border: none;
       border-radius: $border-radius-button;
@@ -376,6 +381,14 @@
   .helpText {
     @include text-tertiary;
   }
+}
+
+// Content display card (view mode)
+.contentCard {
+  padding: $spacing-6;
+  border: $border-width-thin solid $color-border-default;
+  border-radius: $border-radius-lg;
+  background-color: $white;
 }
 
 // ===== FORM FIELDS (Edit Mode) =====
@@ -439,7 +452,7 @@
 .suggestLinksButton {
   padding: $spacing-6 $spacing-6;
   border-radius: $border-radius-button;
-  border: $border-width-thin solid $blue-600;
+  border: $border-width-thin solid $color-border-strong;
   background-color: $color-surface-tertiary;
   color: $color-text-secondary;
   font-weight: $font-weight-medium;

--- a/frontend/src/app/knowledge-base/notes/[id]/page.tsx
+++ b/frontend/src/app/knowledge-base/notes/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { Sparkle } from "@phosphor-icons/react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import NoteEditor from "@/components/NoteEditor";
@@ -398,7 +399,7 @@ export default function NoteDetailPage() {
               {/* Metadata */}
               <div className={styles.meta}>
                 <span>
-                  📝 Created{" "}
+                  Created{" "}
                   <time dateTime={String(note.created_at)}>{formatNoteDate(note.created_at)}</time>
                 </span>
                 <span>by {note.author}</span>
@@ -477,27 +478,23 @@ export default function NoteDetailPage() {
                   className={`space-y-4 ${aiSuggestionsOpen ? "lg:col-span-2" : "lg:col-span-1"}`}
                 >
                   <div>
-                    <label className="mb-1 block text-sm font-medium text-gray-700">
-                      Title (optional)
-                    </label>
+                    <label className={styles.formLabel}>Title (optional)</label>
                     <input
                       type="text"
                       value={editTitle}
                       onChange={(e) => setEditTitle(e.target.value)}
-                      className="w-full rounded-lg border border-gray-300 px-3 py-2"
+                      className={styles.formInput}
                     />
                   </div>
 
                   <div>
-                    <label className="mb-1 block text-sm font-medium text-gray-700">
-                      Tags (optional)
-                    </label>
+                    <label className={styles.formLabel}>Tags (optional)</label>
                     <input
                       type="text"
                       value={editTags}
                       onChange={(e) => setEditTags(e.target.value)}
                       placeholder="Comma-separated tags"
-                      className="w-full rounded-lg border border-gray-300 px-3 py-2"
+                      className={styles.formInput}
                     />
                   </div>
 
@@ -517,9 +514,7 @@ export default function NoteDetailPage() {
                   </div>
 
                   <div>
-                    <label className="mb-1 block text-sm font-medium text-gray-700">
-                      Content *
-                    </label>
+                    <label className={styles.formLabel}>Content *</label>
                     <NoteEditor
                       content={editContent}
                       onChange={setEditContent}
@@ -547,7 +542,7 @@ export default function NoteDetailPage() {
                       {settings.aiMode !== "off" && aiAvailable && (
                         <button
                           onClick={() => setAiSuggestionsOpen(!aiSuggestionsOpen)}
-                          className="rounded-lg border border-blue-600 bg-blue-50 px-6 py-2 text-blue-700 hover:bg-blue-100"
+                          className={styles.suggestLinksButton}
                           aria-label={
                             aiSuggestionsOpen
                               ? "Hide AI suggestions panel"
@@ -555,7 +550,13 @@ export default function NoteDetailPage() {
                           }
                           aria-expanded={aiSuggestionsOpen}
                         >
-                          {aiSuggestionsOpen ? "Hide AI Suggestions" : "✨ Get AI Suggestions"}
+                          {aiSuggestionsOpen ? (
+                            "Hide AI Suggestions"
+                          ) : (
+                            <>
+                              <Sparkle size={16} aria-hidden="true" /> Get AI Suggestions
+                            </>
+                          )}
                         </button>
                       )}
                     </div>
@@ -580,7 +581,7 @@ export default function NoteDetailPage() {
             ) : (
               <div>
                 {/* Content display with markdown and wikilinks */}
-                <div className="rounded-lg border border-gray-200 bg-white p-6">
+                <div className={styles.contentCard}>
                   <MarkdownWithWikilinks content={note.content} />
                 </div>
               </div>
@@ -641,30 +642,30 @@ export default function NoteDetailPage() {
 
       {/* Zero Links Warning Modal */}
       {showZeroLinksWarning && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
-          <div className="max-w-md rounded-lg bg-white p-6 shadow-xl">
-            <h3 className="mb-3 text-lg font-semibold text-gray-900">💡 No connections found</h3>
-            <p className="mb-4 text-gray-700">
+        <div className={styles.modalOverlay}>
+          <div className={styles.modalContent}>
+            <h3 className={styles.modalTitle}>No connections found</h3>
+            <p className={styles.modalText}>
               This note has no connections to other notes. Zettelkasten works best when ideas link
               together.
             </p>
-            <p className="mb-4 text-sm text-gray-600">Consider:</p>
-            <ul className="mb-6 list-inside list-disc space-y-1 text-sm text-gray-600">
+            <p className={styles.modalSubtext}>Consider:</p>
+            <ul className={styles.modalList}>
               <li>What concepts does this relate to?</li>
               <li>What led to this idea?</li>
               <li>Where might you apply this?</li>
             </ul>
-            <div className="flex gap-3">
+            <div className={styles.modalActions}>
               <button
                 onClick={handleGetAISuggestions}
-                className="flex-1 rounded-lg bg-blue-600 px-4 py-2 text-white transition hover:bg-blue-700"
+                className={`${styles.modalButton} ${styles.primary}`}
               >
                 Get AI Link Suggestions
               </button>
               <button
                 onClick={handleSaveAnyway}
                 disabled={saving}
-                className="flex-1 rounded-lg border border-gray-300 px-4 py-2 text-gray-700 transition hover:bg-gray-50 disabled:opacity-50"
+                className={`${styles.modalButton} ${styles.secondary}`}
               >
                 Save Anyway
               </button>

--- a/frontend/src/app/knowledge-base/notes/graph/page.module.scss
+++ b/frontend/src/app/knowledge-base/notes/graph/page.module.scss
@@ -3,13 +3,17 @@
  * Matches production Tailwind design with blue/purple theme
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 .container {
   height: calc(100vh - 80px); // Account for top navigation bar
   overflow: hidden;
-  background: linear-gradient(to bottom right, $color-page-bg-gradient-start, $color-page-bg-gradient-end);
+  background: linear-gradient(
+    to bottom right,
+    $color-page-bg-gradient-start,
+    $color-page-bg-gradient-end
+  );
   display: flex;
   flex-direction: column;
 }
@@ -74,7 +78,8 @@
 }
 
 @keyframes pulse {
-  0%, 100% {
+  0%,
+  100% {
     opacity: 1;
   }
   50% {
@@ -325,7 +330,7 @@
 
     &:hover {
       border-color: $color-border-hover;
-      background-color: $gray-50;
+      background-color: $color-surface-hover;
     }
 
     &Active {
@@ -368,7 +373,7 @@
     flex: 1;
 
     &:hover {
-      background-color: $gray-50;
+      background-color: $color-surface-hover;
     }
   }
 }

--- a/frontend/src/app/knowledge-base/notes/graph/page.tsx
+++ b/frontend/src/app/knowledge-base/notes/graph/page.tsx
@@ -78,6 +78,13 @@ function NotesGraphContent() {
     selectedNodeIdRef.current = selectedNode?.id || null;
   }, [selectedNode]);
 
+  // Drop a stale ?node= param so it can't re-select the old node
+  const clearNodeParam = useCallback(() => {
+    if (window.location.search.includes("node=")) {
+      router.replace("/knowledge-base/notes/graph", { scroll: false });
+    }
+  }, [router]);
+
   useEffect(() => {
     async function fetchGraphData() {
       try {
@@ -501,7 +508,11 @@ function NotesGraphContent() {
     function handleNodeClick(event: MouseEvent, clickedNode: GraphNode) {
       // d3.drag preventDefaults the click that follows a real drag gesture
       if (event.defaultPrevented) return;
+      // Keep the svg background handler from treating this as a deselect
+      event.stopPropagation();
       setSelectedNode(clickedNode);
+      // A stale ?node= param would otherwise re-select the old node
+      clearNodeParam();
     }
 
     function handleNodeDoubleClick(event: MouseEvent, clickedNode: GraphNode) {
@@ -590,18 +601,18 @@ function NotesGraphContent() {
         .attr("text-anchor", (d) => ((d.x || 0) > labelThreshold ? "end" : "start"));
     });
 
-    // Click on SVG background to deselect
-    svg.on("click", (event) => {
-      if (event.target === svg.node()) {
-        setSelectedNode(null);
-      }
+    // Click anywhere in the graph that isn't a node (background, edges,
+    // labels) to deselect. Node clicks stopPropagation so they never land here.
+    svg.on("click", () => {
+      setSelectedNode(null);
+      clearNodeParam();
     });
 
     // Cleanup
     return () => {
       simulation.stop();
     };
-  }, [graphData, getNodeColor, router]);
+  }, [graphData, getNodeColor, router, clearNodeParam]);
 
   // Separate effect for visual updates (selection, filters) without recreating simulation
   useEffect(() => {
@@ -769,8 +780,7 @@ function NotesGraphContent() {
   // Handle deselect
   const handleDeselect = () => {
     setSelectedNode(null);
-    // Remove node query param from URL
-    router.push("/knowledge-base/notes/graph");
+    clearNodeParam();
   };
 
   if (loading) {

--- a/frontend/src/app/knowledge-base/notes/new/page.module.scss
+++ b/frontend/src/app/knowledge-base/notes/new/page.module.scss
@@ -3,12 +3,16 @@
  * Matches production Tailwind design with blue theme
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 .container {
   min-height: 100vh;
-  background: linear-gradient(to bottom right, $color-page-bg-gradient-start, $color-page-bg-gradient-end);
+  background: linear-gradient(
+    to bottom right,
+    $color-page-bg-gradient-start,
+    $color-page-bg-gradient-end
+  );
   padding-top: $spacing-8;
   padding-bottom: $spacing-8;
 }
@@ -171,16 +175,16 @@
   justify-content: space-between;
   padding: $spacing-3 $spacing-4;
   border-radius: $border-radius-md;
-  border: $border-width-thin solid $green-500;
-  background-color: $green-50;
+  border: $border-width-thin solid $color-success-border;
+  background-color: $color-success-bg;
   margin-bottom: $spacing-4;
-  color: $green-700;
+  color: $color-success-text;
   font-size: $font-size-sm;
 
   .discardButton {
     background: none;
     border: none;
-    color: $green-600;
+    color: $color-success-text;
     cursor: pointer;
     font-size: $font-size-sm;
     text-decoration: underline;
@@ -188,7 +192,7 @@
     transition: color 0.2s ease;
 
     &:hover {
-      color: $green-700;
+      color: $color-text-primary;
     }
   }
 }
@@ -205,6 +209,9 @@
     @include flex-between;
 
     .tipTitle {
+      display: inline-flex;
+      align-items: center;
+      gap: $spacing-1;
       @include text-secondary;
       font-weight: $font-weight-semibold;
       color: $color-text-heading;
@@ -213,7 +220,7 @@
 
     .dismissButton {
       margin-left: $spacing-4;
-      color: $blue-400;
+      color: $color-text-tertiary;
       cursor: pointer;
       background: none;
       border: none;
@@ -239,6 +246,22 @@
   .tipExamples {
     @include text-tertiary;
     color: $color-text-secondary;
+
+    .tipAvoid,
+    .tipBetter {
+      display: inline-flex;
+      align-items: center;
+      gap: 2px;
+      font-weight: $font-weight-medium;
+    }
+
+    .tipAvoid {
+      color: $color-error-text;
+    }
+
+    .tipBetter {
+      color: $color-success-text;
+    }
   }
 }
 
@@ -370,11 +393,11 @@
   .count {
     &.good {
       font-weight: $font-weight-medium;
-      color: $green-600;
+      color: $color-success-text;
     }
 
     &.warning {
-      color: $yellow-300;
+      color: $color-warning-text;
     }
 
     &.error {

--- a/frontend/src/app/knowledge-base/notes/new/page.tsx
+++ b/frontend/src/app/knowledge-base/notes/new/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Suspense, useState, useEffect } from "react";
+import { ClockCounterClockwise, Lightbulb, Sparkle, X, Check } from "@phosphor-icons/react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import NoteEditor from "@/components/NoteEditor";
@@ -371,7 +372,10 @@ function NewNoteContent() {
         {/* Draft Restored Banner */}
         {draftRestored && (
           <div className={styles.draftBanner}>
-            <span>📝 Draft restored from your previous session</span>
+            <span>
+              <ClockCounterClockwise size={16} aria-hidden="true" /> Draft restored from your
+              previous session
+            </span>
             <button
               onClick={() => {
                 clearDraft();
@@ -392,17 +396,23 @@ function NewNoteContent() {
           <div className={styles.tipBox}>
             <div className={styles.tipHeader}>
               <div>
-                <h4 className={styles.tipTitle}>💭 Zettelkasten Tip: Write in first person</h4>
+                <h4 className={styles.tipTitle}>
+                  <Lightbulb size={16} aria-hidden="true" /> Zettelkasten Tip: Write in first person
+                </h4>
                 <p className={styles.tipContent}>
                   Capture YOUR understanding, not objective facts. This makes notes more memorable
                   and personal.
                 </p>
                 <div className={styles.tipExamples}>
-                  <span className="font-medium">❌ Avoid:</span> &quot;DORA metrics measure
-                  deployment performance&quot;
+                  <span className={styles.tipAvoid}>
+                    <X size={12} aria-hidden="true" /> Avoid:
+                  </span>{" "}
+                  &quot;DORA metrics measure deployment performance&quot;
                   <br />
-                  <span className="font-medium">✓ Better:</span> &quot;I use DORA metrics to
-                  identify bottlenecks in my team&apos;s pipeline&quot;
+                  <span className={styles.tipBetter}>
+                    <Check size={12} aria-hidden="true" /> Better:
+                  </span>{" "}
+                  &quot;I use DORA metrics to identify bottlenecks in my team&apos;s pipeline&quot;
                 </div>
               </div>
               <button
@@ -543,7 +553,7 @@ function NewNoteContent() {
                 }}
               />
               <p className={styles.formHint}>
-                💡 Tip: Atomic notes are easier to link and reuse. If you&apos;re listing multiple
+                Tip: Atomic notes are easier to link and reuse. If you&apos;re listing multiple
                 concepts, consider creating separate notes.
               </p>
             </div>
@@ -569,7 +579,13 @@ function NewNoteContent() {
                   onClick={() => setAiSuggestionsOpen(!aiSuggestionsOpen)}
                   className={`${styles.button} ${styles.aiButton}`}
                 >
-                  {aiSuggestionsOpen ? "Hide AI Suggestions" : "✨ Get AI Suggestions"}
+                  {aiSuggestionsOpen ? (
+                    "Hide AI Suggestions"
+                  ) : (
+                    <>
+                      <Sparkle size={16} aria-hidden="true" /> Get AI Suggestions
+                    </>
+                  )}
                 </button>
               )}
             </div>
@@ -604,7 +620,7 @@ function NewNoteContent() {
               ))}
             </ul>
             <div className={styles.modalInfo}>
-              <p>💡 Zettelkasten tip:</p>
+              <p>Zettelkasten tip:</p>
               <p>
                 Atomic notes (one idea each) are easier to link and reuse. Consider splitting this
                 into separate notes.
@@ -637,7 +653,7 @@ function NewNoteContent() {
       {showZeroLinksWarning && (
         <div className={styles.modalOverlay}>
           <div className={styles.modalContent}>
-            <h3 className={styles.modalTitle}>💡 No connections found</h3>
+            <h3 className={styles.modalTitle}>No connections found</h3>
             <p className={styles.modalText}>
               This note has no connections to other notes. Zettelkasten works best when ideas link
               together.

--- a/frontend/src/app/knowledge-base/notes/page.module.scss
+++ b/frontend/src/app/knowledge-base/notes/page.module.scss
@@ -281,16 +281,25 @@
   }
 
   .showMoreButton {
+    display: inline-flex;
+    align-items: center;
     margin-top: $spacing-3;
+    padding: $spacing-2 $spacing-3;
+    background-color: $white;
+    border: $border-width-thin solid $color-border-default;
+    border-radius: $border-radius-full;
     @include text-secondary;
-    color: $color-link-default;
+    // link-hover (orange-700/orange-300) instead of link-default: the only
+    // orange step that clears 4.5:1 on $white in both themes at this size
+    color: $color-link-hover;
     cursor: pointer;
     font-weight: $font-weight-medium;
     transition: all 0.2s ease;
 
     &:hover {
+      background-color: $color-surface-hover;
+      border-color: $color-border-hover;
       color: $color-text-primary;
-      text-decoration: underline;
     }
   }
 }

--- a/frontend/src/app/knowledge-base/notes/page.module.scss
+++ b/frontend/src/app/knowledge-base/notes/page.module.scss
@@ -3,12 +3,16 @@
  * Matches production Tailwind design with blue/purple theme
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 .container {
   min-height: 100vh;
-  background: linear-gradient(to bottom right, $color-page-bg-gradient-start, $color-page-bg-gradient-end);
+  background: linear-gradient(
+    to bottom right,
+    $color-page-bg-gradient-start,
+    $color-page-bg-gradient-end
+  );
 }
 
 // ===== LOADING STATE =====
@@ -42,7 +46,8 @@
 }
 
 @keyframes pulse {
-  0%, 100% {
+  0%,
+  100% {
     opacity: 1;
   }
   50% {

--- a/frontend/src/app/knowledge-base/page.module.scss
+++ b/frontend/src/app/knowledge-base/page.module.scss
@@ -3,12 +3,16 @@
  * Matches production Tailwind design with blue/purple theme
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 .container {
   min-height: 100vh;
-  background: linear-gradient(to bottom right, $color-page-bg-gradient-start, $color-page-bg-gradient-end);
+  background: linear-gradient(
+    to bottom right,
+    $color-page-bg-gradient-start,
+    $color-page-bg-gradient-end
+  );
 }
 
 // ===== HEADER =====
@@ -159,7 +163,8 @@
         color: $color-text-primary;
 
         mark {
-          background-color: $yellow-200;
+          background-color: $mustard-200;
+          color: $neutral-cool-800;
           font-weight: $font-weight-semibold;
         }
       }
@@ -169,7 +174,8 @@
         @include line-clamp(2);
 
         mark {
-          background-color: $yellow-200;
+          background-color: $mustard-200;
+          color: $neutral-cool-800;
           font-weight: $font-weight-medium;
         }
       }

--- a/frontend/src/app/knowledge-base/toolbox/page.module.scss
+++ b/frontend/src/app/knowledge-base/toolbox/page.module.scss
@@ -3,12 +3,16 @@
  * Quick reference library for frameworks, checklists, and mental models
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 .container {
   min-height: 100vh;
-  background: linear-gradient(to bottom right, $color-page-bg-gradient-start, $color-page-bg-gradient-end);
+  background: linear-gradient(
+    to bottom right,
+    $color-page-bg-gradient-start,
+    $color-page-bg-gradient-end
+  );
 }
 
 // ===== LOADING STATE =====
@@ -42,7 +46,8 @@
 }
 
 @keyframes pulse {
-  0%, 100% {
+  0%,
+  100% {
     opacity: 1;
   }
   50% {

--- a/frontend/src/app/login/page.module.scss
+++ b/frontend/src/app/login/page.module.scss
@@ -3,12 +3,16 @@
  * Matches production Tailwind design with blue theme
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 .container {
   min-height: 100vh;
-  background: linear-gradient(to bottom right, $color-page-bg-gradient-start, $color-page-bg-gradient-end);
+  background: linear-gradient(
+    to bottom right,
+    $color-page-bg-gradient-start,
+    $color-page-bg-gradient-end
+  );
 }
 
 // ===== HEADER =====

--- a/frontend/src/app/page.module.scss
+++ b/frontend/src/app/page.module.scss
@@ -3,8 +3,8 @@
  * Grounded typographic hero on the warm grey page - no card, no gradient.
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 .container {
   min-height: 100vh;
@@ -76,7 +76,9 @@
     text-decoration: none;
     border-bottom: 1px solid $orange-300;
     padding-bottom: 2px;
-    transition: color 0.2s ease, border-color 0.2s ease;
+    transition:
+      color 0.2s ease,
+      border-color 0.2s ease;
 
     &:hover {
       color: $color-link-active;
@@ -129,7 +131,10 @@
     color: $color-interactive-primary-text;
     background-color: $color-interactive-primary;
     box-shadow: $shadow-button;
-    transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    transition:
+      background-color 0.2s ease,
+      box-shadow 0.2s ease,
+      transform 0.2s ease;
 
     &:hover {
       background-color: $color-interactive-primary-hover;

--- a/frontend/src/components/AIButton.module.scss
+++ b/frontend/src/components/AIButton.module.scss
@@ -4,8 +4,8 @@
  * Cool teal for technical AI features
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 .aiButton {
   position: fixed;
@@ -16,7 +16,7 @@
   width: 3.5rem;
   height: 3.5rem;
   border-radius: $border-radius-full;
-  background-color: $teal-600;          // Cool teal for AI/technical features
+  background-color: $teal-600; // Cool teal for AI/technical features
   color: $white;
   box-shadow: $shadow-card-lg;
   border: none;

--- a/frontend/src/components/AIPanel.module.scss
+++ b/frontend/src/components/AIPanel.module.scss
@@ -4,8 +4,8 @@
  * Matches production Tailwind design
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 // Main panel - slides in from right on desktop
 .panel {
@@ -284,16 +284,16 @@
   font-size: $font-size-xs;
   letter-spacing: $letter-spacing-wide;
 
-  &[data-type='article'] {
+  &[data-type="article"] {
     color: $orange-700;
   }
 
-  &[data-type='note'] {
+  &[data-type="note"] {
     color: $color-text-secondary;
   }
 
-  &[data-type='reference'],
-  &:not([data-type='article']):not([data-type='note']) {
+  &[data-type="reference"],
+  &:not([data-type="article"]):not([data-type="note"]) {
     color: $color-text-tertiary;
   }
 }
@@ -353,7 +353,8 @@
 }
 
 @keyframes bounce {
-  0%, 100% {
+  0%,
+  100% {
     transform: translateY(0);
   }
   50% {

--- a/frontend/src/components/AISuggestionsPanel.module.scss
+++ b/frontend/src/components/AISuggestionsPanel.module.scss
@@ -4,8 +4,8 @@
  * Matches production Tailwind design
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 // Backdrop overlay for mobile/tablet
 .backdrop {
@@ -92,7 +92,8 @@
 }
 
 @keyframes pulse {
-  0%, 100% {
+  0%,
+  100% {
     opacity: 1;
   }
   50% {

--- a/frontend/src/components/ArticleTableOfContents.module.scss
+++ b/frontend/src/components/ArticleTableOfContents.module.scss
@@ -4,8 +4,8 @@
  * Matches production Tailwind design
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 .toc {
   position: sticky;
@@ -44,13 +44,13 @@
   @include transition-default;
 
   &:hover {
-    background-color: $blue-50;
-    color: $blue-700;
+    background-color: $color-interactive-ghost-hover;
+    color: $color-link-hover;
   }
 
   &.active {
-    background-color: $blue-50;
+    background-color: $color-interactive-ghost-hover;
     font-weight: $font-weight-medium;
-    color: $blue-700;
+    color: $color-link-hover;
   }
 }

--- a/frontend/src/components/AuthStatusBanner.module.scss
+++ b/frontend/src/components/AuthStatusBanner.module.scss
@@ -3,15 +3,15 @@
  * Matches production Tailwind design
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 // Success (authenticated) state
 .bannerSuccess {
   margin-bottom: $spacing-4;
   padding: $spacing-3;
-  border-left: 4px solid $green-500;
-  background-color: $green-50;
+  border-left: 4px solid $color-success-border;
+  background-color: $color-success-bg;
 
   .content {
     @include flex-start;
@@ -20,7 +20,7 @@
       width: 1.25rem;
       height: 1.25rem;
       margin-right: $spacing-3;
-      color: $green-500;
+      color: $color-success-border;
     }
 
     .textContent {
@@ -29,13 +29,13 @@
       .title {
         @include text-secondary;
         font-weight: $font-weight-medium;
-        color: $green-700;
+        color: $color-success-text;
       }
 
       .description {
         margin-top: 0.125rem; // 2px
         @include text-tertiary;
-        color: $green-700;
+        color: $color-success-text;
       }
     }
 
@@ -43,8 +43,8 @@
       margin-left: $spacing-3;
       padding: $spacing-1 $spacing-3;
       border-radius: $border-radius-sm;
-      background-color: $green-100;
-      color: $green-700;
+      background-color: $color-surface-tertiary;
+      color: $color-success-text;
       @include text-tertiary;
       font-weight: $font-weight-medium;
       cursor: pointer;
@@ -52,8 +52,7 @@
       @include transition-colors;
 
       &:hover {
-        background-color: $green-100;
-        filter: brightness(0.95);
+        background-color: $color-surface-hover;
       }
     }
   }
@@ -63,8 +62,8 @@
 .bannerWarning {
   margin-bottom: $spacing-4;
   padding: $spacing-4;
-  border-left: 4px solid $yellow-300;
-  background-color: $yellow-50;
+  border-left: 4px solid $color-warning-border;
+  background-color: $color-warning-bg;
 
   .content {
     @include flex-start;
@@ -75,7 +74,7 @@
       height: 1.25rem;
       margin-right: $spacing-3;
       margin-top: 0.125rem; // 2px to align with text
-      color: $yellow-300;
+      color: $color-warning-border;
     }
 
     .textContent {
@@ -96,7 +95,7 @@
       .divider {
         margin-top: $spacing-3;
         padding-top: $spacing-3;
-        border-top: $border-width-thin solid $yellow-200;
+        border-top: $border-width-thin solid $color-warning-border;
       }
 
       .loginPrompt {
@@ -124,12 +123,12 @@
   @include text-tertiary;
 
   &.authenticated {
-    background-color: $green-500;
-    color: $white;
+    background-color: $color-success-bg;
+    color: $color-success-text;
   }
 
   &.unauthenticated {
-    background-color: $yellow-100;
-    color: $neutral-900;
+    background-color: $color-warning-bg;
+    color: $color-warning-text;
   }
 }

--- a/frontend/src/components/Badge.module.scss
+++ b/frontend/src/components/Badge.module.scss
@@ -3,7 +3,7 @@
  * Uppercase mono labels: articles carry the orange accent, notes stay grey.
  */
 
-@use '@/styles/design-tokens' as *;
+@use "@/styles/design-tokens" as *;
 
 .badge {
   display: inline-flex;
@@ -20,13 +20,13 @@
   transition: border-color 0.2s ease;
 
   // Article badge - orange accent
-  &[data-type='article'] {
+  &[data-type="article"] {
     color: $orange-700;
     border-color: $orange-300;
   }
 
   // Note badge - quiet grey
-  &[data-type='note'] {
+  &[data-type="note"] {
     color: $color-text-secondary;
     border-color: $color-border-strong;
   }

--- a/frontend/src/components/Breadcrumb.module.scss
+++ b/frontend/src/components/Breadcrumb.module.scss
@@ -3,8 +3,8 @@
  * Simple back navigation link
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 .breadcrumb {
   margin-bottom: $spacing-4;

--- a/frontend/src/components/Button/Button.module.scss
+++ b/frontend/src/components/Button/Button.module.scss
@@ -3,8 +3,8 @@
  * Retro-modern design with blue primary colors
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 .button {
   @include reset-button;

--- a/frontend/src/components/Card/Card.module.scss
+++ b/frontend/src/components/Card/Card.module.scss
@@ -3,7 +3,7 @@
  * Retro-modern design with warm colors and subtle shadows
  */
 
-@use '@/styles/design-tokens' as *;
+@use "@/styles/design-tokens" as *;
 
 .card {
   background-color: $color-bg-card;

--- a/frontend/src/components/MarkdownWithWikilinks.module.scss
+++ b/frontend/src/components/MarkdownWithWikilinks.module.scss
@@ -4,8 +4,8 @@
  * Matches production Tailwind design
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 // Main prose container
 .container {

--- a/frontend/src/components/MarkdownWithWikilinks.tsx
+++ b/frontend/src/components/MarkdownWithWikilinks.tsx
@@ -53,7 +53,7 @@ const processWikilinks = (children: React.ReactNode): React.ReactNode => {
             href={`/knowledge-base/articles/${articleMatch[1]}`}
             className={`${styles.wikilink} ${styles.articleLink}`}
           >
-            📄 Article {articleMatch[1]}
+            Article {articleMatch[1]}
           </Link>
         );
       }

--- a/frontend/src/components/NoteEditor.module.scss
+++ b/frontend/src/components/NoteEditor.module.scss
@@ -4,8 +4,8 @@
  * Matches production Tailwind design
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 // Main container
 .container {
@@ -24,7 +24,7 @@
   transition: border-color 0.2s ease;
 
   &:focus-within {
-    border-color: $color-input-border-focus;  // Orange focus
+    border-color: $color-input-border-focus; // Orange focus
     outline: none;
   }
 }
@@ -55,7 +55,7 @@
   }
 
   &:hover {
-    background-color: $teal-50;           // Cool teal hover (technical feature)
+    background-color: $teal-50; // Cool teal hover (technical feature)
   }
 
   &.selected {
@@ -66,7 +66,7 @@
 .autocompleteNoteId {
   margin-bottom: $spacing-1;
   @include text-tertiary;
-  color: $teal-600;                       // Cool teal for note IDs
+  color: $teal-600; // Cool teal for note IDs
   font-family: monospace;
 }
 
@@ -110,7 +110,7 @@
 }
 
 .helpLink {
-  color: $blue-600;
+  color: $color-link-default;
   text-decoration: none;
 
   &:hover {

--- a/frontend/src/components/NoteEditor.tsx
+++ b/frontend/src/components/NoteEditor.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import CodeMirror from "@uiw/react-codemirror";
+import { useResolvedTheme } from "@/hooks/useResolvedTheme";
 import { markdown } from "@codemirror/lang-markdown";
 import { EditorView } from "@codemirror/view";
 import { logger } from "@/lib/logger";
@@ -23,6 +24,7 @@ export default function NoteEditor({
   allNotes = [],
   onNoteClick,
 }: NoteEditorProps) {
+  const theme = useResolvedTheme();
   const [showAutocomplete, setShowAutocomplete] = useState(false);
   const [autocompleteQuery, setAutocompleteQuery] = useState("");
   const [autocompletePosition, setAutocompletePosition] = useState({ top: 0, left: 0 });
@@ -139,6 +141,7 @@ export default function NoteEditor({
     <div className={styles.container}>
       <div className={styles.editorWrapper} style={{ minHeight: "400px", resize: "both" }}>
         <CodeMirror
+          theme={theme}
           value={content}
           height="400px"
           extensions={[

--- a/frontend/src/components/NoteOfDay/NoteOfDay.module.scss
+++ b/frontend/src/components/NoteOfDay/NoteOfDay.module.scss
@@ -3,8 +3,8 @@
  * Homepage widget for resurfacing stale notes
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 .noteOfDay {
   background-color: $color-surface-default;
@@ -104,12 +104,7 @@
 
 .skeleton {
   height: 150px;
-  background: linear-gradient(
-    90deg,
-    $neutral-100 25%,
-    $neutral-50 50%,
-    $neutral-100 75%
-  );
+  background: linear-gradient(90deg, $neutral-100 25%, $neutral-50 50%, $neutral-100 75%);
   background-size: 200% 100%;
   animation: shimmer 1.5s infinite;
   border-radius: $border-radius-md;

--- a/frontend/src/components/PostSaveAISuggestions.module.scss
+++ b/frontend/src/components/PostSaveAISuggestions.module.scss
@@ -4,8 +4,8 @@
  * Matches production Tailwind design
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 // Modal overlay
 .overlay {

--- a/frontend/src/components/ProjectTile.module.scss
+++ b/frontend/src/components/ProjectTile.module.scss
@@ -3,8 +3,8 @@
  * Matches production Tailwind design with blue theme
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 .projectTile {
   display: block;
@@ -18,15 +18,15 @@
 
   &:hover {
     transform: translateY(-4px);
-    border-color: $blue-400;
+    border-color: $color-interactive-primary;
     box-shadow: $shadow-popover;
 
     .title {
-      color: $blue-600;
+      color: $color-link-default;
     }
 
     .arrow {
-      color: $blue-600;
+      color: $color-link-default;
     }
   }
 }

--- a/frontend/src/components/QuickLists/QuickLists.module.scss
+++ b/frontend/src/components/QuickLists/QuickLists.module.scss
@@ -3,8 +3,8 @@
  * Color-coded collapsible sections for note categories
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 .quickLists {
   @include stack($spacing-4);
@@ -33,7 +33,8 @@
       gap: $spacing-2;
 
       .icon {
-        font-size: $font-size-lg;
+        display: inline-flex;
+        align-items: center;
         line-height: 1;
       }
 

--- a/frontend/src/components/QuickLists/QuickLists.tsx
+++ b/frontend/src/components/QuickLists/QuickLists.tsx
@@ -7,6 +7,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { CircleDashed, MapTrifold, Star, ClockCounterClockwise } from "@phosphor-icons/react";
 import Link from "next/link";
 import styles from "./QuickLists.module.scss";
 
@@ -33,7 +34,7 @@ interface QuickListsData {
 
 interface QuickListsSectionProps {
   title: string;
-  icon: string;
+  icon: React.ReactNode;
   notes: Note[];
   count: number;
   className: string;
@@ -172,7 +173,7 @@ export default function QuickLists() {
     <div className={styles.quickLists}>
       <QuickListsSection
         title="Orphan Notes"
-        icon="🏝️"
+        icon={<CircleDashed size={18} />}
         notes={data.orphans}
         count={data.counts.orphans}
         className={styles.orphans}
@@ -183,7 +184,7 @@ export default function QuickLists() {
 
       <QuickListsSection
         title="Hub Notes"
-        icon="🗺️"
+        icon={<MapTrifold size={18} />}
         notes={data.hubs}
         count={data.counts.hubs}
         className={styles.hubs}
@@ -194,7 +195,7 @@ export default function QuickLists() {
 
       <QuickListsSection
         title="Central Concepts"
-        icon="⭐"
+        icon={<Star size={18} />}
         notes={data.central_concepts}
         count={data.counts.central_concepts}
         className={styles.central}
@@ -205,7 +206,7 @@ export default function QuickLists() {
 
       <QuickListsSection
         title="Stale Notes"
-        icon="🕰️"
+        icon={<ClockCounterClockwise size={18} />}
         notes={data.stale}
         count={data.counts.stale}
         className={styles.stale}

--- a/frontend/src/components/SearchModal.module.scss
+++ b/frontend/src/components/SearchModal.module.scss
@@ -3,8 +3,8 @@
  * Global search modal accessible from TopNavigation
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 .overlay {
   position: fixed;
@@ -141,11 +141,11 @@
     font-size: $font-size-xs;
     letter-spacing: $letter-spacing-wide;
 
-    &[data-type='article'] {
+    &[data-type="article"] {
       color: $orange-700;
     }
 
-    &[data-type='note'] {
+    &[data-type="note"] {
       color: $color-text-secondary;
     }
   }
@@ -177,7 +177,8 @@
 
 // Highlight
 .highlight {
-  background-color: $yellow-200;
+  background-color: $mustard-200;
+  color: $neutral-cool-800;
   font-weight: 500;
   padding: 0 2px;
   border-radius: 2px;

--- a/frontend/src/components/Settings.module.scss
+++ b/frontend/src/components/Settings.module.scss
@@ -3,8 +3,8 @@
  * Global app settings dropdown (available to all users)
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 .container {
   position: relative;
@@ -78,7 +78,7 @@
 
 .warmupIndicator {
   font-size: 0.75rem;
-  color: $blue-600;
+  color: $color-text-secondary;
   text-align: center;
   margin-bottom: $spacing-2;
 }

--- a/frontend/src/components/SettingsDropdown.module.scss
+++ b/frontend/src/components/SettingsDropdown.module.scss
@@ -4,8 +4,8 @@
  * Matches production Tailwind design
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 .container {
   @include flex-start;

--- a/frontend/src/components/TagPill.module.scss
+++ b/frontend/src/components/TagPill.module.scss
@@ -3,8 +3,8 @@
  * Cool-toned tags with warm-cool theme integration
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 .tagPill {
   @include flex-center;
@@ -17,7 +17,7 @@
   @include transition-default;
 
   // === ARTICLE TAGS (Dusty Blue) ===
-  &[data-variant='article'] {
+  &[data-variant="article"] {
     background-color: $color-tag-article-bg;
     color: $color-tag-article-text;
     border-color: $color-tag-article-border;
@@ -36,7 +36,7 @@
   }
 
   // === NOTE TAGS (Teal) ===
-  &[data-variant='note'] {
+  &[data-variant="note"] {
     background-color: $color-tag-note-bg;
     color: $color-tag-note-text;
     border-color: $color-tag-note-border;

--- a/frontend/src/components/TemplateSelector.module.scss
+++ b/frontend/src/components/TemplateSelector.module.scss
@@ -4,8 +4,8 @@
  * Follows SettingsDropdown pattern
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 .container {
   position: relative;

--- a/frontend/src/components/ThemeToggle.module.scss
+++ b/frontend/src/components/ThemeToggle.module.scss
@@ -2,8 +2,8 @@
  * ThemeToggle Component Styles
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 .toggle {
   @include flex-center;

--- a/frontend/src/components/Toast.module.scss
+++ b/frontend/src/components/Toast.module.scss
@@ -4,8 +4,8 @@
  * Matches production Tailwind design
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 .toast {
   position: fixed;

--- a/frontend/src/components/TopNavigation.tsx
+++ b/frontend/src/components/TopNavigation.tsx
@@ -29,7 +29,8 @@ export default function TopNavigation() {
 
   // Determine active section
   const isArticlesSection = pathname?.startsWith("/knowledge-base/articles");
-  const isNotesSection = pathname?.startsWith("/knowledge-base/notes");
+  const isGraphSection = pathname?.startsWith("/knowledge-base/notes/graph");
+  const isNotesSection = pathname?.startsWith("/knowledge-base/notes") && !isGraphSection;
   const isToolboxSection = pathname?.startsWith("/knowledge-base/toolbox");
   const isInspireSection = pathname?.startsWith("/knowledge-base/inspire");
 
@@ -70,6 +71,12 @@ export default function TopNavigation() {
               className={`${styles.navLink} ${isNotesSection ? styles.active : ""}`}
             >
               Notes
+            </Link>
+            <Link
+              href="/knowledge-base/notes/graph"
+              className={`${styles.navLink} ${isGraphSection ? styles.active : ""}`}
+            >
+              Graph
             </Link>
             <Link
               href="/knowledge-base/toolbox"

--- a/frontend/src/components/UserMenu.module.scss
+++ b/frontend/src/components/UserMenu.module.scss
@@ -3,8 +3,8 @@
  * Dropdown menu for user-specific actions (AI preferences, Sign Out)
  */
 
-@use '@/styles/design-tokens' as *;
-@use '@/styles/mixins' as *;
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
 
 .container {
   position: relative;

--- a/frontend/src/hooks/useFeatureFlags.ts
+++ b/frontend/src/hooks/useFeatureFlags.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useSyncExternalStore } from "react";
+import { useEffect, useSyncExternalStore } from "react";
 import { config } from "@/lib/config";
 import { logger } from "@/lib/logger";
 
@@ -68,9 +68,14 @@ export function applyFeatureFlag(name: string, enabled: boolean): void {
  * to distinguish "disabled" from "still loading" when needed.
  */
 export function useFeatureFlags(): FeatureFlags {
-  if (typeof window !== "undefined" && !fetchStarted) {
-    fetchStarted = true;
-    void fetchFlags();
-  }
+  // Start the fetch after mount, not during render: if it resolved before
+  // hydration finished, the client tree would no longer match the server
+  // HTML (hydration error on e.g. the AIButton).
+  useEffect(() => {
+    if (!fetchStarted) {
+      fetchStarted = true;
+      void fetchFlags();
+    }
+  }, []);
   return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }

--- a/frontend/src/hooks/useResolvedTheme.ts
+++ b/frontend/src/hooks/useResolvedTheme.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Resolves the active theme the same way themes.scss does: an explicit
+ * data-theme on <html> wins (set by ThemeToggle), otherwise the OS
+ * preference applies. Tracks both the toggle and OS changes live.
+ */
+export function useResolvedTheme(): "light" | "dark" {
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+
+  useEffect(() => {
+    const resolve = (): "light" | "dark" => {
+      const explicit = document.documentElement.dataset.theme;
+      if (explicit === "dark" || explicit === "light") return explicit;
+      return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    };
+
+    setTheme(resolve());
+
+    const observer = new MutationObserver(() => setTheme(resolve()));
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-theme"],
+    });
+
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const onChange = () => setTheme(resolve());
+    mq.addEventListener("change", onChange);
+
+    return () => {
+      observer.disconnect();
+      mq.removeEventListener("change", onChange);
+    };
+  }, []);
+
+  return theme;
+}

--- a/frontend/src/styles/design-tokens/_borders.scss
+++ b/frontend/src/styles/design-tokens/_borders.scss
@@ -24,7 +24,7 @@ $border-width-thick: 3px;
 
 // ===== BORDER STYLES =====
 // Import colors for border colors
-@use 'colors' as *;
+@use "colors" as *;
 
 // Standard borders
 $border-default: $border-width-thin solid $color-border;

--- a/frontend/src/styles/design-tokens/_colors.scss
+++ b/frontend/src/styles/design-tokens/_colors.scss
@@ -17,135 +17,135 @@
 // Cool neutrals (400-900) for text/icons - professional, clear
 
 // WARM NEUTRALS (Beige/cream undertones)
-$neutral-warm-50: #FAFAF8;    // Warm cream (main page bg)
-$neutral-warm-100: #F5F5F2;   // Light warm grey
-$neutral-warm-200: #E5E5E0;   // Warm border
-$neutral-warm-300: #D4D4CE;   // Warm mid border
+$neutral-warm-50: #fafaf8; // Warm cream (main page bg)
+$neutral-warm-100: #f5f5f2; // Light warm grey
+$neutral-warm-200: #e5e5e0; // Warm border
+$neutral-warm-300: #d4d4ce; // Warm mid border
 
 // COOL NEUTRALS (Slate/blue undertones)
-$neutral-cool-400: #9CA3AF;   // Cool mid grey (standard Tailwind)
-$neutral-cool-500: #6B7280;   // Cool secondary text
-$neutral-cool-600: #4B5563;   // Cool dark text
-$neutral-cool-700: #374151;   // Cool heading
-$neutral-cool-800: #1F2937;   // Cool primary text (sharp, readable)
-$neutral-cool-900: #111827;   // Cool darkest
+$neutral-cool-400: #9ca3af; // Cool mid grey (standard Tailwind)
+$neutral-cool-500: #6b7280; // Cool secondary text
+$neutral-cool-600: #4b5563; // Cool dark text
+$neutral-cool-700: #374151; // Cool heading
+$neutral-cool-800: #1f2937; // Cool primary text (sharp, readable)
+$neutral-cool-900: #111827; // Cool darkest
 
 // BALANCED NEUTRALS (Mix of both)
 // Surfaces = warm, Text = cool (best of both worlds)
 // Theme-aware: the ramp flips in dark mode (see styles/themes.scss).
-$neutral-50: var(--neutral-50);    // Surfaces = warm
-$neutral-100: var(--neutral-100);  // Surfaces = warm
-$neutral-200: var(--neutral-200);  // Borders = warm
-$neutral-300: var(--neutral-300);  // Borders = warm
-$neutral-400: var(--neutral-400);  // Mid tones = cool
-$neutral-500: var(--neutral-500);  // Text = cool (readable)
-$neutral-600: var(--neutral-600);  // Text = cool
-$neutral-700: var(--neutral-700);  // Headings = cool (sharp)
-$neutral-800: var(--neutral-800);  // Body text = cool (legible)
-$neutral-900: var(--neutral-900);  // Darkest = cool
+$neutral-50: var(--neutral-50); // Surfaces = warm
+$neutral-100: var(--neutral-100); // Surfaces = warm
+$neutral-200: var(--neutral-200); // Borders = warm
+$neutral-300: var(--neutral-300); // Borders = warm
+$neutral-400: var(--neutral-400); // Mid tones = cool
+$neutral-500: var(--neutral-500); // Text = cool (readable)
+$neutral-600: var(--neutral-600); // Text = cool
+$neutral-700: var(--neutral-700); // Headings = cool (sharp)
+$neutral-800: var(--neutral-800); // Body text = cool (legible)
+$neutral-900: var(--neutral-900); // Darkest = cool
 
 // === ORANGE (Primary - Warm) ===
 // Medium-dark orange - sophisticated, not loud
-$orange-50: #FFF7F0;      // Very light peach
-$orange-100: #FFE8D9;     // Light peach
-$orange-200: #FBD4BB;     // Soft orange
-$orange-300: #F4B28E;     // Light orange
-$orange-400: #EE9465;     // Medium light orange
-$orange-500: #E8773C;     // Medium orange
-$orange-600: #D96D32;     // PRIMARY CTA - main orange
-$orange-700: #C2532A;     // Hover state
-$orange-800: #9A4222;     // Active state
-$orange-900: #73311A;     // Darkest orange
+$orange-50: #fff7f0; // Very light peach
+$orange-100: #ffe8d9; // Light peach
+$orange-200: #fbd4bb; // Soft orange
+$orange-300: #f4b28e; // Light orange
+$orange-400: #ee9465; // Medium light orange
+$orange-500: #e8773c; // Medium orange
+$orange-600: #d96d32; // PRIMARY CTA - main orange
+$orange-700: #c2532a; // Hover state
+$orange-800: #9a4222; // Active state
+$orange-900: #73311a; // Darkest orange
 
 // === TERRACOTTA (Secondary - Warm) ===
 // Earthy, sophisticated
-$terracotta-50: #FFF5F2;     // Very light terracotta
-$terracotta-100: #FFE8E3;    // Light terracotta
-$terracotta-200: #F5D0C8;    // Soft terracotta
-$terracotta-300: #E6B4A8;    // Light terracotta
-$terracotta-400: #D99B8D;    // Medium light
-$terracotta-500: #D18573;    // Medium terracotta
-$terracotta-600: #C4624F;    // SECONDARY CTA
-$terracotta-700: #A8503E;    // Hover state
-$terracotta-800: #8B4436;    // Active state
-$terracotta-900: #6E3529;    // Darkest
+$terracotta-50: #fff5f2; // Very light terracotta
+$terracotta-100: #ffe8e3; // Light terracotta
+$terracotta-200: #f5d0c8; // Soft terracotta
+$terracotta-300: #e6b4a8; // Light terracotta
+$terracotta-400: #d99b8d; // Medium light
+$terracotta-500: #d18573; // Medium terracotta
+$terracotta-600: #c4624f; // SECONDARY CTA
+$terracotta-700: #a8503e; // Hover state
+$terracotta-800: #8b4436; // Active state
+$terracotta-900: #6e3529; // Darkest
 
 // === MUSTARD (Warm Accent - Warnings, Orphan Notes) ===
-$mustard-50: #FFF9E6;
-$mustard-100: #FFF4D6;
-$mustard-200: #F5E5B3;
-$mustard-300: #E8D89B;
-$mustard-400: #DCC878;
-$mustard-500: #D4A748;     // Main mustard
-$mustard-600: #B8903D;
-$mustard-700: #8B7A2D;
-$mustard-800: #6B5E22;
+$mustard-50: #fff9e6;
+$mustard-100: #fff4d6;
+$mustard-200: #f5e5b3;
+$mustard-300: #e8d89b;
+$mustard-400: #dcc878;
+$mustard-500: #d4a748; // Main mustard
+$mustard-600: #b8903d;
+$mustard-700: #8b7a2d;
+$mustard-800: #6b5e22;
 
 // === TEAL (Cool Accent - Complements Orange) ===
 // Muted, sophisticated teal - provides cool balance
-$teal-50: #F0F9F7;       // Very light teal (almost white)
-$teal-100: #E0F2EE;      // Light teal background
-$teal-200: #B8DED6;      // Soft teal
-$teal-300: #8FCBC0;      // Light teal
-$teal-400: #6BB8AB;      // Medium light teal
-$teal-500: #4A9D8E;      // Medium teal
-$teal-600: #3A8A7D;      // MAIN TEAL - cool accent
-$teal-700: #2F6F65;      // Darker teal
-$teal-800: #25574F;      // Deep teal
-$teal-900: #1A403A;      // Darkest teal
+$teal-50: #f0f9f7; // Very light teal (almost white)
+$teal-100: #e0f2ee; // Light teal background
+$teal-200: #b8ded6; // Soft teal
+$teal-300: #8fcbc0; // Light teal
+$teal-400: #6bb8ab; // Medium light teal
+$teal-500: #4a9d8e; // Medium teal
+$teal-600: #3a8a7d; // MAIN TEAL - cool accent
+$teal-700: #2f6f65; // Darker teal
+$teal-800: #25574f; // Deep teal
+$teal-900: #1a403a; // Darkest teal
 
 // === SLATE BLUE (Cool Secondary - Sophisticated) ===
 // Muted slate blue - professional, tech-focused
-$slate-blue-50: #F4F6F9;      // Very light slate
-$slate-blue-100: #E8ECF2;     // Light slate background
-$slate-blue-200: #CED6E3;     // Soft slate
-$slate-blue-300: #B0BDD1;     // Light slate
-$slate-blue-400: #91A4BF;     // Medium light slate
-$slate-blue-500: #7388A8;     // Medium slate
-$slate-blue-600: #5B6F8F;     // MAIN SLATE BLUE
-$slate-blue-700: #4A5A74;     // Darker slate
-$slate-blue-800: #3A465A;     // Deep slate
-$slate-blue-900: #2A3441;     // Darkest slate
+$slate-blue-50: #f4f6f9; // Very light slate
+$slate-blue-100: #e8ecf2; // Light slate background
+$slate-blue-200: #ced6e3; // Soft slate
+$slate-blue-300: #b0bdd1; // Light slate
+$slate-blue-400: #91a4bf; // Medium light slate
+$slate-blue-500: #7388a8; // Medium slate
+$slate-blue-600: #5b6f8f; // MAIN SLATE BLUE
+$slate-blue-700: #4a5a74; // Darker slate
+$slate-blue-800: #3a465a; // Deep slate
+$slate-blue-900: #2a3441; // Darkest slate
 
 // === DUSTY BLUE (Cool Accent - Info, Hub Notes) ===
 // Cooler, more saturated than before
-$dusty-blue-50: #EEF4F9;      // Cool light blue (cooler than before)
-$dusty-blue-100: #DCE8F3;     // Light dusty blue
-$dusty-blue-200: #B8D1E6;     // Cool blue border
-$dusty-blue-300: #94BBDA;     // Light dusty blue
-$dusty-blue-400: #73A5CD;     // Medium light
-$dusty-blue-500: #5790BF;     // Medium dusty blue
-$dusty-blue-600: #4278A8;     // MAIN DUSTY BLUE (cooler)
-$dusty-blue-700: #355F84;     // Darker
-$dusty-blue-800: #284960;     // Deep blue
-$dusty-blue-900: #1C3343;     // Darkest
+$dusty-blue-50: #eef4f9; // Cool light blue (cooler than before)
+$dusty-blue-100: #dce8f3; // Light dusty blue
+$dusty-blue-200: #b8d1e6; // Cool blue border
+$dusty-blue-300: #94bbda; // Light dusty blue
+$dusty-blue-400: #73a5cd; // Medium light
+$dusty-blue-500: #5790bf; // Medium dusty blue
+$dusty-blue-600: #4278a8; // MAIN DUSTY BLUE (cooler)
+$dusty-blue-700: #355f84; // Darker
+$dusty-blue-800: #284960; // Deep blue
+$dusty-blue-900: #1c3343; // Darkest
 
 // === SAGE GREEN (Warm-Cool Neutral - Success) ===
 // Sage is naturally balanced (warm + cool)
-$sage-50: #F2F7F2;
-$sage-100: #E8F2E8;
-$sage-200: #D4E5D3;
-$sage-300: #B8D4B7;
-$sage-400: #9CB89B;
-$sage-500: #7B9E7A;        // Main sage
-$sage-600: #6B8B6B;
-$sage-700: #5A7859;
+$sage-50: #f2f7f2;
+$sage-100: #e8f2e8;
+$sage-200: #d4e5d3;
+$sage-300: #b8d4b7;
+$sage-400: #9cb89b;
+$sage-500: #7b9e7a; // Main sage
+$sage-600: #6b8b6b;
+$sage-700: #5a7859;
 $sage-800: #476047;
 
 // === INDIGO (Page Background Gradient - Warm to Cool) ===
 // Updated to match slate-blue for warm-to-cool gradient
-$indigo-50: #F4F6F9;      // Cool slate (same as slate-blue-50)
-$indigo-100: #E8ECF2;     // Light cool slate
-$indigo-200: #DFE3EB;     // Slightly cooler
+$indigo-50: #f4f6f9; // Cool slate (same as slate-blue-50)
+$indigo-100: #e8ecf2; // Light cool slate
+$indigo-200: #dfe3eb; // Slightly cooler
 
 // === RED (Error States) ===
-$red-50: #FEF2F2;
-$red-100: #FEE2E2;
-$red-200: #FECACA;
-$red-500: #EF4444;
-$red-600: #DC2626;
-$red-700: #B91C1C;
-$red-800: #991B1B;
+$red-50: #fef2f2;
+$red-100: #fee2e2;
+$red-200: #fecaca;
+$red-500: #ef4444;
+$red-600: #dc2626;
+$red-700: #b91c1c;
+$red-800: #991b1b;
 
 // === LEGACY SCALE ALIASES (Palette collapse) ===
 // These names remain for existing modules but now resolve into the
@@ -212,48 +212,54 @@ $black: #000000;
 
 // === PAGE STRUCTURE ===
 // Warm to Cool gradient - warm cream to cool slate
-$color-page-bg: var(--color-page-bg);                  // Main page background (warm cream)
-$color-page-bg-gradient-start: var(--color-page-bg-gradient-start);   // Gradient start (warm cream)
-$color-page-bg-gradient-end: var(--color-page-bg-gradient-end);           // Gradient end (cool slate)
-$color-page-bg-alt: var(--color-page-bg-alt);                  // Alternative page background (warm)
+$color-page-bg: var(--color-page-bg); // Main page background (warm cream)
+$color-page-bg-gradient-start: var(--color-page-bg-gradient-start); // Gradient start (warm cream)
+$color-page-bg-gradient-end: var(--color-page-bg-gradient-end); // Gradient end (cool slate)
+$color-page-bg-alt: var(--color-page-bg-alt); // Alternative page background (warm)
 
 // === SURFACES (Cards, Panels) ===
-$color-surface-default: var(--color-surface-default);                    // Default card/surface background (neutral anchor)
-$color-surface-secondary: var(--color-surface-secondary);        // Secondary surfaces (warm cream - inviting)
-$color-surface-tertiary: var(--color-surface-tertiary);             // Tertiary surfaces (warm light grey)
-$color-surface-elevated: var(--color-surface-elevated);                   // Elevated cards (white with warm shadow)
-$color-surface-hover: var(--color-surface-hover);            // Surface hover state (warm)
-$color-surface-cool: var(--color-surface-cool);               // Cool surface variant (for contrast)
-$color-surface-hover-cool: var(--color-surface-hover-cool);               // Cool hover (alternative)
+$color-surface-default: var(
+  --color-surface-default
+); // Default card/surface background (neutral anchor)
+$color-surface-secondary: var(
+  --color-surface-secondary
+); // Secondary surfaces (warm cream - inviting)
+$color-surface-tertiary: var(--color-surface-tertiary); // Tertiary surfaces (warm light grey)
+$color-surface-elevated: var(--color-surface-elevated); // Elevated cards (white with warm shadow)
+$color-surface-hover: var(--color-surface-hover); // Surface hover state (warm)
+$color-surface-cool: var(--color-surface-cool); // Cool surface variant (for contrast)
+$color-surface-hover-cool: var(--color-surface-hover-cool); // Cool hover (alternative)
 
 // === TEXT ===
-$color-text-primary: var(--color-text-primary);            // Primary text (cool dark grey - sharp, readable)
-$color-text-secondary: var(--color-text-secondary);          // Secondary text (cool mid grey)
-$color-text-tertiary: var(--color-text-tertiary);           // Tertiary text (cool lighter grey)
-$color-text-heading: var(--color-text-heading);            // Headings (cool - clear hierarchy)
-$color-text-disabled: var(--color-text-disabled);           // Disabled text
-$color-text-inverse: var(--color-text-inverse);                       // Text on dark backgrounds
-$color-text-warm: var(--color-text-warm);               // Warm text variant (for use on cool backgrounds)
+$color-text-primary: var(--color-text-primary); // Primary text (cool dark grey - sharp, readable)
+$color-text-secondary: var(--color-text-secondary); // Secondary text (cool mid grey)
+$color-text-tertiary: var(--color-text-tertiary); // Tertiary text (cool lighter grey)
+$color-text-heading: var(--color-text-heading); // Headings (cool - clear hierarchy)
+$color-text-disabled: var(--color-text-disabled); // Disabled text
+$color-text-inverse: var(--color-text-inverse); // Text on dark backgrounds
+$color-text-warm: var(--color-text-warm); // Warm text variant (for use on cool backgrounds)
 
 // === BORDERS ===
-$color-border-default: var(--color-border-default);          // Default borders (warm - soft)
-$color-border-subtle: var(--color-border-subtle);           // Subtle borders (warm)
-$color-border-strong: var(--color-border-strong);           // Strong borders (cool - more visible)
-$color-border-hover: var(--color-border-hover);            // Border hover (cool - more defined)
-$color-border-cool: var(--color-border-cool);               // Cool border variant
+$color-border-default: var(--color-border-default); // Default borders (warm - soft)
+$color-border-subtle: var(--color-border-subtle); // Subtle borders (warm)
+$color-border-strong: var(--color-border-strong); // Strong borders (cool - more visible)
+$color-border-hover: var(--color-border-hover); // Border hover (cool - more defined)
+$color-border-cool: var(--color-border-cool); // Cool border variant
 
 // === INTERACTIVE ELEMENTS ===
 
 // === PRIMARY ACTIONS (Orange - Warm) ===
-$color-interactive-primary: var(--color-interactive-primary);           // Orange (warm) primary button
-$color-interactive-primary-hover: var(--color-interactive-primary-hover);     // Orange hover
-$color-interactive-primary-active: var(--color-interactive-primary-active);    // Orange active
-$color-interactive-primary-text: var(--color-interactive-primary-text);           // Text on primary buttons
-$color-interactive-primary-bg-subtle: var(--color-interactive-primary-bg-subtle);  // Subtle primary background
-$color-interactive-primary-focus: var(--color-interactive-primary-focus);     // Primary focus ring
+$color-interactive-primary: var(--color-interactive-primary); // Orange (warm) primary button
+$color-interactive-primary-hover: var(--color-interactive-primary-hover); // Orange hover
+$color-interactive-primary-active: var(--color-interactive-primary-active); // Orange active
+$color-interactive-primary-text: var(--color-interactive-primary-text); // Text on primary buttons
+$color-interactive-primary-bg-subtle: var(
+  --color-interactive-primary-bg-subtle
+); // Subtle primary background
+$color-interactive-primary-focus: var(--color-interactive-primary-focus); // Primary focus ring
 
 // === SECONDARY ACTIONS (Warm - Terracotta) ===
-$color-interactive-secondary: var(--color-interactive-secondary);     // Terracotta (warm) secondary
+$color-interactive-secondary: var(--color-interactive-secondary); // Terracotta (warm) secondary
 $color-interactive-secondary-hover: var(--color-interactive-secondary-hover);
 $color-interactive-secondary-active: var(--color-interactive-secondary-active);
 $color-interactive-secondary-text: var(--color-interactive-secondary-text);
@@ -261,35 +267,35 @@ $color-interactive-secondary-bg: var(--color-interactive-secondary-bg);
 
 // === SECONDARY COOL VARIANT (Cool - Teal) ===
 // Use for cool secondary actions (technical actions, code-related buttons)
-$color-interactive-secondary-cool: var(--color-interactive-secondary-cool);      // Teal (cool) secondary
+$color-interactive-secondary-cool: var(--color-interactive-secondary-cool); // Teal (cool) secondary
 $color-interactive-secondary-cool-hover: var(--color-interactive-secondary-cool-hover);
 $color-interactive-secondary-cool-active: var(--color-interactive-secondary-cool-active);
 $color-interactive-secondary-cool-text: var(--color-interactive-secondary-cool-text);
 $color-interactive-secondary-cool-bg: var(--color-interactive-secondary-cool-bg);
 
 // === TERTIARY ACTIONS (Neutral) ===
-$color-interactive-tertiary: var(--color-interactive-tertiary);         // Warm light grey background
-$color-interactive-tertiary-hover: var(--color-interactive-tertiary-hover);   // Warm border grey
+$color-interactive-tertiary: var(--color-interactive-tertiary); // Warm light grey background
+$color-interactive-tertiary-hover: var(--color-interactive-tertiary-hover); // Warm border grey
 $color-interactive-tertiary-active: var(--color-interactive-tertiary-active);
 $color-interactive-tertiary-text: var(--color-interactive-tertiary-text); // Cool text for clarity
 $color-interactive-tertiary-bg: var(--color-interactive-tertiary-bg);
 
 // === GHOST ACTIONS (Warm) ===
 $color-interactive-ghost: var(--color-interactive-ghost);
-$color-interactive-ghost-hover: var(--color-interactive-ghost-hover);        // Warm orange hover
-$color-interactive-ghost-text: var(--color-interactive-ghost-text);        // Orange text
+$color-interactive-ghost-hover: var(--color-interactive-ghost-hover); // Warm orange hover
+$color-interactive-ghost-text: var(--color-interactive-ghost-text); // Orange text
 $color-interactive-ghost-text-hover: var(--color-interactive-ghost-text-hover);
 
 // === LINKS (Warm primary, Cool variants) ===
-$color-link-default: var(--color-link-default);                  // Orange (warm) default link
-$color-link-hover: var(--color-link-hover);                    // Orange hover
-$color-link-visited: var(--color-link-visited);              // Terracotta (warm) visited
-$color-link-active: var(--color-link-active);                   // Orange active
+$color-link-default: var(--color-link-default); // Orange (warm) default link
+$color-link-hover: var(--color-link-hover); // Orange hover
+$color-link-visited: var(--color-link-visited); // Terracotta (warm) visited
+$color-link-active: var(--color-link-active); // Orange active
 
 // Cool link variants (for cool sections like code docs)
-$color-link-cool: var(--color-link-cool);                       // Teal (cool) link
-$color-link-cool-hover: var(--color-link-cool-hover);                 // Teal hover
-$color-link-cool-visited: var(--color-link-cool-visited);         // Slate blue (cool) visited
+$color-link-cool: var(--color-link-cool); // Teal (cool) link
+$color-link-cool-hover: var(--color-link-cool-hover); // Teal hover
+$color-link-cool-visited: var(--color-link-cool-visited); // Slate blue (cool) visited
 
 // === SEMANTIC STATES ===
 
@@ -310,27 +316,27 @@ $color-error-border: var(--color-error-border);
 $color-error-text: var(--color-error-text);
 
 // === INFO (Cool - Dusty Blue) ===
-$color-info-bg: var(--color-info-bg);                   // Cool blue
+$color-info-bg: var(--color-info-bg); // Cool blue
 $color-info-border: var(--color-info-border);
 $color-info-text: var(--color-info-text);
 
 // === INFO COOL VARIANT (Slate Blue) ===
 // Use for very technical/structural info
-$color-info-cool-bg: var(--color-info-cool-bg);              // Cooler slate
+$color-info-cool-bg: var(--color-info-cool-bg); // Cooler slate
 $color-info-cool-border: var(--color-info-cool-border);
 $color-info-cool-text: var(--color-info-cool-text);
 
 // === BADGES ===
 
 // === ARTICLE BADGES (Warm - Orange) ===
-$color-badge-article-bg: var(--color-badge-article-bg);     // More saturated (was orange-100)
+$color-badge-article-bg: var(--color-badge-article-bg); // More saturated (was orange-100)
 $color-badge-article-text: var(--color-badge-article-text);
-$color-badge-article-border: var(--color-badge-article-border);  // Stronger border (was orange-200)
+$color-badge-article-border: var(--color-badge-article-border); // Stronger border (was orange-200)
 
 // === NOTE BADGES (Warm - Terracotta) ===
-$color-badge-note-bg: var(--color-badge-note-bg);     // More saturated (was terracotta-100)
+$color-badge-note-bg: var(--color-badge-note-bg); // More saturated (was terracotta-100)
 $color-badge-note-text: var(--color-badge-note-text);
-$color-badge-note-border: var(--color-badge-note-border);  // Stronger border (was terracotta-200)
+$color-badge-note-border: var(--color-badge-note-border); // Stronger border (was terracotta-200)
 
 // === NOTE BADGES COOL VARIANT (Teal) ===
 // Alternative for cool sections
@@ -361,12 +367,12 @@ $color-tag-note-hover-border: var(--color-tag-note-hover-border);
 // === FORM ELEMENTS ===
 // Strategy: Warm borders at rest, cool on hover (more defined), warm orange on focus (friendly)
 $color-input-bg: var(--color-input-bg);
-$color-input-border: var(--color-input-border);            // Warm border (soft)
-$color-input-border-hover: var(--color-input-border-hover);      // Cool hover (more visible)
-$color-input-border-focus: var(--color-input-border-focus);            // Orange focus (warm)
-$color-input-text: var(--color-input-text);              // Cool text (readable)
-$color-input-placeholder: var(--color-input-placeholder);       // Cool placeholder
-$color-input-disabled-bg: var(--color-input-disabled-bg);            // Warm disabled
+$color-input-border: var(--color-input-border); // Warm border (soft)
+$color-input-border-hover: var(--color-input-border-hover); // Cool hover (more visible)
+$color-input-border-focus: var(--color-input-border-focus); // Orange focus (warm)
+$color-input-text: var(--color-input-text); // Cool text (readable)
+$color-input-placeholder: var(--color-input-placeholder); // Cool placeholder
+$color-input-disabled-bg: var(--color-input-disabled-bg); // Warm disabled
 $color-input-disabled-text: var(--color-input-disabled-text);
 
 // === QUICK LISTS (Note Categories) ===
@@ -435,16 +441,16 @@ $color-border: var(--color-border);
 $color-primary: var(--color-primary);
 $color-primary-hover: var(--color-primary-hover);
 $color-primary-active: var(--color-primary-active);
-$color-primary-light: var(--color-primary-light);  // Updated to orange
-$color-primary-dark: var(--color-primary-dark);  // Updated to orange
+$color-primary-light: var(--color-primary-light); // Updated to orange
+$color-primary-dark: var(--color-primary-dark); // Updated to orange
 $color-secondary: var(--color-secondary);
 $color-secondary-hover: var(--color-secondary-hover);
-$color-secondary-light: var(--color-secondary-light);  // Updated to terracotta
-$color-accent-blue: var(--color-accent-blue);     // Updated to dusty blue (cool accent)
+$color-secondary-light: var(--color-secondary-light); // Updated to terracotta
+$color-accent-blue: var(--color-accent-blue); // Updated to dusty blue (cool accent)
 $color-accent-blue-light: var(--color-accent-blue-light);
 $color-accent-blue-border: var(--color-accent-blue-border);
 $color-accent-blue-dark: var(--color-accent-blue-dark);
-$color-accent-purple: var(--color-accent-purple);   // Updated to terracotta (warm secondary)
+$color-accent-purple: var(--color-accent-purple); // Updated to terracotta (warm secondary)
 $color-accent-purple-light: var(--color-accent-purple-light);
 $color-accent-purple-border: var(--color-accent-purple-border);
 $color-accent-purple-dark: var(--color-accent-purple-dark);

--- a/frontend/src/styles/design-tokens/_index.scss
+++ b/frontend/src/styles/design-tokens/_index.scss
@@ -3,8 +3,8 @@
  * Import all design tokens for use in components
  */
 
-@forward 'colors';
-@forward 'typography';
-@forward 'spacing';
-@forward 'shadows';
-@forward 'borders';
+@forward "colors";
+@forward "typography";
+@forward "spacing";
+@forward "shadows";
+@forward "borders";

--- a/frontend/src/styles/design-tokens/_shadows.scss
+++ b/frontend/src/styles/design-tokens/_shadows.scss
@@ -5,19 +5,19 @@
 
 // ===== WARM SHADOWS (Default) =====
 // Orange-tinted shadows for warm elements
-$shadow-color-warm: rgba(217, 109, 50, 0.06);        // Orange tint (light)
-$shadow-color-warm-md: rgba(217, 109, 50, 0.10);     // Orange tint (medium)
-$shadow-color-warm-lg: rgba(217, 109, 50, 0.14);     // Orange tint (strong)
+$shadow-color-warm: rgba(217, 109, 50, 0.06); // Orange tint (light)
+$shadow-color-warm-md: rgba(217, 109, 50, 0.1); // Orange tint (medium)
+$shadow-color-warm-lg: rgba(217, 109, 50, 0.14); // Orange tint (strong)
 
-$shadow-color-charcoal: rgba(45, 45, 40, 0.08);      // Warm charcoal
-$shadow-color-charcoal-md: rgba(45, 45, 40, 0.12);   // Warm charcoal (medium)
-$shadow-color-charcoal-lg: rgba(45, 45, 40, 0.16);   // Warm charcoal (strong)
+$shadow-color-charcoal: rgba(45, 45, 40, 0.08); // Warm charcoal
+$shadow-color-charcoal-md: rgba(45, 45, 40, 0.12); // Warm charcoal (medium)
+$shadow-color-charcoal-lg: rgba(45, 45, 40, 0.16); // Warm charcoal (strong)
 
 // ===== COOL SHADOWS (Alternative) =====
 // Teal-tinted shadows for cool elements
-$shadow-color-cool: rgba(58, 138, 125, 0.06);        // Teal tint (light)
-$shadow-color-cool-md: rgba(58, 138, 125, 0.10);     // Teal tint (medium)
-$shadow-color-cool-lg: rgba(58, 138, 125, 0.14);     // Teal tint (strong)
+$shadow-color-cool: rgba(58, 138, 125, 0.06); // Teal tint (light)
+$shadow-color-cool-md: rgba(58, 138, 125, 0.1); // Teal tint (medium)
+$shadow-color-cool-lg: rgba(58, 138, 125, 0.14); // Teal tint (strong)
 
 // ===== CARD SHADOWS (Default - Warm) =====
 // Subtle shadow for resting cards
@@ -39,7 +39,7 @@ $shadow-card-cool-lg: 0 4px 16px $shadow-color-cool-lg;
 // Combines warm and cool shadows for maximum depth
 $shadow-elevated:
   0 2px 8px $shadow-color-warm-md,
-  0 4px 16px $shadow-color-cool;                     // Cool depth layer
+  0 4px 16px $shadow-color-cool; // Cool depth layer
 
 // ===== BUTTON SHADOWS =====
 $shadow-button: 0 1px 3px rgba(45, 45, 40, 0.12);

--- a/frontend/src/styles/design-tokens/_typography.scss
+++ b/frontend/src/styles/design-tokens/_typography.scss
@@ -5,12 +5,22 @@
 
 // ===== FONT FAMILIES =====
 // Primary font stack - 80's retro geometric sans (uses CSS variable from next/font)
-$font-family-primary: var(--font-space-grotesk), -apple-system, BlinkMacSystemFont, 'Segoe UI',
-  'Roboto', 'Helvetica Neue', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
+$font-family-primary:
+  var(--font-space-grotesk),
+  -apple-system,
+  BlinkMacSystemFont,
+  "Segoe UI",
+  "Roboto",
+  "Helvetica Neue",
+  Arial,
+  sans-serif,
+  "Apple Color Emoji",
+  "Segoe UI Emoji";
 
 // Monospace for code - retro terminal feel (uses CSS variable from next/font)
-$font-family-mono: var(--font-space-mono), 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Code',
-  'Source Code Pro', monospace;
+$font-family-mono:
+  var(--font-space-mono), "SF Mono", "Monaco", "Inconsolata", "Fira Code", "Source Code Pro",
+  monospace;
 
 // ===== FONT SIZES =====
 // Standard 16px base: long-form reading is the site's core job.
@@ -41,8 +51,8 @@ $line-height-loose: 1.6;
 // Retro feel - increased letter spacing for that 80s geometric look
 $letter-spacing-tight: -0.01em;
 $letter-spacing-normal: 0.01em; // Slightly wider for body text
-$letter-spacing-wide: 0.025em;  // Wider for headings
-$letter-spacing-wider: 0.04em;  // Even wider for large headings
+$letter-spacing-wide: 0.025em; // Wider for headings
+$letter-spacing-wider: 0.04em; // Even wider for large headings
 
 // ===== HEADING SIZES =====
 $heading-h1-size: $font-size-4xl;

--- a/frontend/src/styles/mixins/_button-variants.scss
+++ b/frontend/src/styles/mixins/_button-variants.scss
@@ -3,7 +3,7 @@
  * Reusable button patterns for consistent interactions
  */
 
-@use '../design-tokens' as *;
+@use "../design-tokens" as *;
 
 // ============================================================================
 // BASE BUTTON

--- a/frontend/src/styles/mixins/_card-variants.scss
+++ b/frontend/src/styles/mixins/_card-variants.scss
@@ -3,7 +3,7 @@
  * Reusable card patterns for consistent styling across the app
  */
 
-@use '../design-tokens' as *;
+@use "../design-tokens" as *;
 
 // ============================================================================
 // BASE CARD MIXINS (Building blocks)

--- a/frontend/src/styles/mixins/_form-elements.scss
+++ b/frontend/src/styles/mixins/_form-elements.scss
@@ -3,7 +3,7 @@
  * Reusable patterns for inputs, selects, textareas, etc.
  */
 
-@use '../design-tokens' as *;
+@use "../design-tokens" as *;
 
 // ============================================================================
 // BASE INPUT
@@ -105,7 +105,7 @@
     border-color: $color-interactive-primary;
 
     &::after {
-      content: '';
+      content: "";
       position: absolute;
       left: 4px;
       top: 1px;
@@ -147,7 +147,7 @@
     border-color: $color-interactive-primary;
 
     &::after {
-      content: '';
+      content: "";
       position: absolute;
       left: 3px;
       top: 3px;

--- a/frontend/src/styles/mixins/_index.scss
+++ b/frontend/src/styles/mixins/_index.scss
@@ -3,11 +3,11 @@
  * Import all mixins for use in components
  */
 
-@forward 'typography';
-@forward 'layout';
-@forward 'utilities';
-@forward 'animations';
-@forward 'card-variants';
-@forward 'button-variants';
-@forward 'form-elements';
-@forward 'page-layouts';
+@forward "typography";
+@forward "layout";
+@forward "utilities";
+@forward "animations";
+@forward "card-variants";
+@forward "button-variants";
+@forward "form-elements";
+@forward "page-layouts";

--- a/frontend/src/styles/mixins/_layout.scss
+++ b/frontend/src/styles/mixins/_layout.scss
@@ -3,7 +3,7 @@
  * Reusable layout patterns for containers, cards, and sections
  */
 
-@use '../design-tokens' as *;
+@use "../design-tokens" as *;
 
 // ===== CONTAINER =====
 @mixin container {

--- a/frontend/src/styles/mixins/_page-layouts.scss
+++ b/frontend/src/styles/mixins/_page-layouts.scss
@@ -3,7 +3,7 @@
  * Common page structure patterns for consistency
  */
 
-@use '../design-tokens' as *;
+@use "../design-tokens" as *;
 
 // ============================================================================
 // PAGE CONTAINERS

--- a/frontend/src/styles/mixins/_typography.scss
+++ b/frontend/src/styles/mixins/_typography.scss
@@ -3,7 +3,7 @@
  * Reusable typography styles for headings, body text, and links
  */
 
-@use '../design-tokens' as *;
+@use "../design-tokens" as *;
 
 // ===== HEADING MIXINS =====
 @mixin heading-h1 {
@@ -118,7 +118,9 @@
   text-decoration: underline;
   text-decoration-thickness: 1px;
   text-underline-offset: 2px;
-  transition: color 0.2s ease, text-decoration-color 0.2s ease;
+  transition:
+    color 0.2s ease,
+    text-decoration-color 0.2s ease;
 
   &:hover {
     color: $color-primary-hover;

--- a/frontend/src/styles/mixins/_utilities.scss
+++ b/frontend/src/styles/mixins/_utilities.scss
@@ -3,7 +3,7 @@
  * Reusable utilities for hover, focus, transitions, and common patterns
  */
 
-@use '../design-tokens' as *;
+@use "../design-tokens" as *;
 
 // ===== TRANSITIONS =====
 @mixin transition-default {
@@ -19,12 +19,17 @@
 }
 
 @mixin transition-colors {
-  transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+  transition:
+    color 0.2s ease,
+    background-color 0.2s ease,
+    border-color 0.2s ease;
 }
 
 // ===== HOVER STATES =====
 @mixin hover-lift {
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
 
   &:hover {
     transform: translateY(-2px);
@@ -53,7 +58,7 @@
   text-decoration: none;
 
   &::after {
-    content: '';
+    content: "";
     position: absolute;
     bottom: 0;
     left: 0;

--- a/frontend/src/styles/themes.scss
+++ b/frontend/src/styles/themes.scss
@@ -7,7 +7,7 @@
  * OS preference when no explicit choice is stored.
  */
 
-@use 'design-tokens' as *;
+@use "design-tokens" as *;
 
 :root {
   color-scheme: light;
@@ -193,66 +193,66 @@
   color-scheme: dark;
 
   // === PAGE STRUCTURE ===
-  --color-page-bg: #1B1D22;
-  --color-page-bg-gradient-start: #1B1D22;
-  --color-page-bg-gradient-end: #1E2127;
-  --color-page-bg-alt: #22252B;
+  --color-page-bg: #1b1d22;
+  --color-page-bg-gradient-start: #1b1d22;
+  --color-page-bg-gradient-end: #1e2127;
+  --color-page-bg-alt: #22252b;
 
   // === SURFACES ===
-  --color-surface-default: #24272E;
-  --color-surface-secondary: #22252B;
-  --color-surface-tertiary: #2A2D34;
-  --color-surface-elevated: #282C34;
-  --color-surface-hover: #2C3038;
-  --color-surface-cool: #262B33;
-  --color-surface-hover-cool: #2A313A;
+  --color-surface-default: #24272e;
+  --color-surface-secondary: #22252b;
+  --color-surface-tertiary: #2a2d34;
+  --color-surface-elevated: #282c34;
+  --color-surface-hover: #2c3038;
+  --color-surface-cool: #262b33;
+  --color-surface-hover-cool: #2a313a;
 
   // === TEXT ===
-  --color-text-primary: #E8E9EC;
-  --color-text-secondary: #B4B7BE;
-  --color-text-tertiary: #8F929A;
-  --color-text-heading: #DDDEE2;
-  --color-text-disabled: #6E7178;
-  --color-text-inverse: #1B1D22;
-  --color-text-warm: #48453D;
+  --color-text-primary: #e8e9ec;
+  --color-text-secondary: #b4b7be;
+  --color-text-tertiary: #8f929a;
+  --color-text-heading: #dddee2;
+  --color-text-disabled: #6e7178;
+  --color-text-inverse: #1b1d22;
+  --color-text-warm: #48453d;
 
   // === BORDERS ===
-  --color-border-default: #34373F;
-  --color-border-subtle: #2E3138;
-  --color-border-strong: #565A64;
-  --color-border-hover: #6B7078;
-  --color-border-cool: #3A4250;
+  --color-border-default: #34373f;
+  --color-border-subtle: #2e3138;
+  --color-border-strong: #565a64;
+  --color-border-hover: #6b7078;
+  --color-border-cool: #3a4250;
 
   // === INTERACTIVE: PRIMARY (phosphor orange) ===
   --color-interactive-primary: #{$orange-500};
   --color-interactive-primary-hover: #{$orange-400};
   --color-interactive-primary-active: #{$orange-300};
-  --color-interactive-primary-text: #1B1D22;
-  --color-interactive-primary-bg-subtle: #3A2A1E;
+  --color-interactive-primary-text: #1b1d22;
+  --color-interactive-primary-bg-subtle: #3a2a1e;
   --color-interactive-primary-focus: #{$orange-400};
 
   // === INTERACTIVE: SECONDARY ===
   --color-interactive-secondary: #{$terracotta-500};
   --color-interactive-secondary-hover: #{$terracotta-400};
   --color-interactive-secondary-active: #{$terracotta-300};
-  --color-interactive-secondary-text: #1B1D22;
+  --color-interactive-secondary-text: #1b1d22;
   --color-interactive-secondary-bg: #362420;
 
   --color-interactive-secondary-cool: #{$teal-500};
   --color-interactive-secondary-cool-hover: #{$teal-400};
   --color-interactive-secondary-cool-active: #{$teal-300};
-  --color-interactive-secondary-cool-text: #1B1D22;
-  --color-interactive-secondary-cool-bg: #1E2E2B;
+  --color-interactive-secondary-cool-text: #1b1d22;
+  --color-interactive-secondary-cool-bg: #1e2e2b;
 
   // === INTERACTIVE: TERTIARY / GHOST ===
-  --color-interactive-tertiary: #2A2D34;
-  --color-interactive-tertiary-hover: #34373F;
-  --color-interactive-tertiary-active: #3E424B;
-  --color-interactive-tertiary-text: #D5D6DA;
-  --color-interactive-tertiary-bg: #2A2D34;
+  --color-interactive-tertiary: #2a2d34;
+  --color-interactive-tertiary-hover: #34373f;
+  --color-interactive-tertiary-active: #3e424b;
+  --color-interactive-tertiary-text: #d5d6da;
+  --color-interactive-tertiary-bg: #2a2d34;
 
   --color-interactive-ghost: transparent;
-  --color-interactive-ghost-hover: #3A2A1E;
+  --color-interactive-ghost-hover: #3a2a1e;
   --color-interactive-ghost-text: #{$orange-400};
   --color-interactive-ghost-text-hover: #{$orange-300};
 
@@ -267,377 +267,377 @@
   --color-link-cool-visited: #{$slate-blue-400};
 
   // === SEMANTIC STATES ===
-  --color-success-bg: #24312A;
+  --color-success-bg: #24312a;
   --color-success-border: #{$sage-600};
   --color-success-text: #{$sage-400};
 
-  --color-warning-bg: #322B1C;
+  --color-warning-bg: #322b1c;
   --color-warning-border: #{$mustard-600};
   --color-warning-text: #{$mustard-400};
 
-  --color-error-bg: #33211F;
+  --color-error-bg: #33211f;
   --color-error-border: #{$red-600};
-  --color-error-text: #E89B94;
+  --color-error-text: #e89b94;
 
-  --color-info-bg: #22303C;
+  --color-info-bg: #22303c;
   --color-info-border: #{$dusty-blue-700};
   --color-info-text: #{$dusty-blue-300};
 
-  --color-info-cool-bg: #262E3A;
+  --color-info-cool-bg: #262e3a;
   --color-info-cool-border: #{$slate-blue-700};
   --color-info-cool-text: #{$slate-blue-300};
 
   // === BADGES ===
-  --color-badge-article-bg: #3A2A1E;
+  --color-badge-article-bg: #3a2a1e;
   --color-badge-article-text: #{$orange-300};
   --color-badge-article-border: #{$orange-800};
 
-  --color-badge-note-bg: #2A2D34;
-  --color-badge-note-text: #B4B7BE;
-  --color-badge-note-border: #565A64;
+  --color-badge-note-bg: #2a2d34;
+  --color-badge-note-text: #b4b7be;
+  --color-badge-note-border: #565a64;
 
-  --color-badge-note-cool-bg: #1E2E2B;
+  --color-badge-note-cool-bg: #1e2e2b;
   --color-badge-note-cool-text: #{$teal-300};
   --color-badge-note-cool-border: #{$teal-800};
 
   // === TAGS ===
-  --color-tag-article-bg: #22303C;
+  --color-tag-article-bg: #22303c;
   --color-tag-article-text: #{$dusty-blue-300};
   --color-tag-article-border: #{$dusty-blue-700};
   --color-tag-article-hover-bg: #28394a;
   --color-tag-article-hover-text: #{$dusty-blue-200};
   --color-tag-article-hover-border: #{$dusty-blue-600};
 
-  --color-tag-note-bg: #1E2E2B;
+  --color-tag-note-bg: #1e2e2b;
   --color-tag-note-text: #{$teal-300};
   --color-tag-note-border: #{$teal-800};
-  --color-tag-note-hover-bg: #24413B;
+  --color-tag-note-hover-bg: #24413b;
   --color-tag-note-hover-text: #{$teal-200};
   --color-tag-note-hover-border: #{$teal-600};
 
   // === FORM ELEMENTS ===
-  --color-input-bg: #22252B;
-  --color-input-border: #34373F;
-  --color-input-border-hover: #565A64;
+  --color-input-bg: #22252b;
+  --color-input-border: #34373f;
+  --color-input-border-hover: #565a64;
   --color-input-border-focus: #{$orange-400};
-  --color-input-text: #E8E9EC;
-  --color-input-placeholder: #8F929A;
-  --color-input-disabled-bg: #2A2D34;
-  --color-input-disabled-text: #6E7178;
+  --color-input-text: #e8e9ec;
+  --color-input-placeholder: #8f929a;
+  --color-input-disabled-bg: #2a2d34;
+  --color-input-disabled-text: #6e7178;
 
   // === QUICK LISTS ===
-  --color-orphan-bg: #322B1C;
-  --color-orphan-border: #4A4128;
+  --color-orphan-bg: #322b1c;
+  --color-orphan-border: #4a4128;
   --color-orphan-text: #{$mustard-400};
   --color-orphan-heading: #{$mustard-300};
-  --color-orphan-hover: #3A3222;
+  --color-orphan-hover: #3a3222;
 
-  --color-hub-bg: #22303C;
-  --color-hub-border: #2E4152;
+  --color-hub-bg: #22303c;
+  --color-hub-border: #2e4152;
   --color-hub-text: #{$dusty-blue-400};
   --color-hub-heading: #{$dusty-blue-300};
   --color-hub-hover: #283848;
 
   --color-central-bg: #362420;
-  --color-central-border: #4A322C;
+  --color-central-border: #4a322c;
   --color-central-text: #{$terracotta-400};
   --color-central-heading: #{$terracotta-300};
-  --color-central-hover: #3E2A25;
+  --color-central-hover: #3e2a25;
 
-  --color-stale-bg: #262E3A;
+  --color-stale-bg: #262e3a;
   --color-stale-border: #364154;
   --color-stale-text: #{$slate-blue-400};
   --color-stale-heading: #{$slate-blue-300};
-  --color-stale-hover: #2C3542;
+  --color-stale-hover: #2c3542;
 
   // === SOCIAL ===
-  --color-social-github-bg: #2A2D34;
-  --color-social-github-bg-hover: #34373F;
-  --color-social-github-text: #E8E9EC;
+  --color-social-github-bg: #2a2d34;
+  --color-social-github-bg-hover: #34373f;
+  --color-social-github-text: #e8e9ec;
   --color-social-linkedin-bg: #{$slate-blue-700};
   --color-social-linkedin-bg-hover: #{$slate-blue-600};
-  --color-social-linkedin-text: #E8E9EC;
-  --color-social-email-bg: #2A2D34;
-  --color-social-email-bg-hover: #34373F;
-  --color-social-email-text: #E8E9EC;
+  --color-social-linkedin-text: #e8e9ec;
+  --color-social-email-bg: #2a2d34;
+  --color-social-email-bg-hover: #34373f;
+  --color-social-email-text: #e8e9ec;
   --color-social-email-border: #454952;
 
   // === DISABLED ===
-  --color-disabled-bg: #3E424B;
-  --color-disabled-text: #6E7178;
+  --color-disabled-bg: #3e424b;
+  --color-disabled-text: #6e7178;
 
   // === NEUTRAL RAMP (flipped) ===
-  --neutral-50: #22252B;
-  --neutral-100: #262A31;
-  --neutral-200: #34373F;
+  --neutral-50: #22252b;
+  --neutral-100: #262a31;
+  --neutral-200: #34373f;
   --neutral-300: #454952;
-  --neutral-400: #8A8E98;
-  --neutral-500: #A5A8B0;
-  --neutral-600: #C0C2C8;
-  --neutral-700: #D5D6DA;
-  --neutral-800: #E8E9EC;
-  --neutral-900: #F4F4F6;
-  --white: #24272E;
-  --gray-50: #22252B;
-  --gray-100: #262A31;
+  --neutral-400: #8a8e98;
+  --neutral-500: #a5a8b0;
+  --neutral-600: #c0c2c8;
+  --neutral-700: #d5d6da;
+  --neutral-800: #e8e9ec;
+  --neutral-900: #f4f4f6;
+  --white: #24272e;
+  --gray-50: #22252b;
+  --gray-100: #262a31;
 
   // === BACKWARD-COMPAT ALIASES ===
-  --color-bg-canvas: #1B1D22;
-  --color-bg-secondary: #2A2D34;
-  --color-bg-card: #24272E;
-  --color-bg-cool: #1B1D22;
-  --color-border: #34373F;
+  --color-bg-canvas: #1b1d22;
+  --color-bg-secondary: #2a2d34;
+  --color-bg-card: #24272e;
+  --color-bg-cool: #1b1d22;
+  --color-border: #34373f;
   --color-primary: #{$orange-500};
   --color-primary-hover: #{$orange-400};
   --color-primary-active: #{$orange-300};
-  --color-primary-light: #3A2A1E;
+  --color-primary-light: #3a2a1e;
   --color-primary-dark: #{$orange-300};
   --color-secondary: #{$terracotta-400};
   --color-secondary-hover: #{$terracotta-300};
   --color-secondary-light: #362420;
   --color-accent-blue: #{$dusty-blue-400};
-  --color-accent-blue-light: #22303C;
-  --color-accent-blue-border: #2E4152;
+  --color-accent-blue-light: #22303c;
+  --color-accent-blue-border: #2e4152;
   --color-accent-blue-dark: #{$dusty-blue-300};
   --color-accent-purple: #{$terracotta-400};
   --color-accent-purple-light: #362420;
-  --color-accent-purple-border: #4A322C;
+  --color-accent-purple-border: #4a322c;
   --color-accent-purple-dark: #{$terracotta-300};
   --color-success: #{$sage-400};
   --color-warning: #{$mustard-400};
   --color-info: #{$dusty-blue-300};
 
   // === KB HEADER ZONE ===
-  --color-header-bg-start: #262B33;
-  --color-header-bg-mid: #22262D;
-  --color-header-bg-end: #1E2127;
-  --color-header-border: #34373F;
+  --color-header-bg-start: #262b33;
+  --color-header-bg-mid: #22262d;
+  --color-header-bg-end: #1e2127;
+  --color-header-border: #34373f;
 }
 
 // Dark theme: OS preference, when the user has not chosen explicitly
 @media (prefers-color-scheme: dark) {
-  :root:not([data-theme='light']) {
+  :root:not([data-theme="light"]) {
     color-scheme: dark;
-  
+
     // === PAGE STRUCTURE ===
-    --color-page-bg: #1B1D22;
-    --color-page-bg-gradient-start: #1B1D22;
-    --color-page-bg-gradient-end: #1E2127;
-    --color-page-bg-alt: #22252B;
-  
+    --color-page-bg: #1b1d22;
+    --color-page-bg-gradient-start: #1b1d22;
+    --color-page-bg-gradient-end: #1e2127;
+    --color-page-bg-alt: #22252b;
+
     // === SURFACES ===
-    --color-surface-default: #24272E;
-    --color-surface-secondary: #22252B;
-    --color-surface-tertiary: #2A2D34;
-    --color-surface-elevated: #282C34;
-    --color-surface-hover: #2C3038;
-    --color-surface-cool: #262B33;
-    --color-surface-hover-cool: #2A313A;
-  
+    --color-surface-default: #24272e;
+    --color-surface-secondary: #22252b;
+    --color-surface-tertiary: #2a2d34;
+    --color-surface-elevated: #282c34;
+    --color-surface-hover: #2c3038;
+    --color-surface-cool: #262b33;
+    --color-surface-hover-cool: #2a313a;
+
     // === TEXT ===
-    --color-text-primary: #E8E9EC;
-    --color-text-secondary: #B4B7BE;
-    --color-text-tertiary: #8F929A;
-    --color-text-heading: #DDDEE2;
-    --color-text-disabled: #6E7178;
-    --color-text-inverse: #1B1D22;
-    --color-text-warm: #48453D;
-  
+    --color-text-primary: #e8e9ec;
+    --color-text-secondary: #b4b7be;
+    --color-text-tertiary: #8f929a;
+    --color-text-heading: #dddee2;
+    --color-text-disabled: #6e7178;
+    --color-text-inverse: #1b1d22;
+    --color-text-warm: #48453d;
+
     // === BORDERS ===
-    --color-border-default: #34373F;
-    --color-border-subtle: #2E3138;
-    --color-border-strong: #565A64;
-    --color-border-hover: #6B7078;
-    --color-border-cool: #3A4250;
-  
+    --color-border-default: #34373f;
+    --color-border-subtle: #2e3138;
+    --color-border-strong: #565a64;
+    --color-border-hover: #6b7078;
+    --color-border-cool: #3a4250;
+
     // === INTERACTIVE: PRIMARY (phosphor orange) ===
     --color-interactive-primary: #{$orange-500};
     --color-interactive-primary-hover: #{$orange-400};
     --color-interactive-primary-active: #{$orange-300};
-    --color-interactive-primary-text: #1B1D22;
-    --color-interactive-primary-bg-subtle: #3A2A1E;
+    --color-interactive-primary-text: #1b1d22;
+    --color-interactive-primary-bg-subtle: #3a2a1e;
     --color-interactive-primary-focus: #{$orange-400};
-  
+
     // === INTERACTIVE: SECONDARY ===
     --color-interactive-secondary: #{$terracotta-500};
     --color-interactive-secondary-hover: #{$terracotta-400};
     --color-interactive-secondary-active: #{$terracotta-300};
-    --color-interactive-secondary-text: #1B1D22;
+    --color-interactive-secondary-text: #1b1d22;
     --color-interactive-secondary-bg: #362420;
-  
+
     --color-interactive-secondary-cool: #{$teal-500};
     --color-interactive-secondary-cool-hover: #{$teal-400};
     --color-interactive-secondary-cool-active: #{$teal-300};
-    --color-interactive-secondary-cool-text: #1B1D22;
-    --color-interactive-secondary-cool-bg: #1E2E2B;
-  
+    --color-interactive-secondary-cool-text: #1b1d22;
+    --color-interactive-secondary-cool-bg: #1e2e2b;
+
     // === INTERACTIVE: TERTIARY / GHOST ===
-    --color-interactive-tertiary: #2A2D34;
-    --color-interactive-tertiary-hover: #34373F;
-    --color-interactive-tertiary-active: #3E424B;
-    --color-interactive-tertiary-text: #D5D6DA;
-    --color-interactive-tertiary-bg: #2A2D34;
-  
+    --color-interactive-tertiary: #2a2d34;
+    --color-interactive-tertiary-hover: #34373f;
+    --color-interactive-tertiary-active: #3e424b;
+    --color-interactive-tertiary-text: #d5d6da;
+    --color-interactive-tertiary-bg: #2a2d34;
+
     --color-interactive-ghost: transparent;
-    --color-interactive-ghost-hover: #3A2A1E;
+    --color-interactive-ghost-hover: #3a2a1e;
     --color-interactive-ghost-text: #{$orange-400};
     --color-interactive-ghost-text-hover: #{$orange-300};
-  
+
     // === LINKS (phosphor amber) ===
     --color-link-default: #{$orange-400};
     --color-link-hover: #{$orange-300};
     --color-link-visited: #{$terracotta-400};
     --color-link-active: #{$orange-200};
-  
+
     --color-link-cool: #{$teal-400};
     --color-link-cool-hover: #{$teal-300};
     --color-link-cool-visited: #{$slate-blue-400};
-  
+
     // === SEMANTIC STATES ===
-    --color-success-bg: #24312A;
+    --color-success-bg: #24312a;
     --color-success-border: #{$sage-600};
     --color-success-text: #{$sage-400};
-  
-    --color-warning-bg: #322B1C;
+
+    --color-warning-bg: #322b1c;
     --color-warning-border: #{$mustard-600};
     --color-warning-text: #{$mustard-400};
-  
-    --color-error-bg: #33211F;
+
+    --color-error-bg: #33211f;
     --color-error-border: #{$red-600};
-    --color-error-text: #E89B94;
-  
-    --color-info-bg: #22303C;
+    --color-error-text: #e89b94;
+
+    --color-info-bg: #22303c;
     --color-info-border: #{$dusty-blue-700};
     --color-info-text: #{$dusty-blue-300};
-  
-    --color-info-cool-bg: #262E3A;
+
+    --color-info-cool-bg: #262e3a;
     --color-info-cool-border: #{$slate-blue-700};
     --color-info-cool-text: #{$slate-blue-300};
-  
+
     // === BADGES ===
-    --color-badge-article-bg: #3A2A1E;
+    --color-badge-article-bg: #3a2a1e;
     --color-badge-article-text: #{$orange-300};
     --color-badge-article-border: #{$orange-800};
-  
-    --color-badge-note-bg: #2A2D34;
-    --color-badge-note-text: #B4B7BE;
-    --color-badge-note-border: #565A64;
-  
-    --color-badge-note-cool-bg: #1E2E2B;
+
+    --color-badge-note-bg: #2a2d34;
+    --color-badge-note-text: #b4b7be;
+    --color-badge-note-border: #565a64;
+
+    --color-badge-note-cool-bg: #1e2e2b;
     --color-badge-note-cool-text: #{$teal-300};
     --color-badge-note-cool-border: #{$teal-800};
-  
+
     // === TAGS ===
-    --color-tag-article-bg: #22303C;
+    --color-tag-article-bg: #22303c;
     --color-tag-article-text: #{$dusty-blue-300};
     --color-tag-article-border: #{$dusty-blue-700};
     --color-tag-article-hover-bg: #28394a;
     --color-tag-article-hover-text: #{$dusty-blue-200};
     --color-tag-article-hover-border: #{$dusty-blue-600};
-  
-    --color-tag-note-bg: #1E2E2B;
+
+    --color-tag-note-bg: #1e2e2b;
     --color-tag-note-text: #{$teal-300};
     --color-tag-note-border: #{$teal-800};
-    --color-tag-note-hover-bg: #24413B;
+    --color-tag-note-hover-bg: #24413b;
     --color-tag-note-hover-text: #{$teal-200};
     --color-tag-note-hover-border: #{$teal-600};
-  
+
     // === FORM ELEMENTS ===
-    --color-input-bg: #22252B;
-    --color-input-border: #34373F;
-    --color-input-border-hover: #565A64;
+    --color-input-bg: #22252b;
+    --color-input-border: #34373f;
+    --color-input-border-hover: #565a64;
     --color-input-border-focus: #{$orange-400};
-    --color-input-text: #E8E9EC;
-    --color-input-placeholder: #8F929A;
-    --color-input-disabled-bg: #2A2D34;
-    --color-input-disabled-text: #6E7178;
-  
+    --color-input-text: #e8e9ec;
+    --color-input-placeholder: #8f929a;
+    --color-input-disabled-bg: #2a2d34;
+    --color-input-disabled-text: #6e7178;
+
     // === QUICK LISTS ===
-    --color-orphan-bg: #322B1C;
-    --color-orphan-border: #4A4128;
+    --color-orphan-bg: #322b1c;
+    --color-orphan-border: #4a4128;
     --color-orphan-text: #{$mustard-400};
     --color-orphan-heading: #{$mustard-300};
-    --color-orphan-hover: #3A3222;
-  
-    --color-hub-bg: #22303C;
-    --color-hub-border: #2E4152;
+    --color-orphan-hover: #3a3222;
+
+    --color-hub-bg: #22303c;
+    --color-hub-border: #2e4152;
     --color-hub-text: #{$dusty-blue-400};
     --color-hub-heading: #{$dusty-blue-300};
     --color-hub-hover: #283848;
-  
+
     --color-central-bg: #362420;
-    --color-central-border: #4A322C;
+    --color-central-border: #4a322c;
     --color-central-text: #{$terracotta-400};
     --color-central-heading: #{$terracotta-300};
-    --color-central-hover: #3E2A25;
-  
-    --color-stale-bg: #262E3A;
+    --color-central-hover: #3e2a25;
+
+    --color-stale-bg: #262e3a;
     --color-stale-border: #364154;
     --color-stale-text: #{$slate-blue-400};
     --color-stale-heading: #{$slate-blue-300};
-    --color-stale-hover: #2C3542;
-  
+    --color-stale-hover: #2c3542;
+
     // === SOCIAL ===
-    --color-social-github-bg: #2A2D34;
-    --color-social-github-bg-hover: #34373F;
-    --color-social-github-text: #E8E9EC;
+    --color-social-github-bg: #2a2d34;
+    --color-social-github-bg-hover: #34373f;
+    --color-social-github-text: #e8e9ec;
     --color-social-linkedin-bg: #{$slate-blue-700};
     --color-social-linkedin-bg-hover: #{$slate-blue-600};
-    --color-social-linkedin-text: #E8E9EC;
-    --color-social-email-bg: #2A2D34;
-    --color-social-email-bg-hover: #34373F;
-    --color-social-email-text: #E8E9EC;
+    --color-social-linkedin-text: #e8e9ec;
+    --color-social-email-bg: #2a2d34;
+    --color-social-email-bg-hover: #34373f;
+    --color-social-email-text: #e8e9ec;
     --color-social-email-border: #454952;
-  
+
     // === DISABLED ===
-    --color-disabled-bg: #3E424B;
-    --color-disabled-text: #6E7178;
-  
+    --color-disabled-bg: #3e424b;
+    --color-disabled-text: #6e7178;
+
     // === NEUTRAL RAMP (flipped) ===
-    --neutral-50: #22252B;
-    --neutral-100: #262A31;
-    --neutral-200: #34373F;
+    --neutral-50: #22252b;
+    --neutral-100: #262a31;
+    --neutral-200: #34373f;
     --neutral-300: #454952;
-    --neutral-400: #8A8E98;
-    --neutral-500: #A5A8B0;
-    --neutral-600: #C0C2C8;
-    --neutral-700: #D5D6DA;
-    --neutral-800: #E8E9EC;
-    --neutral-900: #F4F4F6;
-    --white: #24272E;
-    --gray-50: #22252B;
-    --gray-100: #262A31;
-  
+    --neutral-400: #8a8e98;
+    --neutral-500: #a5a8b0;
+    --neutral-600: #c0c2c8;
+    --neutral-700: #d5d6da;
+    --neutral-800: #e8e9ec;
+    --neutral-900: #f4f4f6;
+    --white: #24272e;
+    --gray-50: #22252b;
+    --gray-100: #262a31;
+
     // === BACKWARD-COMPAT ALIASES ===
-    --color-bg-canvas: #1B1D22;
-    --color-bg-secondary: #2A2D34;
-    --color-bg-card: #24272E;
-    --color-bg-cool: #1B1D22;
-    --color-border: #34373F;
+    --color-bg-canvas: #1b1d22;
+    --color-bg-secondary: #2a2d34;
+    --color-bg-card: #24272e;
+    --color-bg-cool: #1b1d22;
+    --color-border: #34373f;
     --color-primary: #{$orange-500};
     --color-primary-hover: #{$orange-400};
     --color-primary-active: #{$orange-300};
-    --color-primary-light: #3A2A1E;
+    --color-primary-light: #3a2a1e;
     --color-primary-dark: #{$orange-300};
     --color-secondary: #{$terracotta-400};
     --color-secondary-hover: #{$terracotta-300};
     --color-secondary-light: #362420;
     --color-accent-blue: #{$dusty-blue-400};
-    --color-accent-blue-light: #22303C;
-    --color-accent-blue-border: #2E4152;
+    --color-accent-blue-light: #22303c;
+    --color-accent-blue-border: #2e4152;
     --color-accent-blue-dark: #{$dusty-blue-300};
     --color-accent-purple: #{$terracotta-400};
     --color-accent-purple-light: #362420;
-    --color-accent-purple-border: #4A322C;
+    --color-accent-purple-border: #4a322c;
     --color-accent-purple-dark: #{$terracotta-300};
     --color-success: #{$sage-400};
     --color-warning: #{$mustard-400};
     --color-info: #{$dusty-blue-300};
-  
+
     // === KB HEADER ZONE ===
-    --color-header-bg-start: #262B33;
-    --color-header-bg-mid: #22262D;
-    --color-header-bg-end: #1E2127;
-    --color-header-border: #34373F;
+    --color-header-bg-start: #262b33;
+    --color-header-bg-mid: #22262d;
+    --color-header-bg-end: #1e2127;
+    --color-header-border: #34373f;
   }
 }

--- a/frontend/src/styles/typography.module.scss
+++ b/frontend/src/styles/typography.module.scss
@@ -3,8 +3,8 @@
  * Reusable typography styles for headings, body text, and links
  */
 
-@use 'mixins' as *;
-@use 'design-tokens' as *;
+@use "mixins" as *;
+@use "design-tokens" as *;
 
 // ===== HEADINGS =====
 .h1 {

--- a/frontend/src/styles/utilities.scss
+++ b/frontend/src/styles/utilities.scss
@@ -4,7 +4,7 @@
  * Use sparingly - prefer component-specific styles in CSS modules
  */
 
-@use 'design-tokens' as *;
+@use "design-tokens" as *;
 
 // ===== DISPLAY =====
 .flex {


### PR DESCRIPTION
## Summary

Closes out the design-system consistency work plus production feedback on the graph.

### #202 — consistency sweep (`c85498a`)
- All UI-chrome emoji replaced with Phosphor icons (editor tips, AI panels, settings, template selector, toast, inspire, quick lists, article metadata, wikilink chips)
- Legacy `$blue/$green/$yellow/$gray` tokens swept to Tier 2 semantic tokens (editor, AI panels, admin toggle, auth banner, TOC, project tiles, search highlights)
- `notes/[id]`: dead Tailwind utility classes (Tailwind isn't installed) converted to the module's scss classes — zero-links modal and edit form were rendering unstyled
- NoteEditor (CodeMirror) follows the active theme via new `useResolvedTheme` hook — no more white editor in dark mode
- Article page uses the shared theme-aware KB header gradient (fixes the light header / unreadable title in dark mode reported from prod)
- Inspire header/buttons aligned with the design system (orange primary, standard heading colors)
- `mark` highlights pin dark text on light mustard in both themes

### #203 — 'Show N more' chip contrast (`d207b33`)
Styled like the other filter chips; `$color-link-hover` text is the only orange step clearing 4.5:1 on the chip surface in both themes.

### Graph deselect (prod feedback on #201) (`e33bc02`)
- Clicking anywhere in the canvas that isn't a node deselects (was only the literal svg background)
- Deselect button and background clicks clear a stale `?node=` param via `router.replace` so another node can be selected

### Hydration fix (`096350a`)
`useFeatureFlags` started its fetch during render; a fast backend updated the store before hydration finished, so the client tree (AIButton) mismatched the server HTML — the "1 Issue" dev overlay on every KB page. Fetch now starts after mount.

### Graph nav link (`615244f`)
"Graph" added to the top navigation with its own active state (Notes no longer claims the graph route). No overflow at 390px.

## Testing
- Typecheck, ESLint, 55/55 frontend unit tests pass
- Live-verified graph interactions with Playwright: select, deselect (button/background/URL-param flows), double-click navigation — 8/8 pass
- Screenshot-verified light + dark themes: article page, notes list, note editor, inspire, nav (desktop + 390px)