### PR TITLE
fix: skip fresh embeddings in sync and back off on 429s

### DIFF
--- a/backend/adapters/neo4j.py
+++ b/backend/adapters/neo4j.py
@@ -649,9 +649,7 @@ class Neo4jAdapter:
 
             return central
 
-    def get_stale_notes(
-        self, days_threshold: int = 60, limit: int = 50
-    ) -> list[dict[str, Any]]:
+    def get_stale_notes(self, days_threshold: int = 60, limit: int = 50) -> list[dict[str, Any]]:
         """Get notes not updated in the specified number of days.
 
         Args:
@@ -787,7 +785,9 @@ class Neo4jAdapter:
             return {}
 
         with self.driver.session(database=self.database) as session:
-            result = session.run("MATCH (f:FeatureFlag) RETURN f.name AS name, f.enabled AS enabled")
+            result = session.run(
+                "MATCH (f:FeatureFlag) RETURN f.name AS name, f.enabled AS enabled"
+            )
             return {record["name"]: bool(record["enabled"]) for record in result}
 
     def set_feature_flag(self, name: str, enabled: bool) -> bool:
@@ -827,8 +827,12 @@ class Neo4jAdapter:
             result = session.run("MATCH (n:Note) RETURN n.id AS id")
             return {record["id"] for record in result}
 
-    def get_all_notes(self) -> list[dict[str, Any]]:
+    def get_all_notes(self, include_embeddings: bool = False) -> list[dict[str, Any]]:
         """Get all notes.
+
+        Args:
+            include_embeddings: Include embedding/embedding_model/embedding_version
+                fields (needed for embedding staleness checks)
 
         Returns:
             List of note dicts
@@ -838,7 +842,10 @@ class Neo4jAdapter:
 
         with self.driver.session(database=self.database) as session:
             result = session.run("MATCH (n:Note) RETURN n ORDER BY n.created_at DESC")
-            return [self._node_to_dict(record["n"]) for record in result]
+            return [
+                self._node_to_dict(record["n"], exclude_embedding=not include_embeddings)
+                for record in result
+            ]
 
     def _create_links(self, session: Session, source_id: str, target_ids: list[str]) -> None:
         """Create LINKS_TO relationships.
@@ -1023,8 +1030,12 @@ class Neo4jAdapter:
                 return None
             return self._node_to_dict(record["a"])
 
-    def get_all_articles(self) -> list[dict[str, Any]]:
+    def get_all_articles(self, include_embeddings: bool = False) -> list[dict[str, Any]]:
         """Get all articles.
+
+        Args:
+            include_embeddings: Include embedding/embedding_model/embedding_version
+                fields (needed for embedding staleness checks)
 
         Returns:
             List of article dicts
@@ -1034,7 +1045,10 @@ class Neo4jAdapter:
 
         with self.driver.session(database=self.database) as session:
             result = session.run("MATCH (a:Article) RETURN a ORDER BY a.created_at DESC")
-            return [self._node_to_dict(record["a"]) for record in result]
+            return [
+                self._node_to_dict(record["a"], exclude_embedding=not include_embeddings)
+                for record in result
+            ]
 
     # ===== EMBEDDING METHODS =====
 
@@ -1045,6 +1059,7 @@ class Neo4jAdapter:
         embedding: list[float],
         model: str,
         version: int,
+        content_hash: str,
     ) -> bool:
         """Store embedding for an article or note.
 
@@ -1054,6 +1069,7 @@ class Neo4jAdapter:
             embedding: Embedding vector (768 dimensions)
             model: Model name (e.g., "nomic-embed-text")
             version: Embedding version for cache invalidation
+            content_hash: SHA256 hash of the embedded content (staleness detection)
 
         Returns:
             True if successful
@@ -1070,12 +1086,14 @@ class Neo4jAdapter:
                 MATCH (n:{validated_type} {{id: $id}})
                 SET n.embedding = $embedding,
                     n.embedding_model = $model,
-                    n.embedding_version = $version
+                    n.embedding_version = $version,
+                    n.content_hash = $content_hash
                 """,
                 id=node_id,
                 embedding=embedding,
                 model=model,
                 version=version,
