### PR TITLE
fix: show true note totals in Notes header and fetch all Toolbox references

### DIFF
--- a/frontend/src/app/knowledge-base/notes/page.tsx
+++ b/frontend/src/app/knowledge-base/notes/page.tsx
@@ -253,7 +253,7 @@ function NotesContent() {
             <div className={styles.titleSection}>
               <h1 className={styles.title}>Notes</h1>
               <p className={styles.subtitle}>
-                Atomic insights and knowledge building ({notes.length} notes) &middot;{" "}
+                Atomic insights and knowledge building ({totalNotes} notes) &middot;{" "}
                 <Link href="/knowledge-base/toolbox" className={styles.toolboxLink}>
                   Looking for frameworks and checklists? Check the Toolbox →
                 </Link>

--- a/frontend/src/app/knowledge-base/toolbox/page.tsx
+++ b/frontend/src/app/knowledge-base/toolbox/page.tsx
@@ -24,13 +24,24 @@ export default function ToolboxPage() {
     async function fetchReferences() {
       try {
         setLoading(true);
-        // Fetch with previews only for performance
-        const response = await listNotes({
-          is_reference: true,
-          include_full_content: false,
-        });
-        setReferences(response.notes);
-        logger.info("Toolbox references loaded", { count: response.count });
+        // Fetch ALL references (the API paginates; without a limit it returns
+        // only the first 20 and the rest never render). Previews only for performance.
+        const all: Note[] = [];
+        let page = 1;
+        let totalPages = 1;
+        do {
+          const response = await listNotes({
+            is_reference: true,
+            include_full_content: false,
+            page,
+            limit: 100,
+          });
+          all.push(...response.notes);
+          totalPages = response.total_pages;
+          page += 1;
+        } while (page <= totalPages);
+        setReferences(all);
+        logger.info("Toolbox references loaded", { count: all.length });
       } catch (err) {
         const message = err instanceof Error ? err.message : "Failed to load references";
         setError(message);


### PR DESCRIPTION
## Summary
Fixes #216. Prod has 45 notes = 21 insights + 24 references, but the UI showed "20" in two places — both artifacts of the API's default page size (20):

- **Notes header** rendered `{notes.length}` (the fetched page) instead of the API `total`. Now uses the already-tracked `totalNotes` state.
- **Toolbox** called `listNotes({ is_reference: true })` with no `limit`, loading only the first 20 of 24 references — 4 were completely invisible on the page. Now pages through all references (`limit: 100` per request, looping `total_pages`).

The filtered-count display on Toolbox is unchanged — it was correct, just fed incomplete data.

## Testing
- tsc, eslint clean; 55 frontend unit tests pass
- After deploy: Notes header should read "(21 notes)" and Toolbox "24 references" against current prod data