### PR TITLE
fix: bind container ports to loopback, forward real client IPs

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -80,5 +80,9 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8000/ || exit 1
 
-# Run with production settings (uvloop, httptools from uvicorn[standard])
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "4", "--loop", "uvloop", "--http", "httptools"]
+# Run with production settings (uvloop, httptools from uvicorn[standard]).
+# --proxy-headers: trust X-Forwarded-For from host nginx so request.client is
+# the real visitor, not the Docker bridge IP — without it slowapi rate-limits
+# all traffic in one global bucket (#226). Trusting '*' is safe because the
+# host port is bound to 127.0.0.1; only nginx can reach the container.
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "4", "--loop", "uvloop", "--http", "httptools", "--proxy-headers", "--forwarded-allow-ips", "*"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,9 +2,13 @@ services:
   neo4j:
     image: neo4j:latest
     container_name: mongado-neo4j-prod
+    # Loopback-only: nothing external needs Neo4j (backend uses the Docker
+    # network, backups use docker exec). Docker-published ports bypass ufw,
+    # so 0.0.0.0 here meant the DB was internet-reachable (#226).
+    # Droplet-local admin still works, e.g. via SSH tunnel.
     ports:
-      - "7474:7474"  # HTTP (browser interface)
-      - "7687:7687"  # Bolt protocol
+      - "127.0.0.1:7474:7474"  # HTTP (browser interface)
+      - "127.0.0.1:7687:7687"  # Bolt protocol
     environment:
       - NEO4J_AUTH=${NEO4J_AUTH:?NEO4J_AUTH must be set in production}
       - NEO4J_PLUGINS=["apoc"]
@@ -38,8 +42,10 @@ services:
       context: ./backend
       target: production
     container_name: mongado-backend-prod
+    # Loopback-only: host nginx proxies api.mongado.com -> localhost:8000.
+    # 0.0.0.0 let clients bypass Cloudflare + nginx entirely (#226).
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     environment:
       - DEBUG=false
       - OP_MONGADO_SERVICE_ACCOUNT_TOKEN=${OP_MONGADO_SERVICE_ACCOUNT_TOKEN}
@@ -77,8 +83,9 @@ services:
       args:
         - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://localhost:8000}
     container_name: mongado-frontend-prod
+    # Loopback-only: host nginx proxies mongado.com -> localhost:3000 (#226).
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     environment:
       - NODE_ENV=production
       - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://localhost:8000}

