### PR TITLE
fix: prod backups — write access, change detection, cron monitoring (+ frontend healthcheck)

### DIFF
--- a/backend/models/admin.py
+++ b/backend/models/admin.py
@@ -120,3 +120,10 @@ class DatabaseHealthResponse(BaseModel):
     needs_restore: bool = Field(..., description="Whether database appears to need restore")
     last_backup: str | None = Field(None, description="Timestamp of last backup (ISO 8601)")
     neo4j_available: bool = Field(..., description="Whether Neo4j connection is available")
+    backup_cron_last_run: str | None = Field(
+        None, description="Timestamp of the last backup-cron run (ISO 8601, from heartbeat file)"
+    )
+    backup_cron_healthy: bool | None = Field(
+        None,
+        description="False if the backup cron has not run within 48h; None if no heartbeat exists",
+    )

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import os
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Annotated, Any
 
@@ -432,6 +432,19 @@ def create_admin_router(neo4j_adapter: Any) -> APIRouter:
                 except Exception as e:
                     logger.warning("Failed to parse backup timestamp: %s", e)
 
+        # Backup-cron heartbeat (written by backup_neo4j_prod.sh on every run, #218)
+        backup_cron_last_run: str | None = None
+        backup_cron_healthy: bool | None = None
+        heartbeat_file = backup_dir / ".last_cron_run"
+        if heartbeat_file.exists():
+            try:
+                backup_cron_last_run = heartbeat_file.read_text().strip()
+                last_run = datetime.fromisoformat(backup_cron_last_run.replace("Z", "+00:00"))
+                backup_cron_healthy = datetime.now(UTC) - last_run < timedelta(hours=48)
+            except (ValueError, OSError) as e:
+                logger.warning("Failed to read backup cron heartbeat: %s", e)
+                backup_cron_healthy = False
+
         # Determine if restore is needed
         # Criteria: Neo4j unavailable OR note count is 0 but backups exist
         needs_restore = (not neo4j_available and backups_available > 0) or (
@@ -441,7 +454,7 @@ def create_admin_router(neo4j_adapter: Any) -> APIRouter:
         # Determine overall status
         if not neo4j_available:
             status = "unhealthy"
-        elif needs_restore:
+        elif needs_restore or backup_cron_healthy is False:
             status = "degraded"
         else:
             status = "healthy"
@@ -453,6 +466,8 @@ def create_admin_router(neo4j_adapter: Any) -> APIRouter:
             needs_restore=needs_restore,
             last_backup=last_backup,
             neo4j_available=neo4j_available,
+            backup_cron_last_run=backup_cron_last_run,
+            backup_cron_healthy=backup_cron_healthy,
         )
 
     return router

--- a/backend/scripts/backup_neo4j_prod.sh
+++ b/backend/scripts/backup_neo4j_prod.sh
@@ -50,6 +50,10 @@ if ! docker info >/dev/null 2>&1; then
     exit 1
 fi
 
+# Heartbeat: record that the cron job ran, even if we later skip or fail.
+# The backend health endpoint reads this to detect a dead cron (#218).
+date -u +%Y-%m-%dT%H:%M:%SZ > "${BACKUP_DIR}/.last_cron_run"
+
 # Create backup directory (will move dump here after creation)
 mkdir -p "${BACKUP_SUBDIR}"
 
@@ -68,8 +72,18 @@ log_info "Notes in database: ${NOTE_COUNT}"
 # Hash-based change detection
 HASH_FILE="${BACKUP_DIR}/.last_backup_hash"
 if [ -n "${NEO4J_PASSWORD:-}" ]; then
-    CONTENT_HASH=$(docker exec "${NEO4J_CONTAINER}" cypher-shell -u neo4j -p "${NEO4J_PASSWORD}" \
-        "MATCH (n:Note) RETURN count(n) as c, collect(n.title) as titles" 2>/dev/null | tail -1 | sha256sum | cut -d' ' -f1 || echo "unknown")
+    # count catches creates/deletes; max(updated_at) catches edits (content-only
+    # edits were previously invisible to change detection, #218)
+    QUERY_RESULT=$(docker exec "${NEO4J_CONTAINER}" cypher-shell -u neo4j -p "${NEO4J_PASSWORD}" \
+        "MATCH (n:Note) RETURN count(n) as c, max(n.updated_at) as u" 2>/dev/null | tail -1 || true)
+    if [ -n "$QUERY_RESULT" ]; then
+        CONTENT_HASH=$(echo "$QUERY_RESULT" | sha256sum | cut -d' ' -f1)
+    else
+        # An empty result must never be hashed: it produces a constant hash that,
+        # once saved, makes every future run skip as "no changes" (#218)
+        log_warn "Change-detection query failed - proceeding with backup"
+        CONTENT_HASH="unknown"
+    fi
 
     if [ -f "$HASH_FILE" ]; then
         LAST_HASH=$(cat "$HASH_FILE")