+                content_hash=content_hash,
             )
             return True
 
@@ -1226,9 +1244,7 @@ class Neo4jAdapter:
             )
             return True
 
-    def get_ai_content(
-        self, node_type: str, node_id: str
-    ) -> dict[str, Any] | None:
+    def get_ai_content(self, node_type: str, node_id: str) -> dict[str, Any] | None:
         """Get pre-computed AI content for an article or note.
 
         Args:

--- a/backend/embedding_sync.py
+++ b/backend/embedding_sync.py
@@ -24,6 +24,45 @@ logger = logging.getLogger(__name__)
 # Embedding version - increment when model or logic changes
 EMBEDDING_VERSION = 1
 
+# Retry-with-backoff settings for rate-limited embedding APIs (e.g. Gemini 429s).
+# The whole sync shares one time budget; per-item retries back off exponentially.
+SYNC_TIME_BUDGET_SECONDS = 600.0
+RETRY_BASE_DELAY_SECONDS = 2.0
+RETRY_MAX_DELAY_SECONDS = 60.0
+
+
+def _generate_with_retry(
+    ollama_client: Any,
+    content: str,
+    deadline: float,
+) -> list[float] | None:
+    """Generate an embedding, retrying with exponential backoff until deadline.
+
+    Embedding APIs enforce per-minute rate limits (429s), so waiting and
+    retrying usually succeeds. Retries stop once the next wait would pass
+    the shared sync deadline; the item is then reported as failed.
+
+    Args:
+        ollama_client: Client with generate_embedding()
+        content: Text to embed
+        deadline: time.monotonic() timestamp after which no more retries
+
+    Returns:
+        Embedding vector, or None if all attempts failed
+    """
+    delay = RETRY_BASE_DELAY_SECONDS
+    attempt = 1
+    while True:
+        embedding: list[float] | None = ollama_client.generate_embedding(content, use_cache=True)
+        if embedding:
+            return embedding
+        if time.monotonic() + delay > deadline:
+            return None
+        logger.warning("  Embedding attempt %d failed, retrying in %.0fs", attempt, delay)
+        time.sleep(delay)
+        delay = min(delay * 2, RETRY_MAX_DELAY_SECONDS)
+        attempt += 1
+
 
 def sync_articles_to_neo4j(
     articles: list[dict[str, Any]],
@@ -138,6 +177,7 @@ def _process_embeddings_for_nodes(
     neo4j_adapter: Any,
     ollama_client: Any,
     stats: dict[str, int],
+    deadline: float,
 ) -> None:
     """Process embeddings for a list of nodes (Articles or Notes).
 
