### PR TITLE
Perf: code-split heavy components and prefetch on user intent (fixes #179)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -203,9 +203,13 @@ class CacheControlMiddleware(BaseHTTPMiddleware):
 
         # API responses - respect explicit cache headers, add defaults otherwise
         elif request.url.path.startswith("/api/") and "Cache-Control" not in response.headers:
-            # Allow browser to cache list/read operations for 60 seconds
+            # Allow browser to cache list/read operations for 60 seconds;
+            # serve stale while revalidating so refreshes never block on the
+            # network for content that just changed underneath
             if request.method == "GET":
-                response.headers["Cache-Control"] = "public, max-age=60"
+                response.headers["Cache-Control"] = (
+                    "public, max-age=60, stale-while-revalidate=300"
+                )
             else:
                 response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
 

--- a/frontend/src/app/knowledge-base/articles/[id]/page.tsx
+++ b/frontend/src/app/knowledge-base/articles/[id]/page.tsx
@@ -4,9 +4,13 @@ import { useEffect, useState } from "react";
 import { CalendarBlank, PencilSimple, NotePencil } from "@phosphor-icons/react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
-import MarkdownWithWikilinks from "@/components/MarkdownWithWikilinks";
+import dynamic from "next/dynamic";
+
+const AIPanel = dynamic(() => import("@/components/AIPanel"), { ssr: false });
+// Fallback renderer only; articles normally arrive as pre-rendered HTML,
+// so keep the react-markdown stack out of the first load
+const MarkdownWithWikilinks = dynamic(() => import("@/components/MarkdownWithWikilinks"));
 import ArticleTableOfContents from "@/components/ArticleTableOfContents";
-import AIPanel from "@/components/AIPanel";
 import AIButton from "@/components/AIButton";
 import Breadcrumb from "@/components/Breadcrumb";
 import Badge from "@/components/Badge";

--- a/frontend/src/app/knowledge-base/articles/page.tsx
+++ b/frontend/src/app/knowledge-base/articles/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { prefetchOnce } from "@/lib/prefetch";
 
 import { Suspense } from "react";
 import { useState, useEffect, useCallback } from "react";
@@ -7,6 +8,12 @@ import dynamic from "next/dynamic";
 
 const AIPanel = dynamic(() => import("@/components/AIPanel"), { ssr: false });
 const MarkdownWithWikilinks = dynamic(() => import("@/components/MarkdownWithWikilinks"));
+
+// Warm the browser HTTP cache with the article the user is about to open
+function prefetchArticle(id: number | string): void {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+  prefetchOnce(`article:${id}`, () => fetch(`${apiUrl}/api/articles/${id}`));
+}
 import { useRouter, useSearchParams } from "next/navigation";
 import { logger } from "@/lib/logger";
 import AIButton from "@/components/AIButton";
@@ -332,6 +339,8 @@ function ArticlesContent() {
                       key={resource.id}
                       href={`/knowledge-base/articles/${resource.id}`}
                       className={`${styles.articleCard} ${resource.draft ? styles.draftCard : ""}`}
+                      onMouseEnter={() => prefetchArticle(resource.id)}
+                      onFocus={() => prefetchArticle(resource.id)}
                     >
                       <div className={styles.articleHeader}>
                         <div className={styles.titleRow}>

--- a/frontend/src/app/knowledge-base/articles/page.tsx
+++ b/frontend/src/app/knowledge-base/articles/page.tsx
@@ -3,10 +3,12 @@
 import { Suspense } from "react";
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
+import dynamic from "next/dynamic";
+
+const AIPanel = dynamic(() => import("@/components/AIPanel"), { ssr: false });
+const MarkdownWithWikilinks = dynamic(() => import("@/components/MarkdownWithWikilinks"));
 import { useRouter, useSearchParams } from "next/navigation";
 import { logger } from "@/lib/logger";
-import MarkdownWithWikilinks from "@/components/MarkdownWithWikilinks";
-import AIPanel from "@/components/AIPanel";
 import AIButton from "@/components/AIButton";
 import Breadcrumb from "@/components/Breadcrumb";
 import { TagPillList } from "@/components/TagPill";

--- a/frontend/src/app/knowledge-base/notes/[id]/page.tsx
+++ b/frontend/src/app/knowledge-base/notes/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { Sparkle } from "@phosphor-icons/react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
+import { prefetchOnce } from "@/lib/prefetch";
 import dynamic from "next/dynamic";
 
 // Heavy editor (CodeMirror) and AI panels load on demand, not in first-load JS
@@ -441,6 +442,9 @@ export default function NoteDetailPage() {
                   </Link>
                   <button
                     onClick={() => setIsEditing(true)}
+                    onMouseEnter={() =>
+                      prefetchOnce("chunk:note-editor", () => import("@/components/NoteEditor"))
+                    }
                     className={`${styles.button} ${styles.editButton}`}
                     aria-label="Edit this note"
                   >

--- a/frontend/src/app/knowledge-base/notes/[id]/page.tsx
+++ b/frontend/src/app/knowledge-base/notes/[id]/page.tsx
@@ -4,12 +4,22 @@ import { useEffect, useState } from "react";
 import { Sparkle } from "@phosphor-icons/react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
-import NoteEditor from "@/components/NoteEditor";
-import MarkdownWithWikilinks from "@/components/MarkdownWithWikilinks";
-import AIPanel from "@/components/AIPanel";
+import dynamic from "next/dynamic";
+
+// Heavy editor (CodeMirror) and AI panels load on demand, not in first-load JS
+const NoteEditor = dynamic(() => import("@/components/NoteEditor"), {
+  ssr: false,
+  loading: () => <div style={{ minHeight: "400px" }}>Loading editor…</div>,
+});
+const AIPanel = dynamic(() => import("@/components/AIPanel"), { ssr: false });
+const MarkdownWithWikilinks = dynamic(() => import("@/components/MarkdownWithWikilinks"));
+const AISuggestionsPanel = dynamic(() => import("@/components/AISuggestionsPanel"), {
+  ssr: false,
+});
+const PostSaveAISuggestions = dynamic(() => import("@/components/PostSaveAISuggestions"), {
+  ssr: false,
+});
 import AIButton from "@/components/AIButton";
-import AISuggestionsPanel from "@/components/AISuggestionsPanel";
-import PostSaveAISuggestions from "@/components/PostSaveAISuggestions";
 import Breadcrumb from "@/components/Breadcrumb";
 import Badge from "@/components/Badge";
 import { TagPillList } from "@/components/TagPill";

--- a/frontend/src/app/knowledge-base/notes/new/page.tsx
+++ b/frontend/src/app/knowledge-base/notes/new/page.tsx
@@ -4,15 +4,25 @@ import { Suspense, useState, useEffect } from "react";
 import { ClockCounterClockwise, Lightbulb, Sparkle, X, Check } from "@phosphor-icons/react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
-import NoteEditor from "@/components/NoteEditor";
+import dynamic from "next/dynamic";
+
+// Heavy editor (CodeMirror) and AI panels load on demand, not in first-load JS
+const NoteEditor = dynamic(() => import("@/components/NoteEditor"), {
+  ssr: false,
+  loading: () => <div style={{ minHeight: "400px" }}>Loading editor…</div>,
+});
+const AIPanel = dynamic(() => import("@/components/AIPanel"), { ssr: false });
+const AISuggestionsPanel = dynamic(() => import("@/components/AISuggestionsPanel"), {
+  ssr: false,
+});
+const PostSaveAISuggestions = dynamic(() => import("@/components/PostSaveAISuggestions"), {
+  ssr: false,
+});
 import TemplateSelector from "@/components/TemplateSelector";
 import { createNote, listNotes, updateNote, getNote, Note } from "@/lib/api/notes";
 import { listTemplates, getTemplate, TemplateMetadata } from "@/lib/api/templates";
 import { logger } from "@/lib/logger";
-import AIPanel from "@/components/AIPanel";
 import AIButton from "@/components/AIButton";
-import PostSaveAISuggestions from "@/components/PostSaveAISuggestions";
-import AISuggestionsPanel from "@/components/AISuggestionsPanel";
 import { useSettings } from "@/hooks/useSettings";
 import { isAuthenticated } from "@/lib/api/client";
 import { config } from "@/lib/config";

--- a/frontend/src/app/knowledge-base/notes/page.tsx
+++ b/frontend/src/app/knowledge-base/notes/page.tsx
@@ -2,10 +2,24 @@
 
 import { Suspense } from "react";
 import { useEffect, useState } from "react";
+import { prefetchOnce } from "@/lib/prefetch";
+import { getNote, getBacklinks, getOutboundLinks } from "@/lib/api/notes";
 import Link from "next/link";
 import dynamic from "next/dynamic";
 
 const AIPanel = dynamic(() => import("@/components/AIPanel"), { ssr: false });
+
+// Warm the browser HTTP cache with everything the note page fetches on load,
+// and pull in the (code-split) editor chunk the note page may need.
+function prefetchNote(noteId: string): void {
+  prefetchOnce(`note:${noteId}`, () =>
+    Promise.all([getNote(noteId), getBacklinks(noteId), getOutboundLinks(noteId)])
+  );
+}
+
+function prefetchEditorChunk(): void {
+  prefetchOnce("chunk:note-editor", () => import("@/components/NoteEditor"));
+}
 import { useRouter, useSearchParams } from "next/navigation";
 import { listNotes, getRandomNote, Note, formatNoteDate } from "@/lib/api/notes";
 import { logger } from "@/lib/logger";
@@ -257,7 +271,12 @@ function NotesContent() {
               >
                 {randomNoteLoading ? "Loading..." : "Random Note"}
               </button>
-              <Link href="/knowledge-base/notes/new" className={styles.newNoteButton}>
+              <Link
+                href="/knowledge-base/notes/new"
+                className={styles.newNoteButton}
+                onMouseEnter={prefetchEditorChunk}
+                onFocus={prefetchEditorChunk}
+              >
                 + New Note
               </Link>
             </div>
@@ -428,6 +447,8 @@ function NotesContent() {
                       key={note.id}
                       href={`/knowledge-base/notes/${note.id}`}
                       className={styles.noteCard}
+                      onMouseEnter={() => prefetchNote(note.id)}
+                      onFocus={() => prefetchNote(note.id)}
                     >
                       <div className={styles.noteCardContent}>
                         <div className={styles.noteInfo}>

--- a/frontend/src/app/knowledge-base/notes/page.tsx
+++ b/frontend/src/app/knowledge-base/notes/page.tsx
@@ -3,10 +3,12 @@
 import { Suspense } from "react";
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import dynamic from "next/dynamic";
+
+const AIPanel = dynamic(() => import("@/components/AIPanel"), { ssr: false });
 import { useRouter, useSearchParams } from "next/navigation";
 import { listNotes, getRandomNote, Note, formatNoteDate } from "@/lib/api/notes";
 import { logger } from "@/lib/logger";
-import AIPanel from "@/components/AIPanel";
 import AIButton from "@/components/AIButton";
 import Breadcrumb from "@/components/Breadcrumb";
 import { TagPillList } from "@/components/TagPill";

--- a/frontend/src/app/knowledge-base/page.tsx
+++ b/frontend/src/app/knowledge-base/page.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import Link from "next/link";
+import dynamic from "next/dynamic";
+
+const AIPanel = dynamic(() => import("@/components/AIPanel"), { ssr: false });
 import { useState, useEffect, useRef } from "react";
-import AIPanel from "@/components/AIPanel";
 import AIButton from "@/components/AIButton";
 import Badge from "@/components/Badge";
 import { logger } from "@/lib/logger";

--- a/frontend/src/components/TopNavigation.tsx
+++ b/frontend/src/components/TopNavigation.tsx
@@ -15,6 +15,19 @@
 
 import { useState, useEffect } from "react";
 import { MagnifyingGlass } from "@phosphor-icons/react";
+import { prefetchOnce } from "@/lib/prefetch";
+
+// The graph payload (100+ notes with edges) is the slowest KB fetch; warm the
+// browser HTTP cache while the user is still hovering the nav link.
+function prefetchGraphData(): void {
+  prefetchOnce("graph:data", () => {
+    const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+    const token = localStorage.getItem("admin_token");
+    const headers: HeadersInit = { "Content-Type": "application/json" };
+    if (token) headers["Authorization"] = `Bearer ${token}`;
+    return fetch(`${apiUrl}/api/notes/graph/data`, { headers, credentials: "include" });
+  });
+}
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import Settings from "./Settings";
@@ -75,6 +88,8 @@ export default function TopNavigation() {
             <Link
               href="/knowledge-base/notes/graph"
               className={`${styles.navLink} ${isGraphSection ? styles.active : ""}`}
+              onMouseEnter={prefetchGraphData}
+              onFocus={prefetchGraphData}
             >
               Graph
             </Link>

--- a/frontend/src/lib/prefetch.ts
+++ b/frontend/src/lib/prefetch.ts
@@ -1,0 +1,19 @@
+/**
+ * Fire-and-forget data prefetching on user intent (hover/focus).
+ *
+ * The API sends `Cache-Control: public, max-age=60` on GET endpoints, so
+ * issuing the same request the target page will make warms the browser's
+ * HTTP cache — the page's own fetch then resolves instantly. Each key is
+ * only prefetched once per session (the HTTP cache handles freshness).
+ */
+
+const prefetched = new Set<string>();
+
+export function prefetchOnce(key: string, fn: () => Promise<unknown>): void {
+  if (typeof window === "undefined" || prefetched.has(key)) return;
+  prefetched.add(key);
+  fn().catch(() => {
+    // Allow a retry on the next hover if the warmup failed
+    prefetched.delete(key);
+  });
+}


### PR DESCRIPTION
## Summary

Two-part performance batch: cut first-load JS on the heavy routes, then hide the remaining latency with intent-based prefetching.

### Code splitting (`67be42e`)
Heavy client-only components load via `next/dynamic` instead of shipping in every route's first load:
- **NoteEditor** (CodeMirror, ~210 kB) — only needed in edit mode on `notes/[id]` and on `notes/new`
- **AIPanel / AISuggestionsPanel / PostSaveAISuggestions** — only render when LLM features are enabled and opened
- **MarkdownWithWikilinks** (react-markdown + remark-gfm) — fallback path on articles (backend pre-renders HTML); on notes it loads in parallel with the client-side fetch

| Route | Before | After |
|---|---|---|
| `notes/[id]` | 388 kB | **118 kB** |
| `notes/new` | 339 kB | **121 kB** |
| `articles/[id]` | 180 kB | **124 kB** |

Every route now lands in 103–130 kB first-load JS. (d3 on the graph page already tree-shakes well; react-syntax-highlighter was already dynamic.)

### Prefetch on intent (`dd08e0a`)
New `lib/prefetch.ts` warms the browser HTTP cache on hover/focus (the API serves `public, max-age=60` on GETs, so the target page's own fetch resolves instantly):
- Note cards → note + backlinks + outbound links
- Article cards → article payload
- Graph nav link → graph dataset
- "+ New Note" / Edit button → pulls in the code-split CodeMirror chunk

Backend GET cache header gains `stale-while-revalidate=300` so revalidation after the 60s window never blocks rendering.

## Testing
- Production build route table before/after (numbers above)
- Playwright live checks: all five hover-prefetch behaviors fire the right requests; note detail, editor, and article pages render correctly from the split chunks; no page errors
- Backend: ruff, mypy, 303 unit tests pass · Frontend: ESLint, tsc, 55 tests pass

## Follow-ups (separate branches)
- SWR/React Query client cache (#177)
- Article SSG/server components (deeper refactor)