--- a/backend/tests/unit/test_admin_api.py
+++ b/backend/tests/unit/test_admin_api.py
@@ -374,3 +374,64 @@ class TestDatabaseHealth:
         if data["neo4j_available"] and data["notes_count"] == 0:
             assert data["needs_restore"] is True
             assert data["status"] in ["degraded", "unhealthy"]
+
+    def test_database_health_no_cron_heartbeat(self, client: TestClient) -> None:
+        """Without a heartbeat file, cron health is unknown (None), not unhealthy."""
+        with TemporaryDirectory() as temp_dir:
+            (Path(temp_dir) / "backups").mkdir()
+            with patch("routers.admin.Path.cwd", return_value=Path(temp_dir)):
+                response = client.get("/api/admin/health/database")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["backup_cron_last_run"] is None
+        assert data["backup_cron_healthy"] is None
+
+    def test_database_health_fresh_cron_heartbeat(self, client: TestClient) -> None:
+        """A heartbeat within 48h reports the cron as healthy."""
+        from datetime import UTC, datetime
+
+        with TemporaryDirectory() as temp_dir:
+            backup_dir = Path(temp_dir) / "backups"
+            backup_dir.mkdir()
+            timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+            (backup_dir / ".last_cron_run").write_text(timestamp + "\n")
+
+            with patch("routers.admin.Path.cwd", return_value=Path(temp_dir)):
+                response = client.get("/api/admin/health/database")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["backup_cron_last_run"] == timestamp
+        assert data["backup_cron_healthy"] is True
+
+    def test_database_health_stale_cron_heartbeat(self, client: TestClient) -> None:
+        """A heartbeat older than 48h reports the cron as unhealthy and degrades status."""
+        from datetime import UTC, datetime, timedelta
+
+        with TemporaryDirectory() as temp_dir:
+            backup_dir = Path(temp_dir) / "backups"
+            backup_dir.mkdir()
+            stale = datetime.now(UTC) - timedelta(days=5)
+            (backup_dir / ".last_cron_run").write_text(stale.strftime("%Y-%m-%dT%H:%M:%SZ"))
+
+            with patch("routers.admin.Path.cwd", return_value=Path(temp_dir)):
+                response = client.get("/api/admin/health/database")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["backup_cron_healthy"] is False
+        assert data["status"] in ["degraded", "unhealthy"]
+
+    def test_database_health_corrupt_cron_heartbeat(self, client: TestClient) -> None:
+        """An unparseable heartbeat is treated as unhealthy rather than crashing."""
+        with TemporaryDirectory() as temp_dir:
+            backup_dir = Path(temp_dir) / "backups"
+            backup_dir.mkdir()
+            (backup_dir / ".last_cron_run").write_text("not-a-timestamp")
+
+            with patch("routers.admin.Path.cwd", return_value=Path(temp_dir)):
+                response = client.get("/api/admin/health/database")
+
+        assert response.status_code == 200
+        assert response.json()["backup_cron_healthy"] is False

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -56,7 +56,7 @@ services:
       - ./backend/.env
     volumes:
       - ./backend/static:/app/static:ro  # Mount static files for hot-reload without restart