--- a/infra/nginx/README.md
+++ b/infra/nginx/README.md
@@ -1,0 +1,50 @@
+# nginx (production droplet)
+
+Host-level nginx that fronts the Docker containers. **Not** deployed by the
+GitHub Actions workflow — changes must be applied manually.
+
+## Topology
+
+```
+Visitor
+  └─ Cloudflare edge (TLS, proxied DNS: mongado.com / api.mongado.com)
+       └─ nginx on droplet :80/:443 (Let's Encrypt via certbot)
+            ├─ mongado.com      → 127.0.0.1:3000 (frontend container)
+            └─ api.mongado.com  → 127.0.0.1:8000 (backend container)
+```
+
+Container ports (including Neo4j 7474/7687) are bound to `127.0.0.1` in
+`docker-compose.prod.yml` — Docker-published ports bypass ufw, so anything on
+`0.0.0.0` is internet-reachable regardless of firewall rules (#226).
+
+## Applying changes
+
+```bash
+scp infra/nginx/mongado.conf <droplet>:/etc/nginx/sites-available/mongado
+ssh <droplet> "nginx -t && systemctl reload nginx"
+```
+
+`sites-enabled/mongado` is a symlink to `sites-available/mongado`.
+
+## Key decisions
+
+- **Client IPs**: `CF-Connecting-IP` (with `$remote_addr` fallback) is passed
+  as `X-Forwarded-For`; uvicorn runs with `--proxy-headers` so slowapi
+  rate-limits per real visitor. `$proxy_add_x_forwarded_for` was deliberately
+  replaced — it preserves client-spoofable XFF values.
+- **HSTS** is set at nginx for both origins (HTTP→HTTPS redirects already in
+  place via certbot).
+- **Security headers** for the frontend origin live here; the API sets its own
+  via FastAPI `SecurityHeadersMiddleware`. CSP for the frontend is tracked in
+  #172.
+- **certbot** manages the `# managed by Certbot` lines and renewals; keep them
+  intact when editing.
+
+## Droplet admin access to Neo4j
+
+Ports are loopback-only. From your machine, tunnel:
+
+```bash
+ssh -L 7474:localhost:7474 -L 7687:localhost:7687 <droplet>
+# then browse http://localhost:7474
+```

--- a/infra/nginx/mongado.conf
+++ b/infra/nginx/mongado.conf
@@ -1,0 +1,134 @@
+# Mongado production nginx config
+#
+# Lives on the droplet at /etc/nginx/sites-enabled/mongado (symlinked from
+# sites-available). This file is the source of truth — the droplet copy is
+# NOT managed by the deploy workflow; apply changes manually:
+#
+#   scp infra/nginx/mongado.conf <droplet>:/etc/nginx/sites-available/mongado
+#   ssh <droplet> "nginx -t && systemctl reload nginx"
+#
+# Topology (#226): Cloudflare edge (TLS to visitors, proxied DNS)
+#   -> this nginx (80/443, Let's Encrypt certs via certbot)
+#   -> Docker containers on 127.0.0.1 (frontend :3000, backend :8000)
+#
+# Lines marked "managed by Certbot" are certbot's; keep them intact so
+# `certbot renew` keeps working.
+
+# Real client IP: behind Cloudflare, CF-Connecting-IP is the only
+# trustworthy client identity ($proxy_add_x_forwarded_for keeps
+# client-supplied XFF values, which are spoofable). Fall back to
+# $remote_addr for any request that didn't come through Cloudflare.
+map $http_cf_connecting_ip $client_ip {
+    ""      $remote_addr;
+    default $http_cf_connecting_ip;
+}
+
+# Frontend - mongado.com and www.mongado.com
+server {
+    server_name mongado.com www.mongado.com;
+
+    # Hide nginx version in headers/error pages
+    server_tokens off;
+
+    # Security headers for the frontend origin. CSP is tracked separately
+    # (#172) since it needs app-level knowledge (inline theme script).
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    # Let's Encrypt challenge
+    location /.well-known/acme-challenge/ {
+        root /var/www/html;
+    }
+
+    # Proxy to frontend container (loopback-bound, see docker-compose.prod.yml)
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+        proxy_set_header X-Real-IP $client_ip;
+        proxy_set_header X-Forwarded-For $client_ip;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    listen [::]:443 ssl ipv6only=on; # managed by Certbot
+    listen 443 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/mongado.com/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/mongado.com/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+}
+
+# Backend API - api.mongado.com
+server {
+    server_name api.mongado.com;
+
+    server_tokens off;
+
+    # HSTS only: the FastAPI SecurityHeadersMiddleware already sets the
+    # other security headers app-side; duplicating them here would emit
+    # doubled headers.
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+    # Let's Encrypt challenge
+    location /.well-known/acme-challenge/ {
+        root /var/www/html;
+    }
+
+    # Proxy to backend container (loopback-bound, see docker-compose.prod.yml)
+    location / {
+        proxy_pass http://localhost:8000;
+        # Generous timeouts for SSE streaming endpoints (AI suggestions)
+        proxy_read_timeout 300s;
+        proxy_connect_timeout 300s;
+        proxy_send_timeout 300s;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+        # X-Forwarded-For feeds uvicorn --proxy-headers -> request.client ->
+        # slowapi rate-limit keys. Must be the single real client IP (#226).
+        proxy_set_header X-Real-IP $client_ip;
+        proxy_set_header X-Forwarded-For $client_ip;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    listen [::]:443 ssl; # managed by Certbot
+    listen 443 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/mongado.com/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/mongado.com/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+}
+
+# HTTP -> HTTPS redirects
+server {
+    if ($host = www.mongado.com) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
+
+    if ($host = mongado.com) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
+
+    listen 80;
+    listen [::]:80;
+    server_name mongado.com www.mongado.com;
+    return 404; # managed by Certbot
+}
+
+server {
+    if ($host = api.mongado.com) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
+
+    listen 80;
+    listen [::]:80;
+    server_name api.mongado.com;
+    return 404; # managed by Certbot
+}


### PR DESCRIPTION
## Summary

Implements #226 (final finding of the 2026-07 security audit). Confirmed topology: Cloudflare edge (TLS) → host nginx (Let's Encrypt) → Docker containers, with **ufw inactive**.

**Fixes #226**

## The exposure
- `docker-compose.prod.yml` published Neo4j (7474/7687), backend (8000), and frontend (3000) on `0.0.0.0`. Docker-published ports bypass ufw, so the **production database's bolt port was internet-reachable**, protected only by its password — and clients could hit the apps directly, skipping Cloudflare and nginx.
- Prod uvicorn ran without `--proxy-headers`, so `request.client` was the Docker bridge IP for every request: slowapi rate-limited **all traffic in one global bucket** (any one visitor hitting 60 searches/min throttled the whole site; per-client abuse protection was nonexistent).

## Changes
- **Loopback bindings** for all four container ports — nothing external needs them (backend reaches Neo4j over the Docker network; backups use `docker exec`; nginx proxies locally). Droplet-local admin still works via SSH tunnel (recipe in the README).
- **`--proxy-headers --forwarded-allow-ips '*'`** on prod uvicorn — safe to trust because the port is loopback-bound; only nginx can reach it.
- **`infra/nginx/`** — the live droplet config is now version-controlled, with fixes: `X-Forwarded-For` from `CF-Connecting-IP` (spoof-resistant, $remote_addr fallback for direct connections), `server_tokens off`, HSTS on both origins, frontend security headers (narrows #172 to just CSP), certbot lines preserved verbatim.

## Testing
- `docker compose -f docker-compose.prod.yml config` validates
- nginx config syntax-checked in an nginx:alpine container (cert paths stubbed)
- No app code changed; CI covers the rest

## Post-merge (manual — nginx is not workflow-managed)
1. `scp infra/nginx/mongado.conf <droplet>:/etc/nginx/sites-available/mongado`
2. `ssh <droplet> "nginx -t && systemctl reload nginx"`
3. Verify from outside: `nmap -p 3000,8000,7474,7687 <droplet-ip>` → all closed/filtered; site + admin panel work normally through Cloudflare
4. Optional check that rate-limit keys are now per-client: two different networks hitting search shouldn't share a bucket