### PR TITLE
fix: backup dir ownership for backend writes (+ error detail in admin UI)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -138,6 +138,14 @@ jobs:
             export NEO4J_PASSWORD="$NEO4J_PASSWORD"
             export NEO4J_AUTH="neo4j/$NEO4J_PASSWORD"
 
+            # Ensure the backup directory exists and is writable by the backend
+            # container, which runs as uid 1000 (appuser). Root ownership breaks
+            # POST /api/admin/backup with EACCES (#218). Root-run writers
+            # (backup-cron, neo4j-admin dumps) are unaffected.
+            echo "🗄️  Ensuring backup directory ownership..."
+            mkdir -p /var/mongado-backups
+            chown 1000:1000 /var/mongado-backups
+
             # Build and restart containers (without --no-cache to reduce resource usage)
             # --remove-orphans cleans up services deleted from the compose file
             # (e.g. the prod Ollama container removed in #190)

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -101,7 +101,8 @@ export default function AdminPage() {
       loadHealth();
     } catch (err) {
       adminLogger.error("Backup failed:", err);
-      setHealthError("Backup failed. Check the backend logs.");
+      const detail = err instanceof Error ? err.message : "Check the backend logs.";
+      setHealthError(`Backup failed: ${detail}`);
     } finally {
       setBackingUp(false);
     }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

Follow-up to #222, **fixes #218** (reopened): the rw mount traded EROFS for EACCES. The backend container runs as `appuser` (uid 1000) but `/var/mongado-backups` on the host is root-owned, so `POST /api/admin/backup` still failed in prod.

## Changes
- **Deploy workflow**: ensure `/var/mongado-backups` exists and is owned by `1000:1000` before `compose up` — idempotent, survives droplet rebuilds, and merging this PR auto-heals prod. Root-run writers (backup-cron, `neo4j-admin` dumps) are unaffected.
- **Admin UI**: backup failures now surface the backend's error detail (`err.message` carries the API `detail` field) instead of a generic message — the original EACCES would have been visible immediately.
- **tsconfig**: `target` `es5` → `ES2017` (Next.js recommended).

## Testing
- Frontend tsc, eslint, 64/64 unit tests green
- Deploy script addition is static shell, no untrusted interpolation

## Post-merge verification
Admin panel → Database & Backups → "Back up now" should succeed and bump the backup count.