-      - /var/mongado-backups:/var/mongado-backups:ro  # Backup directory for health checks
+      - /var/mongado-backups:/var/mongado-backups  # Backup storage (rw: POST /api/admin/backup writes JSON exports here, #218)
     networks:
       - mongado-network
     depends_on:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -89,7 +89,9 @@ services:
       - mongado-network
     restart: always
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/"]
+      # 127.0.0.1, not localhost: busybox wget resolves localhost to ::1 and
+      # Next.js binds IPv4 only, so the probe is always refused (#221)
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3000/"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/frontend/src/app/admin/page.module.scss
+++ b/frontend/src/app/admin/page.module.scss
@@ -68,6 +68,73 @@
 .card {
   @include card-elevated;
   padding: $spacing-6;
+
+  & + & {
+    margin-top: $spacing-6;
+  }
+}
+
+.cardTitle {
+  @include heading-h3;
+  margin: 0 0 $spacing-4 0;
+}
+
+.success {
+  margin: 0 0 $spacing-4 0;
+  padding: $spacing-3 $spacing-4;
+  background-color: rgba(209, 250, 229, 0.8);
+  border: $border-width-thin solid rgba(5, 150, 105, 0.3);
+  border-radius: $border-radius-md;
+  color: $color-text-primary;
+}
+
+.healthGrid {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: $spacing-2 $spacing-6;
+  margin: 0 0 $spacing-5 0;
+
+  dt {
+    @include text-secondary;
+    font-size: $font-size-sm;
+    color: $color-text-secondary;
+  }
+
+  dd {
+    margin: 0;
+    font-family: $font-family-mono;
+    font-size: $font-size-sm;
+    color: $color-text-primary;
+  }
+}
+
+.badge {
+  display: inline-block;
+  padding: 0 $spacing-2;
+  border-radius: $border-radius-md;
+  font-family: $font-family-mono;
+  font-size: $font-size-sm;
+  text-transform: uppercase;
+}
+
+.healthy {
+  background-color: rgba(5, 150, 105, 0.15);
+  color: $color-text-primary;
+}
+
+.degraded {
+  background-color: rgba(217, 119, 6, 0.2);
+  color: $color-text-primary;
+}
+
+.unhealthy {
+  background-color: rgba(220, 38, 38, 0.2);
+  color: $color-text-primary;
+}
+
+.backupButton {
+  @include button-secondary;
+  @include button-sm;
 }
 
 .status {

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -1,15 +1,29 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import TopNavigation from "@/components/TopNavigation";
 import { isAuthenticated } from "@/lib/api/client";
-import { getFeatureFlags, updateFeatureFlag, type FeatureFlag } from "@/lib/api/admin";
+import {
+  getFeatureFlags,
+  updateFeatureFlag,
+  getDatabaseHealth,
+  createBackup,
+  type FeatureFlag,
+  type DatabaseHealth,
+} from "@/lib/api/admin";
 import { applyFeatureFlag } from "@/hooks/useFeatureFlags";
 import { logger } from "@/lib/logger";
 import styles from "./page.module.scss";
 
 const adminLogger = logger.withContext("AdminSettings");
+
+function formatTimestamp(iso: string | null): string {
+  if (!iso) return "never";
+  const date = new Date(iso);
+  if (isNaN(date.getTime())) return iso;
+  return date.toLocaleString();
+}
 
 export default function AdminPage() {
   const router = useRouter();
@@ -18,6 +32,20 @@ export default function AdminPage() {
   const [error, setError] = useState<string | null>(null);
   const [warning, setWarning] = useState<string | null>(null);
   const [saving, setSaving] = useState<string | null>(null);
+
+  const [health, setHealth] = useState<DatabaseHealth | null>(null);
+  const [healthError, setHealthError] = useState<string | null>(null);
+  const [backingUp, setBackingUp] = useState(false);
+  const [backupMessage, setBackupMessage] = useState<string | null>(null);
+
+  const loadHealth = useCallback(() => {
+    getDatabaseHealth()
+      .then(setHealth)
+      .catch((err) => {
+        adminLogger.error("Failed to load database health:", err);
+        setHealthError("Failed to load database health.");
+      });
+  }, []);
 
   useEffect(() => {
     if (!isAuthenticated()) {
@@ -32,7 +60,9 @@ export default function AdminPage() {
         setError("Failed to load feature flags. Is your admin session still valid?");
       })
       .finally(() => setLoading(false));
-  }, [router]);
+
+    loadHealth();
+  }, [router, loadHealth]);
 
   const handleToggle = async (flag: FeatureFlag) => {
     const newValue = !flag.enabled;
@@ -59,6 +89,25 @@ export default function AdminPage() {
       setSaving(null);
     }
   };
+
+  const handleBackup = async () => {
+    setBackingUp(true);
+    setBackupMessage(null);
+    setHealthError(null);
+
+    try {
+      const result = await createBackup();
+      setBackupMessage(`Backup created: ${result.backup_file} (${result.note_count} notes)`);
+      loadHealth();
+    } catch (err) {
+      adminLogger.error("Backup failed:", err);
+      setHealthError("Backup failed. Check the backend logs.");
+    } finally {
+      setBackingUp(false);
+    }
+  };
+
+  const cronStale = health?.backup_cron_healthy === false;
 
   return (
     <>
@@ -103,6 +152,53 @@ export default function AdminPage() {
                 </button>
               </div>
             ))}