@@ -152,6 +192,7 @@ def _process_embeddings_for_nodes(
         neo4j_adapter: Neo4jAdapter instance
         ollama_client: OllamaClient instance
         stats: Stats dict to update (modified in place)
+        deadline: time.monotonic() timestamp bounding retry waits
     """
     logger.info("Checking %ss for missing embeddings...", node_type.lower())
 
@@ -170,11 +211,16 @@ def _process_embeddings_for_nodes(
                 title,
             )
 
-            embedding = ollama_client.generate_embedding(content, use_cache=True)
+            embedding = _generate_with_retry(ollama_client, content, deadline)
 
             if embedding:
                 neo4j_adapter.store_embedding(
-                    node_type, node_id, embedding, current_model, current_version
+                    node_type,
+                    node_id,
+                    embedding,
+                    current_model,
+                    current_version,
+                    calculate_content_hash(content),
                 )
                 duration = time.time() - start_time
                 logger.info(
@@ -186,6 +232,7 @@ def _process_embeddings_for_nodes(
                 logger.error(
                     "  [%d/%d] ✗ Failed to generate embedding for: %s", idx, len(nodes), title
                 )
+                stats["embeddings_failed"] += 1
         else:
             logger.debug(
                 "  [%d/%d] %s has valid embedding: %s", idx, len(nodes), node_type, node_id
@@ -210,38 +257,31 @@ def sync_embeddings(
             "notes_processed": int,
             "embeddings_generated": int,
             "embeddings_cached": int,
+            "embeddings_failed": int,
         }
     """
-    if not neo4j_adapter.is_available():
-        logger.warning("Neo4j not available - skipping embedding sync")
-        return {
-            "articles_processed": 0,
-            "notes_processed": 0,
-            "embeddings_generated": 0,
-            "embeddings_cached": 0,
-        }
-
-    if not ollama_client.embeddings_available():
-        logger.warning("Ollama not available - skipping embedding sync")
-        return {
-            "articles_processed": 0,
-            "notes_processed": 0,
-            "embeddings_generated": 0,
-            "embeddings_cached": 0,
-        }
-
-    current_model = ollama_client.model
-    current_version = EMBEDDING_VERSION
-
     stats = {
         "articles_processed": 0,
         "notes_processed": 0,
         "embeddings_generated": 0,
         "embeddings_cached": 0,
+        "embeddings_failed": 0,
     }
 
-    # Process Articles
-    articles = neo4j_adapter.get_all_articles()
+    if not neo4j_adapter.is_available():
+        logger.warning("Neo4j not available - skipping embedding sync")
+        return stats
+
+    if not ollama_client.embeddings_available():
+        logger.warning("Ollama not available - skipping embedding sync")
+        return stats
+
+    current_model = ollama_client.model
+    current_version = EMBEDDING_VERSION
+    deadline = time.monotonic() + SYNC_TIME_BUDGET_SECONDS
+
+    # Process Articles (with embedding metadata so staleness checks can skip fresh ones)
+    articles = neo4j_adapter.get_all_articles(include_embeddings=True)
     _process_embeddings_for_nodes(
         articles,
         "Article",
@@ -251,18 +291,28 @@ def sync_embeddings(
         neo4j_adapter,
         ollama_client,
         stats,
+        deadline,
     )
 
-    # Process Notes
-    notes = neo4j_adapter.get_all_notes()
+    # Process Notes (with embedding metadata so staleness checks can skip fresh ones)
+    notes = neo4j_adapter.get_all_notes(include_embeddings=True)
     _process_embeddings_for_nodes(
-        notes, "Note", "notes", current_model, current_version, neo4j_adapter, ollama_client, stats
+        notes,
+        "Note",
+        "notes",
+        current_model,
+        current_version,
+        neo4j_adapter,
+        ollama_client,
+        stats,
+        deadline,
     )
 
     logger.info(
-        "Embedding sync complete: %d generated, %d cached",
+        "Embedding sync complete: %d generated, %d cached, %d failed",
         stats["embeddings_generated"],
         stats["embeddings_cached"],
+        stats["embeddings_failed"],
     )
 
     return stats

--- a/backend/llm_client.py
+++ b/backend/llm_client.py
@@ -228,7 +228,12 @@ class ApiLLMClient:
     # --- embeddings ----------------------------------------------------------
 
     def generate_embedding(self, text: str, use_cache: bool = True) -> list[float] | None:
-        """Generate an embedding via Gemini's OpenAI-compatible endpoint."""
+        """Generate an embedding via Gemini's OpenAI-compatible endpoint.
+
+        Fails fast (no retries): interactive callers shouldn't stall on 429s.
+        Batch callers that need eventual completion retry with backoff at
+        their own level (see embedding_sync).
+        """
         import httpx
 
         if self.embed_provider is None:

--- a/backend/main.py
+++ b/backend/main.py
@@ -207,9 +207,7 @@ class CacheControlMiddleware(BaseHTTPMiddleware):
             # serve stale while revalidating so refreshes never block on the
             # network for content that just changed underneath
             if request.method == "GET":
-                response.headers["Cache-Control"] = (
-                    "public, max-age=60, stale-while-revalidate=300"
-                )
+                response.headers["Cache-Control"] = "public, max-age=60, stale-while-revalidate=300"
             else:
                 response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
 
@@ -462,7 +460,9 @@ async def upload_image(
     try:
         with open(temp_path, "wb") as f:
             f.write(content)
-        logger.info("Image uploaded: %s (size=%d, type=%s)", temp_filename, len(content), detected_type)
+        logger.info(
+            "Image uploaded: %s (size=%d, type=%s)", temp_filename, len(content), detected_type
+        )
     except Exception as e:
         logger.error("Error uploading image: %s", e)
         raise HTTPException(status_code=500, detail="Failed to upload image") from e
@@ -559,12 +559,15 @@ def trigger_embedding_sync(
             f"Sync complete: {stats['articles_processed']} articles, "
             f"{stats['notes_processed']} notes processed. "
             f"{stats['embeddings_generated']} embeddings generated, "
-            f"{stats['embeddings_cached']} cached."
+            f"{stats['embeddings_cached']} cached, "
+            f"{stats['embeddings_failed']} failed."
         )
 
         logger.info("Manual embedding sync complete: %s", message)
 
-        return EmbeddingSyncResponse(success=True, message=message, stats=stats)
+        return EmbeddingSyncResponse(
+            success=stats["embeddings_failed"] == 0, message=message, stats=stats
+        )
 
     except Exception as e:
         logger.error("Manual embedding sync failed: %s", e)

--- a/backend/notes_service.py
+++ b/backend/notes_service.py
@@ -275,9 +275,7 @@ class NotesService:
         self._require_neo4j()
         return self.neo4j.get_central_notes(min_backlinks=min_backlinks)
 
-    def get_stale_notes(
-        self, days_threshold: int = 60, limit: int = 50
-    ) -> list[dict[str, Any]]:
+    def get_stale_notes(self, days_threshold: int = 60, limit: int = 50) -> list[dict[str, Any]]:
         """Get notes not updated in the specified number of days.
 
         Args:
@@ -379,8 +377,15 @@ class NotesService:
             embedding = self.ollama.generate_embedding(content, use_cache=True)
 
             if embedding:
+                from utils import calculate_content_hash
+
                 self.neo4j.store_embedding(
-                    "Note", note_id, embedding, self.ollama.model, EMBEDDING_VERSION
+                    "Note",
+                    note_id,
+                    embedding,
+                    self.ollama.model,
+                    EMBEDDING_VERSION,
+                    calculate_content_hash(content),
                 )
                 logger.info("Generated and stored embedding for note: %s", note_id)
             else:
@@ -450,9 +455,7 @@ class NotesService:
                     max_candidates=50,
                 )
 
-                response_text = (
-                    self.ollama.generate(prompt, role="structured", num_ctx=8192) or ""
-                )
+                response_text = self.ollama.generate(prompt, role="structured", num_ctx=8192) or ""
                 suggestions_data = ai_core.parse_json_response(response_text, expected_type="array")
 
                 if suggestions_data and isinstance(suggestions_data, list):
@@ -461,12 +464,14 @@ class NotesService:
                     link_suggestions = []
                     for s in suggestions_data[:5]:
                         if isinstance(s, dict) and s.get("note_id") in note_map:
-                            link_suggestions.append({
-                                "note_id": s["note_id"],
-                                "title": note_map[s["note_id"]].get("title", "Untitled"),
-                                "confidence": s.get("confidence", 0.5),
-                                "reason": s.get("reason", ""),
-                            })
+                            link_suggestions.append(
+                                {
+                                    "note_id": s["note_id"],
+                                    "title": note_map[s["note_id"]].get("title", "Untitled"),
+                                    "confidence": s.get("confidence", 0.5),
+                                    "reason": s.get("reason", ""),
+                                }
+                            )
                     if link_suggestions:
                         logger.info(
                             "Generated %d link suggestions for note: %s",

--- a/backend/tests/unit/test_embedding_sync.py
+++ b/backend/tests/unit/test_embedding_sync.py
@@ -1,0 +1,189 @@
+"""Unit tests for embedding_sync: staleness detection, retry, and stats.
+
+Regression tests for the bug where every sync regenerated all embeddings
+(nodes fetched without embedding metadata + content_hash never persisted),
+hammering the embedding API with burst requests (Gemini 429s).
+"""
+
+import time
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from embedding_sync import (
+    EMBEDDING_VERSION,
+    _generate_with_retry,
+    _process_embeddings_for_nodes,
+    needs_embedding_regeneration,
+    sync_embeddings,
+)
+from utils import calculate_content_hash
+
+MODEL = "gemini-embedding-001"
+
+
+def _fresh_node(content: str = "hello world") -> dict[str, Any]:
+    """A node whose embedding is up to date (should be skipped)."""
+    return {
+        "id": "curious-elephant",
+        "title": "Test",
+        "content": content,
+        "embedding": [0.1, 0.2],
+        "embedding_model": MODEL,
+        "embedding_version": EMBEDDING_VERSION,
+        "content_hash": calculate_content_hash(content),
+    }
+
+
+class TestNeedsEmbeddingRegeneration:
+    def test_fresh_node_is_skipped(self) -> None:
+        node = _fresh_node()
+        assert not needs_embedding_regeneration(node, MODEL, EMBEDDING_VERSION, node["content"])
+
+    def test_missing_embedding_regenerates(self) -> None:
+        node = _fresh_node()
+        del node["embedding"]
+        assert needs_embedding_regeneration(node, MODEL, EMBEDDING_VERSION, node["content"])
+
+    def test_model_change_regenerates(self) -> None:
+        node = _fresh_node()
+        assert needs_embedding_regeneration(node, "other-model", EMBEDDING_VERSION, node["content"])
+
+    def test_content_change_regenerates(self) -> None:
+        node = _fresh_node()
+        assert needs_embedding_regeneration(node, MODEL, EMBEDDING_VERSION, "edited content")
+
+
+class TestGenerateWithRetry:
+    def test_returns_immediately_on_success(self) -> None:
+        client = MagicMock()
+        client.generate_embedding.return_value = [0.1]
+        result = _generate_with_retry(client, "text", deadline=time.monotonic() + 600)
+        assert result == [0.1]
+        assert client.generate_embedding.call_count == 1
+
+    def test_retries_after_failure(self) -> None:
+        client = MagicMock()
+        client.generate_embedding.side_effect = [None, None, [0.5]]
+        with patch("embedding_sync.time.sleep") as mock_sleep:
+            result = _generate_with_retry(client, "text", deadline=time.monotonic() + 600)
+        assert result == [0.5]
+        assert client.generate_embedding.call_count == 3
+        # Exponential backoff: 2s then 4s
+        assert [c.args[0] for c in mock_sleep.call_args_list] == [2.0, 4.0]
+
+    def test_gives_up_at_deadline(self) -> None:
+        client = MagicMock()
+        client.generate_embedding.return_value = None
+        # Deadline already passed: one attempt, no sleeps
+        with patch("embedding_sync.time.sleep") as mock_sleep:
+            result = _generate_with_retry(client, "text", deadline=time.monotonic() - 1)
+        assert result is None
+        assert client.generate_embedding.call_count == 1
+        mock_sleep.assert_not_called()
+
+
+class TestProcessEmbeddingsForNodes:
+    def _stats(self) -> dict[str, int]:
+        return {
+            "articles_processed": 0,
+            "notes_processed": 0,
+            "embeddings_generated": 0,
+            "embeddings_cached": 0,
+            "embeddings_failed": 0,
+        }
+
+    def test_fresh_node_counts_as_cached_without_api_call(self) -> None:
+        neo4j = MagicMock()
+        client = MagicMock()
+        stats = self._stats()
+
+        _process_embeddings_for_nodes(
+            [_fresh_node()],
+            "Note",
+            "notes",
+            MODEL,
+            EMBEDDING_VERSION,
+            neo4j,
+            client,
+            stats,
+            deadline=time.monotonic() + 600,
+        )
+
+        client.generate_embedding.assert_not_called()
+        neo4j.store_embedding.assert_not_called()
+        assert stats["embeddings_cached"] == 1
+        assert stats["notes_processed"] == 1
+
+    def test_stale_node_stores_embedding_with_content_hash(self) -> None:
+        neo4j = MagicMock()
+        client = MagicMock()
+        client.generate_embedding.return_value = [0.1]
+        stats = self._stats()
+        node = _fresh_node()
+        del node["content_hash"]  # simulates pre-fix nodes
+
+        _process_embeddings_for_nodes(
+            [node],
+            "Note",
+            "notes",
+            MODEL,
+            EMBEDDING_VERSION,
+            neo4j,
+            client,
+            stats,
+            deadline=time.monotonic() + 600,
+        )
+
+        neo4j.store_embedding.assert_called_once_with(
+            "Note",
+            node["id"],
+            [0.1],
+            MODEL,
+            EMBEDDING_VERSION,
+            calculate_content_hash(node["content"]),
+        )
+        assert stats["embeddings_generated"] == 1
+
+    def test_failed_generation_counts_as_failed(self) -> None:
+        neo4j = MagicMock()
+        client = MagicMock()
+        client.generate_embedding.return_value = None
+        stats = self._stats()
+        node = _fresh_node()
+        del node["embedding"]
+
+        _process_embeddings_for_nodes(
+            [node],
+            "Note",
+            "notes",
+            MODEL,
+            EMBEDDING_VERSION,
+            neo4j,
+            client,
+            stats,
+            deadline=time.monotonic() - 1,  # no retries
+        )
+
+        neo4j.store_embedding.assert_not_called()
+        assert stats["embeddings_failed"] == 1
+        assert stats["notes_processed"] == 0
+
+
+class TestSyncEmbeddings:
+    def test_fetches_nodes_with_embedding_metadata(self) -> None:
+        """Regression: fetching without embeddings made every sync regenerate everything."""
+        neo4j = MagicMock()
+        neo4j.is_available.return_value = True
+        neo4j.get_all_articles.return_value = []
+        neo4j.get_all_notes.return_value = [_fresh_node()]
+        client = MagicMock()
+        client.embeddings_available.return_value = True
+        client.model = MODEL
+
+        stats = sync_embeddings(neo4j, client)
+
+        neo4j.get_all_articles.assert_called_once_with(include_embeddings=True)
+        neo4j.get_all_notes.assert_called_once_with(include_embeddings=True)
+        client.generate_embedding.assert_not_called()
+        assert stats["embeddings_cached"] == 1
+        assert stats["embeddings_failed"] == 0

--- a/backend/tests/unit/test_notes_api.py
+++ b/backend/tests/unit/test_notes_api.py
@@ -238,6 +238,7 @@ class TestListNotes:
             embedding=test_embedding,
             model="test-model",
             version=1,
+            content_hash="test-hash",
         )
 
         # List notes with embedding


### PR DESCRIPTION
## Summary
Fixes #213. Every run of the admin embedding sync regenerated all ~65 embeddings and burst-fired them at Gemini, causing 429 cascades (observed in prod after #212: consecutive syncs generated 7, 65, then 6 embeddings — everything else silently failed).

## Root causes
- `get_all_notes()`/`get_all_articles()` built dicts with `exclude_embedding=True`, so the staleness check never saw stored embeddings and always regenerated.
- `store_embedding()` never persisted `content_hash`, so the content-change check could never pass either.
- No 429 handling anywhere.

## Changes
- `Neo4jAdapter.get_all_notes/get_all_articles`: `include_embeddings` flag; sync passes `True`
- `Neo4jAdapter.store_embedding`: persists `content_hash`
- `embedding_sync`: failed generations retry with exponential backoff (2s→60s cap) under a shared 10-minute budget; new `embeddings_failed` stat
- `llm_client.ApiLLMClient.generate_embedding`: stays fail-fast (interactive callers shouldn't stall on 429s; the batch layer owns patience)
- Admin sync endpoint reports failed count and `success: false` when any item fails

## Testing
- New `tests/unit/test_embedding_sync.py` (staleness, retry/backoff, deadline, stats, regression for metadata fetch)
- Full backend suite: 334 passed; ruff + mypy clean
- Steady-state sync now makes zero Gemini calls once embeddings are fresh