### PR TITLE
infra: remove Ollama from production, embeddings via Gemini API (refs #190)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,7 +121,8 @@ jobs:
             echo "CORS_ORIGINS=$CORS_ORIGINS" >> backend/.env
             echo "OP_MONGADO_SERVICE_ACCOUNT_TOKEN=$OP_SERVICE_ACCOUNT_TOKEN" >> backend/.env
             echo "ADMIN_TOKEN=$ADMIN_PASSKEY" >> backend/.env
-            # Hosted LLM API keys (empty until the GitHub secrets are set - see issue #190)
+            # Hosted LLM API keys (#190): Groq = generation primary,
+            # Gemini = generation fallback + embeddings
             echo "GROQ_API_KEY=$GROQ_API_KEY" >> backend/.env
             echo "GEMINI_API_KEY=$GEMINI_API_KEY" >> backend/.env
 
@@ -138,9 +139,11 @@ jobs:
             export NEO4J_AUTH="neo4j/$NEO4J_PASSWORD"
 
             # Build and restart containers (without --no-cache to reduce resource usage)
+            # --remove-orphans cleans up services deleted from the compose file
+            # (e.g. the prod Ollama container removed in #190)
             echo "🐳 Building and restarting Docker containers..."
             docker compose -f docker-compose.prod.yml build
-            docker compose -f docker-compose.prod.yml up -d
+            docker compose -f docker-compose.prod.yml up -d --remove-orphans
 
             # Wait for services to be healthy
             echo "⏳ Waiting for services to be healthy..."
@@ -150,10 +153,6 @@ jobs:
             # This ensures new/updated articles are picked up immediately
             echo "🔄 Restarting backend to invalidate article cache..."
             docker compose -f docker-compose.prod.yml restart backend
-
-            # Pull Ollama model if not already present (use 1B model for 4GB RAM server)
-            echo "🤖 Setting up Ollama model..."
-            docker exec mongado-ollama-prod ollama pull llama3.2:1b || echo "⚠️  Failed to pull Ollama model, will retry on next deployment"
 
             # Wait for backend to fully restart before health check
             echo "⏳ Waiting for backend to fully restart..."

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -40,6 +40,15 @@ OLLAMA_HOST=http://localhost:11434
 OLLAMA_MODEL=llama3.2:latest
 OLLAMA_ENABLED=true
 
+# Hosted LLM APIs (#190). Generation routes here when the llm_use_api admin
+# flag is on: Groq primary, Gemini fallback. Leave empty to stay on Ollama.
+GROQ_API_KEY=
+GEMINI_API_KEY=
+
+# Embedding backend: "ollama" (default, dev) or "api" (Gemini; prod).
+# Switching regenerates all stored embeddings on next startup.
+EMBEDDING_PROVIDER=ollama
+
 # API Keys - Store these in 1Password!
 # DO NOT put actual API keys here - use 1Password references instead
 # Format: op://vault-name/item-name/field-name

--- a/backend/config.py
+++ b/backend/config.py
@@ -58,7 +58,7 @@ class Settings(BaseSettings):
     # LLM API provider seed default for the "llm_use_api" feature flag.
     # When enabled (via admin UI), AI generation (Q&A, summaries, suggestions)
     # is routed to hosted APIs (Groq primary, Gemini fallback) instead of
-    # local Ollama. Embeddings always stay on Ollama regardless of this flag.
+    # local Ollama. Embeddings are routed separately via embedding_provider.
     llm_use_api: bool = False
 
     # Hosted API providers (OpenAI-compatible chat completions)
@@ -68,8 +68,15 @@ class Settings(BaseSettings):
     gemini_api_key: str | None = None
     gemini_base_url: str = "https://generativelanguage.googleapis.com/v1beta/openai"
     gemini_model: str = "gemini-flash-latest"  # Free tier: 1,500 req/day
+    gemini_embed_model: str = "gemini-embedding-001"  # Embeddings via OpenAI-compat endpoint
     llm_api_timeout: float = 30.0  # Per-provider request timeout (seconds)
     llm_api_max_tokens: int = 1024  # Default response cap for API generation
+
+    # Which backend generates embeddings: "ollama" (default, dev) or "api"
+    # (Gemini, prod). Startup-level config rather than a runtime flag: query
+    # embeddings must match the model tag stored with precomputed embeddings
+    # in Neo4j, and embedding_sync only reconciles model changes at startup.
+    embedding_provider: str = "ollama"
 
     # Ollama settings
     ollama_host: str = "http://localhost:11434"  # Default Ollama endpoint

--- a/backend/llm_client.py
+++ b/backend/llm_client.py
@@ -2,15 +2,19 @@
 
 Provides a single client surface for all AI generation and embedding calls.
 Which backend handles *generation* is decided per-call by the "llm_use_api"
-runtime feature flag (admin UI). Embeddings and semantic search always use
-Ollama so stored embeddings in Neo4j stay consistent with query embeddings.
+runtime feature flag (admin UI). Which backend handles *embeddings* is a
+startup-level setting (EMBEDDING_PROVIDER), because query embeddings must
+match the model tag stored with precomputed embeddings in Neo4j and
+embedding_sync only reconciles model changes at startup.
 
 Architecture:
 - ApiLLMClient: OpenAI-compatible chat completions with a provider fallback
   chain (Groq primary, Gemini fallback). Configured via GROQ_API_KEY /
-  GEMINI_API_KEY; a provider without a key is simply skipped.
+  GEMINI_API_KEY; a provider without a key is simply skipped. Embeddings go
+  through Gemini's /embeddings endpoint (Groq hosts no embedding models).
 - RoutingLLMClient: delegates each call to Ollama or the API chain based on
-  the feature flag. This is what routers receive via dependencies.get_llm().
+  the feature flag (generation) or EMBEDDING_PROVIDER (embeddings). This is
+  what routers receive via dependencies.get_llm().
 """
 
 import json
@@ -22,6 +26,7 @@ from typing import Any
 from config import get_settings
 from core import ai as ai_core
 from ollama_client import OllamaClient, get_ollama_client
+from utils import calculate_content_hash
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +74,11 @@ class ApiLLMClient:
         self.providers = _build_providers() if providers is None else providers
         self.timeout = settings.llm_api_timeout
         self.default_max_tokens = settings.llm_api_max_tokens
+        # Embeddings are served by Gemini only (Groq hosts no embedding models)
+        self.embed_provider = next((p for p in self.providers if p.name == "gemini"), None)
+        self.embed_model = settings.gemini_embed_model
+        # Embedding cache: {content_hash: embedding_vector}, mirrors OllamaClient
+        self.embedding_cache: dict[str, list[float]] = {}
         if self.providers:
             logger.info(
                 "API LLM client configured with providers: %s",
@@ -78,6 +88,10 @@ class ApiLLMClient:
     def is_available(self) -> bool:
         """Check if at least one API provider is configured."""
         return bool(self.providers)
+
+    def embeddings_available(self) -> bool:
+        """Check if embedding generation is possible (requires Gemini)."""
+        return self.embed_provider is not None
 
     def _request_body(
         self, provider: ApiProvider, prompt: str, max_tokens: int | None, stream: bool
@@ -206,18 +220,93 @@ class ApiLLMClient:
 
     def warmup(self, context: str = "chat") -> tuple[bool, str]:
         """No-op: hosted APIs need no warmup."""
+        if context == "embedding":
+            return self.embeddings_available(), self.embed_model
         model = self.providers[0].model if self.providers else ""
         return self.is_available(), model
 
+    # --- embeddings ----------------------------------------------------------
+
+    def generate_embedding(self, text: str, use_cache: bool = True) -> list[float] | None:
+        """Generate an embedding via Gemini's OpenAI-compatible endpoint."""
+        import httpx
+
+        if self.embed_provider is None:
+            logger.debug("No embedding-capable API provider configured")
+            return None
+
+        if use_cache:
+            content_hash = calculate_content_hash(text)
+            if content_hash in self.embedding_cache:
+                logger.debug("Using cached embedding for content")
+                return self.embedding_cache[content_hash]
+
+        try:
+            response = httpx.post(
+                f"{self.embed_provider.base_url}/embeddings",
+                headers={"Authorization": f"Bearer {self.embed_provider.api_key}"},
+                json={"model": self.embed_model, "input": text},
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            embedding: list[float] = response.json()["data"][0]["embedding"]
+            if use_cache:
+                self.embedding_cache[calculate_content_hash(text)] = embedding
+            return embedding
+        except Exception as e:
+            logger.error("Failed to generate embedding via %s: %s", self.embed_provider.name, e)
+            return None
+
+    def semantic_search(
+        self, query: str, documents: list[dict[str, Any]], top_k: int = 5
+    ) -> list[dict[str, Any]]:
+        """Semantic search, embedding documents on the fly (cached per content)."""
+        query_embedding = self.generate_embedding(query, use_cache=False)
+        if not query_embedding:
+            return []
+
+        documents_with_embeddings = []
+        for doc in documents:
+            doc_embedding = self.generate_embedding(doc.get("content", ""), use_cache=True)
+            if doc_embedding:
+                documents_with_embeddings.append({**doc, "embedding": doc_embedding})
+
+        ranked = ai_core.rank_documents_by_similarity(
+            query_embedding, documents_with_embeddings, top_k
+        )
+        # Strip the transient embeddings added above (parity with OllamaClient)
+        return [{k: v for k, v in doc.items() if k != "embedding"} for doc in ranked]
+
+    def semantic_search_with_precomputed_embeddings(
+        self, query: str, documents_with_embeddings: list[dict[str, Any]], top_k: int = 5
+    ) -> list[dict[str, Any]]:
+        """Semantic search against precomputed embeddings (only embeds the query)."""
+        query_embedding = self.generate_embedding(query, use_cache=False)
+        if not query_embedding:
+            logger.warning("Failed to generate query embedding")
+            return []
+        return ai_core.rank_documents_by_similarity(
+            query_embedding, documents_with_embeddings, top_k
+        )
+
+    def clear_cache(self) -> int:
+        """Clear the embedding cache, returning the number of entries removed."""
+        count = len(self.embedding_cache)
+        self.embedding_cache.clear()
+        return count
+
 
 class RoutingLLMClient:
-    """Routes LLM calls to Ollama or hosted APIs based on the runtime flag.
+    """Routes LLM calls to Ollama or hosted APIs based on configuration.
 
     - Generation (generate, ask_question, summarize, streaming): API chain
       when the "llm_use_api" flag is on and providers are configured,
       otherwise Ollama.
-    - Embeddings and semantic search: always Ollama, so query embeddings
-      match the precomputed embeddings stored in Neo4j.
+    - Embeddings and semantic search: the EMBEDDING_PROVIDER setting ("api"
+      routes to Gemini, anything else stays on Ollama). Startup-level, not a
+      runtime flag: query embeddings must match the model tag stored with
+      precomputed embeddings in Neo4j, and embedding_sync only reconciles
+      model changes at startup.
     """
 
     def __init__(self, ollama: OllamaClient, api: ApiLLMClient) -> None:
@@ -236,6 +325,11 @@ class RoutingLLMClient:
 
     def _generation_backend(self) -> Any:
         return self.api if self._use_api() else self.ollama
+
+    def _embedding_backend(self) -> Any:
+        if get_settings().embedding_provider == "api" and self.api.embeddings_available():
+            return self.api
+        return self.ollama
 
     @property
     def active_provider(self) -> str:
@@ -274,12 +368,13 @@ class RoutingLLMClient:
         return available
 
     def embeddings_available(self) -> bool:
-        """Whether embedding generation is possible (always requires Ollama).
+        """Whether embedding generation is possible on the embedding backend.
 
-        Distinct from is_available(): in API mode generation can be healthy
-        while Ollama (and therefore semantic search) is down.
+        Distinct from is_available(): generation can be healthy while the
+        embedding backend (and therefore semantic search) is down.
         """
-        return self.ollama.is_available()
+        available: bool = self._embedding_backend().embeddings_available()
+        return available
 
     def has_gpu(self) -> bool:
         """Hosted APIs are treated as accelerated; Ollama reports its own state."""
@@ -290,15 +385,24 @@ class RoutingLLMClient:
     def warmup(self, context: str = "chat") -> tuple[bool, str]:
         """Warm up the backend that will serve the given context."""
         if context == "embedding":
-            return self.ollama.warmup(context=context)
-        result: tuple[bool, str] = self._generation_backend().warmup(context=context)
+            backend = self._embedding_backend()
+        else:
+            backend = self._generation_backend()
+        result: tuple[bool, str] = backend.warmup(context=context)
         return result
 
-    # --- embeddings / search (always Ollama) --------------------------------
+    # --- embeddings / search (routed by EMBEDDING_PROVIDER) -----------------
 
     @property
     def model(self) -> str:
-        """Embedding model tag used when storing embeddings (Ollama's)."""
+        """Embedding model tag used when storing embeddings.
+
+        Changing this tag makes embedding_sync regenerate the corpus at the
+        next startup (model-change detection).
+        """
+        backend = self._embedding_backend()
+        if backend is self.api:
+            return self.api.embed_model
         return self.ollama.model
 
     @property
@@ -314,22 +418,31 @@ class RoutingLLMClient:
         return self.ollama.structured_model
 
     def generate_embedding(self, text: str, use_cache: bool = True) -> list[float] | None:
-        return self.ollama.generate_embedding(text, use_cache=use_cache)
+        result: list[float] | None = self._embedding_backend().generate_embedding(
+            text, use_cache=use_cache
+        )
+        return result
 
     def semantic_search(
         self, query: str, documents: list[dict[str, Any]], top_k: int = 5
     ) -> list[dict[str, Any]]:
-        return self.ollama.semantic_search(query, documents, top_k)
+        results: list[dict[str, Any]] = self._embedding_backend().semantic_search(
+            query, documents, top_k
+        )
+        return results
 
     def semantic_search_with_precomputed_embeddings(
         self, query: str, documents_with_embeddings: list[dict[str, Any]], top_k: int = 5
     ) -> list[dict[str, Any]]:
-        return self.ollama.semantic_search_with_precomputed_embeddings(
-            query, documents_with_embeddings, top_k
+        results: list[dict[str, Any]] = (
+            self._embedding_backend().semantic_search_with_precomputed_embeddings(
+                query, documents_with_embeddings, top_k
+            )
         )
+        return results
 
     def clear_cache(self) -> int:
-        return self.ollama.clear_cache()
+        return self.ollama.clear_cache() + self.api.clear_cache()
 
 
 _llm_client: RoutingLLMClient | None = None

--- a/backend/main.py
+++ b/backend/main.py
@@ -537,7 +537,9 @@ def trigger_embedding_sync(
 
     if not ollama.embeddings_available():
         return EmbeddingSyncResponse(
-            success=False, message="Ollama not available - cannot generate embeddings", stats=None
+            success=False,
+            message="Embedding backend not available - cannot generate embeddings",
+            stats=None,
         )
 
     logger.info("Admin triggered manual embedding sync")

--- a/backend/tests/unit/test_llm_client.py
+++ b/backend/tests/unit/test_llm_client.py
@@ -30,6 +30,14 @@ def _completion_response(content: str) -> MagicMock:
     return response
 
 
+def _embedding_response(embedding: list[float]) -> MagicMock:
+    """Build a mock httpx response with an OpenAI-compatible embedding."""
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = {"data": [{"embedding": embedding}]}
+    return response
+
+
 # ============================================================================
 # ApiLLMClient
 # ============================================================================
@@ -113,6 +121,92 @@ class TestApiLLMClient:
         assert success is True
         assert model == GROQ.model
 
+    def test_embeddings_require_gemini(self) -> None:
+        assert ApiLLMClient(providers=[GROQ]).embeddings_available() is False
+        assert ApiLLMClient(providers=[GROQ, GEMINI]).embeddings_available() is True
+
+    def test_generate_embedding_none_without_gemini(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list[str] = []
+        monkeypatch.setattr("httpx.post", lambda url, **kw: calls.append(url))
+        client = ApiLLMClient(providers=[GROQ])
+        assert client.generate_embedding("text") is None
+        assert calls == []
+
+    def test_generate_embedding_posts_to_gemini(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list[dict[str, Any]] = []
+
+        def mock_post(url: str, **kwargs: Any) -> MagicMock:
+            calls.append({"url": url, **kwargs})
+            return _embedding_response([0.1, 0.2, 0.3])
+
+        monkeypatch.setattr("httpx.post", mock_post)
+        client = ApiLLMClient(providers=[GROQ, GEMINI])
+
+        assert client.generate_embedding("some text") == [0.1, 0.2, 0.3]
+        assert len(calls) == 1
+        assert calls[0]["url"] == f"{GEMINI.base_url}/embeddings"
+        assert calls[0]["headers"]["Authorization"] == "Bearer test-gemini-key"
+        assert calls[0]["json"] == {"model": client.embed_model, "input": "some text"}
+
+    def test_generate_embedding_caches_by_content(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list[str] = []
+
+        def mock_post(url: str, **kwargs: Any) -> MagicMock:
+            calls.append(url)
+            return _embedding_response([0.5])
+
+        monkeypatch.setattr("httpx.post", mock_post)
+        client = ApiLLMClient(providers=[GEMINI])
+
+        assert client.generate_embedding("same text") == [0.5]
+        assert client.generate_embedding("same text") == [0.5]
+        assert len(calls) == 1
+        assert client.clear_cache() == 1
+        client.generate_embedding("same text")
+        assert len(calls) == 2
+
+    def test_generate_embedding_returns_none_on_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def mock_post(url: str, **kwargs: Any) -> MagicMock:
+            raise ConnectionError("gemini down")
+
+        monkeypatch.setattr("httpx.post", mock_post)
+        client = ApiLLMClient(providers=[GEMINI])
+        assert client.generate_embedding("text") is None
+
+    def test_precomputed_search_ranks_by_similarity(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("httpx.post", lambda url, **kw: _embedding_response([1.0, 0.0]))
+        client = ApiLLMClient(providers=[GEMINI])
+        docs = [
+            {"id": "orthogonal", "embedding": [0.0, 1.0]},
+            {"id": "aligned", "embedding": [1.0, 0.0]},
+        ]
+
+        results = client.semantic_search_with_precomputed_embeddings("query", docs, top_k=2)
+        assert [doc["id"] for doc in results] == ["aligned", "orthogonal"]
+        assert results[0]["score"] == pytest.approx(1.0)
+
+    def test_semantic_search_embeds_documents(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("httpx.post", lambda url, **kw: _embedding_response([1.0, 0.0]))
+        client = ApiLLMClient(providers=[GEMINI])
+        docs = [{"id": "a", "content": "doc a"}, {"id": "b", "content": "doc b"}]
+
+        results = client.semantic_search("query", docs, top_k=1)
+        assert len(results) == 1
+        # Transient embeddings are stripped from results
+        assert "embedding" not in results[0]
+
+    def test_embedding_warmup_reports_embed_model(self) -> None:
+        client = ApiLLMClient(providers=[GROQ, GEMINI])
+        success, model = client.warmup(context="embedding")
+        assert success is True
+        assert model == client.embed_model
+
+        no_gemini = ApiLLMClient(providers=[GROQ])
+        success, _ = no_gemini.warmup(context="embedding")
+        assert success is False
+
 
 # ============================================================================
 # RoutingLLMClient
@@ -130,9 +224,13 @@ class MockBackend:
         self.model = f"{name}-model"
         self.chat_model = f"{name}-chat"
         self.structured_model = f"{name}-structured"
+        self.embed_model = f"{name}-embed"
         self.providers = [GROQ]
 
     def is_available(self) -> bool:
+        return self._available
+
+    def embeddings_available(self) -> bool:
         return self._available
 
     def has_gpu(self) -> bool:
@@ -189,6 +287,20 @@ def flag_state(monkeypatch: pytest.MonkeyPatch) -> dict[str, bool]:
     return state
 
 
+@pytest.fixture
+def embedding_provider(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    """Control the embedding_provider setting seen by RoutingLLMClient."""
+    state = {"embedding_provider": "ollama"}
+
+    def mock_settings() -> MagicMock:
+        settings = MagicMock()
+        settings.embedding_provider = state["embedding_provider"]
+        return settings
+
+    monkeypatch.setattr(llm_module, "get_settings", mock_settings)
+    return state
+
+
 class TestRoutingLLMClient:
     def _make(
         self, api_available: bool = True
@@ -219,7 +331,10 @@ class TestRoutingLLMClient:
         assert routing.generate("hi") == "answer from ollama"
         assert api.calls == []
 
-    def test_embeddings_always_use_ollama(self, flag_state: dict[str, bool]) -> None:
+    def test_embeddings_default_to_ollama(
+        self, flag_state: dict[str, bool], embedding_provider: dict[str, str]
+    ) -> None:
+        # The generation flag must not affect embedding routing
         flag_state["llm_use_api"] = True
         routing, ollama, api = self._make()
         routing.generate_embedding("text")
@@ -230,12 +345,39 @@ class TestRoutingLLMClient:
         assert "semantic_search_precomputed" in ollama.calls
         assert api.calls == []
 
-    def test_embedding_warmup_always_uses_ollama(self, flag_state: dict[str, bool]) -> None:
-        flag_state["llm_use_api"] = True
+    def test_embeddings_route_to_api_when_provider_api(
+        self, flag_state: dict[str, bool], embedding_provider: dict[str, str]
+    ) -> None:
+        embedding_provider["embedding_provider"] = "api"
+        routing, ollama, api = self._make()
+        routing.generate_embedding("text")
+        routing.semantic_search("q", [])
+        routing.semantic_search_with_precomputed_embeddings("q", [])
+        assert "generate_embedding" in api.calls
+        assert "semantic_search" in api.calls
+        assert "semantic_search_precomputed" in api.calls
+        assert ollama.calls == []
+
+    def test_embedding_provider_api_falls_back_to_ollama_without_gemini(
+        self, flag_state: dict[str, bool], embedding_provider: dict[str, str]
+    ) -> None:
+        embedding_provider["embedding_provider"] = "api"
+        routing, ollama, api = self._make(api_available=False)
+        routing.generate_embedding("text")
+        assert "generate_embedding" in ollama.calls
+        assert api.calls == []
+
+    def test_embedding_warmup_follows_provider(
+        self, flag_state: dict[str, bool], embedding_provider: dict[str, str]
+    ) -> None:
         routing, ollama, api = self._make()
         routing.warmup(context="embedding")
         assert ollama.calls == ["warmup"]
         assert api.calls == []
+
+        embedding_provider["embedding_provider"] = "api"
+        routing.warmup(context="embedding")
+        assert api.calls == ["warmup"]
 
     def test_has_gpu_true_in_api_mode(self, flag_state: dict[str, bool]) -> None:
         flag_state["llm_use_api"] = True
@@ -248,20 +390,35 @@ class TestRoutingLLMClient:
         flag_state["llm_use_api"] = True
         assert routing.active_provider == "groq"
 
-    def test_embedding_model_tag_stays_ollama(self, flag_state: dict[str, bool]) -> None:
+    def test_embedding_model_tag_follows_provider(
+        self, flag_state: dict[str, bool], embedding_provider: dict[str, str]
+    ) -> None:
+        # .model tags stored embeddings - the generation flag must not move it
         flag_state["llm_use_api"] = True
         routing, _, _ = self._make()
-        # .model tags stored embeddings - must stay Ollama's even in API mode
         assert routing.model == "ollama-model"
 
-    def test_embeddings_available_tracks_ollama_not_api(self, flag_state: dict[str, bool]) -> None:
-        """In API mode, generation can be up while embeddings (Ollama) are down."""
+        embedding_provider["embedding_provider"] = "api"
+        assert routing.model == "api-embed"
+
+    def test_embeddings_available_tracks_embedding_backend(
+        self, flag_state: dict[str, bool], embedding_provider: dict[str, str]
+    ) -> None:
+        """Generation can be up while the embedding backend is down."""
         flag_state["llm_use_api"] = True
         ollama = MockBackend("ollama", available=False)
         api = MockBackend("api")
         routing = RoutingLLMClient(ollama, api)  # type: ignore[arg-type]
         assert routing.is_available() is True
         assert routing.embeddings_available() is False
+
+    def test_clear_cache_clears_both_backends(
+        self, flag_state: dict[str, bool], embedding_provider: dict[str, str]
+    ) -> None:
+        routing, ollama, api = self._make()
+        routing.clear_cache()
+        assert "clear_cache" in ollama.calls
+        assert "clear_cache" in api.calls
 
 
 # ============================================================================

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -12,7 +12,9 @@ services:
       - BACKUP_DIR=/var/mongado-backups
       - BACKUP_RETENTION_COUNT=14
       - BACKUP_RETENTION_DAYS=30
-      # Memory tuning for 4GB server - reserve RAM for Ollama (issue #60)
+      # Conservative memory limits (issue #60). Ollama is gone from prod
+      # (#190), but these stay low deliberately to keep a 4GB -> 2GB droplet
+      # downsize possible. Plenty for <1000 notes + articles.
       - NEO4J_dbms_memory_heap_initial__size=256m
       - NEO4J_dbms_memory_heap_max__size=512m
       - NEO4J_dbms_memory_pagecache_size=256m
@@ -31,28 +33,6 @@ services:
       retries: 5
       start_period: 40s
 
-  ollama:
-    image: ollama/ollama:latest
-    container_name: mongado-ollama-prod
-    ports:
-      - "11434:11434"
-    environment:
-      # Aggressive model unloading to prevent OOM on 4GB server (issue #59)
-      - OLLAMA_MAX_LOADED_MODELS=1  # Only keep 1 model in memory at a time
-      - OLLAMA_NUM_PARALLEL=1        # Limit concurrent requests to 1
-      - OLLAMA_KEEP_ALIVE=0          # Unload model immediately after use (no idle time)
-    volumes:
-      - ollama-data:/root/.ollama
-    networks:
-      - mongado-network
-    restart: always
-    healthcheck:
-      test: ["CMD", "ollama", "list"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 60s
-
   backend:
     build:
       context: ./backend
@@ -66,8 +46,10 @@ services:
       - NEO4J_URI=bolt://neo4j:7687
       - NEO4J_USER=neo4j
       - NEO4J_PASSWORD=${NEO4J_PASSWORD:?NEO4J_PASSWORD must be set in production}
-      - OLLAMA_HOST=http://ollama:11434
-      - OLLAMA_ENABLED=true
+      # AI runs on hosted APIs in prod (#190): generation via Groq -> Gemini
+      # (behind the llm_use_api admin flag), embeddings via Gemini
+      - OLLAMA_ENABLED=false
+      - EMBEDDING_PROVIDER=api
       - LLM_FEATURES_ENABLED=false
       - COMPOSE_FILE=docker-compose.prod.yml  # Enable prod backup path detection
     env_file:
@@ -80,8 +62,6 @@ services:
     depends_on:
       neo4j:
         condition: service_healthy
-      ollama:
-        condition: service_healthy  # Backend disables embeddings if Ollama isn't up yet (#194)
     restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/"]
@@ -144,4 +124,3 @@ networks:
 volumes:
   neo4j-data:
   neo4j-logs:
-  ollama-data:

--- a/docs/AI_OPTIMIZATION.md
+++ b/docs/AI_OPTIMIZATION.md
@@ -73,6 +73,8 @@ Semantic search embeddings can stay local or move to an API:
 
 Recommendation: **move embeddings to the same API provider** and drop Ollama from prod entirely. The droplet downsizing pays for the entire AI budget. Keep Ollama in dev compose for offline work.
 
+**Implemented (Phase 3):** embeddings route to Gemini `gemini-embedding-001` (Groq hosts no embedding models) via the `EMBEDDING_PROVIDER` env var — `ollama` (dev default) or `api` (prod). This is startup-level config rather than a runtime flag: query embeddings must match the model tag stored in Neo4j, and `embedding_sync` only reconciles model changes on a sync run. The model-tag change makes the next sync (`POST /api/admin/sync-embeddings`, or startup if `SYNC_EMBEDDINGS_ON_STARTUP=true`) re-embed the whole corpus.
+
 ## Decision (2026-07-03)
 
 **Groq free tier (primary) + Gemini free tier (fallback)**, hard-gated to free tiers (no payment method attached). May switch to Anthropic Haiku 4.5 later — the abstraction makes that a config change. Provider selection is a runtime feature flag (`llm_use_api` in the admin panel), so everything deploys dark with Ollama as the default until API keys are added.
@@ -112,10 +114,15 @@ Local dev override: put the keys in `backend/.env` and toggle the flag in the lo
 
 ### Phase 3: Infra cleanup and savings
 
-1. Remove Ollama service from `docker-compose.prod.yml`; keep it in dev compose.
-2. Restore Neo4j memory settings (currently squeezed to leave room for Ollama, issues #59/#60).
-3. Evaluate droplet downsize 4GB → 2GB (−$12/mo) once memory headroom is confirmed.
-4. Close/supersede #150 (dedicated Ollama server) — no longer needed.
+1. ✅ Remove Ollama service from `docker-compose.prod.yml`; keep it in dev compose. Prod backend runs with `OLLAMA_ENABLED=false` and `EMBEDDING_PROVIDER=api`. The deploy uses `--remove-orphans` to delete the old container; reclaim its model storage on the droplet with `docker volume rm mongado_ollama-data` (~2GB).
+2. ✅ Neo4j memory settings reviewed (#59/#60): kept at conservative values deliberately — the dataset is small and low limits keep the 2GB downsize possible. Bump heap/pagecache instead if staying on 4GB long-term.
+3. Evaluate droplet downsize 4GB → 2GB (−$12/mo): after this deploys, confirm headroom with `docker stats` (expect ~1.5–2GB used), then resize via the DigitalOcean console.
+4. ✅ Close/supersede #150 (dedicated Ollama server) — no longer needed.
+
+**Prod rollout notes:**
+- After the first deploy, trigger a one-time re-embed with the new model: `curl -X POST https://<host>/api/admin/sync-embeddings -H "Authorization: Bearer $ADMIN_TOKEN"`. The model-tag change (`nomic-embed-text` → `gemini-embedding-001`) makes it regenerate everything (~150 docs, a couple of minutes on Gemini free tier). Until then, semantic search is harmless but useless: the 3072-dim Gemini query vectors score 0.0 against the stored 768-dim nomic vectors (dimension-mismatch guard in `cosine_similarity`).
+- Semantic search now requires the Gemini key: if Gemini is unreachable, search falls back to text matching (same graceful degradation as before).
+- The `llm_use_api` admin flag still controls generation only. With Ollama gone from prod, toggling it off means "AI generation unavailable", not a revert to local inference.
 
 ### Explicit non-goals
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -119,8 +119,11 @@ Add these secrets:
 | `OP_MONGADO_SERVICE_ACCOUNT_TOKEN` | No | - | 1Password service account token |
 | `NEO4J_URI` | No | `bolt://localhost:7687` | Neo4j connection string |
 | `NEO4J_USER` | No | `neo4j` | Neo4j username |
-| `OLLAMA_HOST` | No | `http://localhost:11434` | Ollama API endpoint |
-| `OLLAMA_ENABLED` | No | `true` | Enable/disable AI features |
+| `OLLAMA_HOST` | No | `http://localhost:11434` | Ollama API endpoint (dev only; prod sets `OLLAMA_ENABLED=false`) |
+| `OLLAMA_ENABLED` | No | `true` | Enable/disable local Ollama inference |
+| `GROQ_API_KEY` | No | - | Hosted generation, primary (set via GitHub secret) |
+| `GEMINI_API_KEY` | No | - | Hosted generation fallback + embeddings (set via GitHub secret) |
+| `EMBEDDING_PROVIDER` | No | `ollama` | `api` routes embeddings to Gemini (prod) |
 | `DEBUG` | No | `false` | Enable debug mode (set to `false` in production) |
 
 **Important Notes**:


### PR DESCRIPTION
## Summary

Phase 3 of #190: production AI now runs entirely on hosted APIs, and the Ollama container is removed from prod. Dev compose is unchanged — Ollama remains the local/offline default.

- **Embeddings route to Gemini** (`gemini-embedding-001` via the OpenAI-compatible `/embeddings` endpoint — Groq hosts no embedding models) behind a new `EMBEDDING_PROVIDER=ollama|api` env var. Startup-level config rather than a runtime flag: query embeddings must match the model tag stored in Neo4j, and `embedding_sync` only reconciles model changes on a sync run.
- **`docker-compose.prod.yml`**: ollama service + volume removed; backend runs `OLLAMA_ENABLED=false` + `EMBEDDING_PROVIDER=api`; backend no longer depends on ollama health.
- **Deploy workflow**: `ollama pull` step removed; `up --remove-orphans` cleans the old container off the droplet.
- **Neo4j memory (#59/#60)**: kept conservative deliberately — the freed 1–2GB enables the 4GB → 2GB droplet downsize (−$12/mo).
- Admin sync-embeddings error message made backend-neutral.

## Data safety

- Neo4j service, `neo4j-data` volume, and backups untouched. Re-embedding SETs only `embedding`/`embedding_model`/`embedding_version` — never content, titles, or links.
- `ollama-data` volume is not auto-deleted (reclaim manually with `docker volume rm mongado_ollama-data`, ~2GB of re-downloadable model weights).
- Rollback restores the previous compose file, which still defines Ollama; its volume is intact.

## Rollout (after merge — runbook in `docs/AI_OPTIMIZATION.md`)

1. Deploy; confirm the ollama container is gone (`docker ps`).
2. One-time re-embed: `POST /api/admin/sync-embeddings` (model-tag change regenerates the corpus, ~150 docs). Until then semantic search scores 0.0 on the dimension-mismatch guard — harmless, no crash.
3. Check `docker stats` headroom, then evaluate the 2GB droplet resize.

Note: with Ollama gone from prod, toggling `llm_use_api` **off** means 'AI generation unavailable', not a revert to local inference.

## Testing

- 12 new unit tests (ApiLLMClient embeddings, routing by `EMBEDDING_PROVIDER`); suite at 323 green; mypy/ruff/bandit clean.
- Live-verified from dev: real Gemini embeddings (3072-dim) and correct relevance ranking through the routed precomputed-search path; graceful `None`/fallback with no Gemini key.
- `docker compose -f docker-compose.prod.yml config` validates.

Refs #190