+          </div>
+
+          <div className={styles.card}>
+            <h2 className={styles.cardTitle}>Database &amp; Backups</h2>
+
+            {healthError && <p className={styles.error}>{healthError}</p>}
+            {backupMessage && <p className={styles.success}>{backupMessage}</p>}
+            {cronStale && (
+              <p className={styles.warning}>
+                The nightly backup cron has not run in over 48 hours. Check{" "}
+                <code>mongado-backup-cron</code> on the droplet.
+              </p>
+            )}
+
+            {!health && !healthError && <p className={styles.status}>Loading health...</p>}
+
+            {health && (
+              <dl className={styles.healthGrid}>
+                <dt>Status</dt>
+                <dd>
+                  <span className={`${styles.badge} ${styles[health.status] ?? ""}`}>
+                    {health.status}
+                  </span>
+                </dd>
+                <dt>Notes</dt>
+                <dd>{health.notes_count}</dd>
+                <dt>Backups available</dt>
+                <dd>{health.backups_available}</dd>
+                <dt>Last backup</dt>
+                <dd>{formatTimestamp(health.last_backup)}</dd>
+                <dt>Cron last ran</dt>
+                <dd>
+                  {health.backup_cron_last_run
+                    ? formatTimestamp(health.backup_cron_last_run)
+                    : "no heartbeat recorded"}
+                </dd>
+              </dl>
+            )}
+
+            <button
+              type="button"
+              className={styles.backupButton}
+              disabled={backingUp}
+              onClick={handleBackup}
+            >
+              {backingUp ? "Backing up..." : "Back up now"}
+            </button>
           </div>
         </main>
       </div>

--- a/frontend/src/lib/api/admin.ts
+++ b/frontend/src/lib/api/admin.ts
@@ -2,7 +2,7 @@
  * Admin API - feature flag management (requires admin token)
  */
 
-import { apiGet, apiPut } from "./client";
+import { apiGet, apiPost, apiPut } from "./client";
 
 export interface FeatureFlag {
   name: string;
@@ -29,4 +29,31 @@ export async function updateFeatureFlag(
   enabled: boolean
 ): Promise<FeatureFlagUpdateResponse> {
   return apiPut<FeatureFlagUpdateResponse>(`/api/admin/feature-flags/${name}`, { enabled });
+}
+
+export interface DatabaseHealth {
+  status: "healthy" | "degraded" | "unhealthy";
+  notes_count: number;
+  backups_available: number;
+  needs_restore: boolean;
+  last_backup: string | null;
+  neo4j_available: boolean;
+  backup_cron_last_run: string | null;
+  backup_cron_healthy: boolean | null;
+}
+
+export interface BackupCreateResponse {
+  status: string;
+  backup_file: string;
+  timestamp: string;
+  downtime_seconds: number;
+  note_count: number;
+}
+
+export async function getDatabaseHealth(): Promise<DatabaseHealth> {
+  return apiGet<DatabaseHealth>("/api/admin/health/database");
+}
+
+export async function createBackup(): Promise<BackupCreateResponse> {
+  return apiPost<BackupCreateResponse>("/api/admin/backup", {});
 }


### PR DESCRIPTION
## Summary

Fixes the two prod backup failures from #218 plus the always-failing frontend healthcheck found during verification (#221).

**Fixes #218, fixes #221**

### Backup endpoint (hard-broken)
- `POST /api/admin/backup` writes its JSON export to `/var/mongado-backups`, but the prod backend mounted it `:ro` — every call failed with `[Errno 30] Read-only file system`. Mount is now `rw`.

### Nightly cron (silent since April 2)
Prod log confirmed the cron ran every night and skipped with "no changes detected" — the change-detection hash covered only note count + titles, so **content-only edits were invisible**.
- Hash now includes `max(n.updated_at)` — edits trigger backups
- Hardened a latent poison-hash bug: an empty cypher-shell result hashed to a constant that, once saved, made all future runs skip forever; now warns and backs up anyway
- Self-healing rollout: the changed hash query guarantees a mismatch with the stored hash, so the first nightly run after deploy takes a fresh backup

### Never fail silently again
- Cron writes a `.last_cron_run` heartbeat on every run (including skips)
- `GET /api/admin/health/database` reports `backup_cron_last_run` / `backup_cron_healthy` and degrades status when the heartbeat is >48h stale
- Admin UI: new **Database & Backups** card — health status, note/backup counts, staleness warning, and a manual "Back up now" button

### Frontend healthcheck (#221)
busybox wget resolves `localhost` → `::1` with no IPv4 fallback while Next.js binds IPv4 only, so `mongado-frontend-prod` was unhealthy on all 28k+ checks since startup. Probe `127.0.0.1:3000` instead.

## Testing
- 23/23 backend admin API tests (4 new heartbeat tests), mypy + ruff clean
- Frontend: tsc, eslint, 64/64 unit tests
- Both compose files validate; live-verified the new health fields and `/admin` render in dev

## Post-merge verification
1. Frontend container flips to healthy within ~1 min of deploy
2. Admin panel → Database & Backups → "Back up now" succeeds (exercises the rw mount)
3. Next 2am run produces a real backup; health card shows fresh cron heartbeat