### PR TITLE
Server-render article pages with ISR (fixes #207)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -89,6 +89,8 @@ services:
     environment:
       - NODE_ENV=production
       - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://localhost:8000}
+      # Server components fetch the backend over the Docker network (#207)
+      - API_URL_INTERNAL=http://backend:8000
     depends_on:
       backend:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,8 @@ services:
       - /app/.next
     environment:
       - NEXT_PUBLIC_API_URL=http://localhost:8000
+      # Server components fetch the backend over the Docker network (#207)
+      - API_URL_INTERNAL=http://backend:8000
       # NODE_ENV is automatically set by Next.js commands:
       # - 'npm run dev' sets NODE_ENV=development
       # - 'npm run build' sets NODE_ENV=production

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -124,6 +124,7 @@ Add these secrets:
 | `GROQ_API_KEY` | No | - | Hosted generation, primary (set via GitHub secret) |
 | `GEMINI_API_KEY` | No | - | Hosted generation fallback + embeddings (set via GitHub secret) |
 | `EMBEDDING_PROVIDER` | No | `ollama` | `api` routes embeddings to Gemini (prod) |
+| `API_URL_INTERNAL` | No | falls back to `NEXT_PUBLIC_API_URL` | Backend URL for the frontend's server-side fetches (#207). Set to `http://backend:8000` in both compose files - server components run inside the frontend container, where the public URL isn't the right host |
 | `DEBUG` | No | `false` | Enable debug mode (set to `false` in production) |
 
 **Important Notes**:

--- a/docs/knowledge-base/ARTICLES.md
+++ b/docs/knowledge-base/ARTICLES.md
@@ -10,6 +10,7 @@ Articles are static markdown files stored in source control, designed for:
 - **Fast rendering**: Intelligent caching with hot-reload in dev
 - **Optimized assets**: WebP images with long-term browser caching
 - **Zero database**: All content loaded from filesystem at startup
+- **Server-rendered pages**: Article pages are Next.js server components (#207) - the article HTML is in the initial response and cached with a short revalidate window, so readers and search engines never wait on a client-side fetch
 
 ## Directory Structure
 

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -31,6 +31,11 @@ const nextConfig = {
   output: "standalone",
   poweredByHeader: false,
 
+  // isomorphic-dompurify uses jsdom on the server, which reads its
+  // default-stylesheet.css from disk at runtime - bundling it breaks that
+  // path resolution (ENOENT), so require it from node_modules instead
+  serverExternalPackages: ["isomorphic-dompurify"],
+
   // Rewrite @phosphor-icons/react barrel imports to per-icon imports.
   // Without this, webpack compiles all ~9,000 icons into every route that
   // renders the nav (10k+ modules, 10s+ dev compiles).

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@uiw/react-codemirror": "^4.25.2",
         "d3": "^7.9.0",
         "dompurify": "^3.3.1",
+        "isomorphic-dompurify": "^3.18.0",
         "next": "^15.5.7",
         "react": "^19.2.1",
         "react-dom": "^19.2.1",
@@ -126,11 +127,19 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/@asamuzakjp/nwsapi": {
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
@@ -434,6 +443,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@codemirror/autocomplete": {
       "version": "6.20.3",
       "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
@@ -591,7 +612,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
       "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -611,7 +631,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
       "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -635,7 +654,6 @@
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
       "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -663,7 +681,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
       "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -686,7 +703,6 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
       "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -711,7 +727,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
       "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1360,7 +1375,6 @@
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
       "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -1533,9 +1547,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1551,9 +1562,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1571,9 +1579,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1589,9 +1594,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1609,9 +1611,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1627,9 +1626,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1647,9 +1643,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1666,9 +1659,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1684,9 +1674,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1710,9 +1697,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1734,9 +1718,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1760,9 +1741,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1784,9 +1762,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1810,9 +1785,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1835,9 +1807,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1859,9 +1828,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2189,9 +2155,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2207,9 +2170,6 @@
       "integrity": "sha512-RQmDfeYBtXV2FSId7dfA1hE6M/T6+g7wdbYnFQ47tw/gUBwV+CccLVejNmCGa9yLDitk83foeg8hl/3DjfYQ5g==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2227,9 +2187,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2245,9 +2202,6 @@
       "integrity": "sha512-rAO5b7pKHvX+ExdmJskusDXTNbiNZfptifIPZItbUx+AOXxxTydVBsPt7Oz84DRd5mY8e0DcE8kvLj3AIfjE6w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2342,6 +2296,7 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2381,6 +2336,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2401,6 +2357,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2421,6 +2378,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2441,6 +2399,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2461,9 +2420,7 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2484,9 +2441,7 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2507,9 +2462,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2530,9 +2483,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2553,9 +2504,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2576,9 +2525,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2599,6 +2546,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2619,6 +2567,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2639,6 +2588,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2656,6 +2606,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -2811,9 +2762,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2828,9 +2776,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2845,9 +2790,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2862,9 +2804,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2879,9 +2818,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2896,9 +2832,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2913,9 +2846,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2930,9 +2860,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2947,9 +2874,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2964,9 +2888,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2981,9 +2902,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2998,9 +2916,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3015,9 +2930,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4159,9 +4071,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4176,9 +4085,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4193,9 +4099,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4210,9 +4113,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4227,9 +4127,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4244,9 +4141,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4261,9 +4155,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4278,9 +4169,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4295,9 +4183,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4312,9 +4197,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5018,7 +4900,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
@@ -5381,7 +5262,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mdn-data": "2.27.1",
@@ -5944,7 +5824,6 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
@@ -6131,7 +6010,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
       "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20.19.0"
@@ -7064,6 +6942,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7543,7 +7422,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.6.0"
@@ -7905,7 +7783,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7961,7 +7839,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -8059,7 +7937,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-regex": {
@@ -8220,6 +8097,136 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/isomorphic-dompurify": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-3.18.0.tgz",
+      "integrity": "sha512-ajp0D8laIHeoYlhBTevpE2HUhqWaqLXFk6K/wV3Ok8kDraBZpZsifwVWaY8IfJntMRIo1VSksgKV+lXyet9Q7A==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "^3.4.11",
+        "jsdom": "^29.1.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -8931,7 +8938,6 @@
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/merge2": {
@@ -9705,6 +9711,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -9987,7 +9994,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
       "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^8.0.0"
@@ -10259,7 +10265,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10547,7 +10552,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10775,7 +10779,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
@@ -11453,7 +11456,6 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/test-exclude": {
@@ -11606,7 +11608,6 @@
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.6.tgz",
       "integrity": "sha512-rbP0Gyx8b3Ae9yO//CU2wbSnQNoQ66m1nJdSbSHmnwKwzkkz/u8mERYU8T2rmlmy+bJvRNn84yNCW8gYqox44Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^7.4.6"
@@ -11619,7 +11620,6 @@
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.6.tgz",
       "integrity": "sha512-TkQNGJIhlEphpHCjKodMTSe23egUZr/g+flI2qkLgiJ/maAzSgXypSLRTNH3nCmqgayEmtcJBiLcfODSAr1xoA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/to-regex-range": {
@@ -11649,7 +11649,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
       "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^7.0.5"
@@ -11662,7 +11661,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -11858,6 +11856,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -12301,7 +12308,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
@@ -12314,7 +12320,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20"
@@ -12652,7 +12657,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -12662,7 +12666,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/yallist": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "@uiw/react-codemirror": "^4.25.2",
     "d3": "^7.9.0",
     "dompurify": "^3.3.1",
+    "isomorphic-dompurify": "^3.18.0",
     "next": "^15.5.7",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",

--- a/frontend/src/app/knowledge-base/articles/ArticlesClient.tsx
+++ b/frontend/src/app/knowledge-base/articles/ArticlesClient.tsx
@@ -1,0 +1,348 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+import AIAssistant from "@/components/AIAssistant";
+import { useRouter, useSearchParams } from "next/navigation";
+import Breadcrumb from "@/components/Breadcrumb";
+import { TagPillList } from "@/components/TagPill";
+import styles from "./page.module.scss";
+
+export interface ArticleMetadata {
+  id: number;
+  title: string;
+  summary?: string; // Optional 1-2 sentence description
+  url?: string;
+  tags: string[];
+  draft?: boolean;
+  published_date?: string;
+  updated_date?: string;
+  created_at?: string; // Legacy fallback
+}
+
+type SortOption = "newest" | "oldest" | "recently-updated" | "alphabetical";
+
+export default function ArticlesClient({ resources }: { resources: ArticleMetadata[] }) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const tagsParam = searchParams.get("tags");
+  const selectedTags = tagsParam ? tagsParam.split(",") : [];
+
+  const [searchQuery, setSearchQuery] = useState("");
+  const [sortBy, setSortBy] = useState<SortOption>("newest");
+  const [showAllTags, setShowAllTags] = useState(false);
+
+  // Calculate tag counts
+  const tagCounts = resources.reduce(
+    (acc, resource) => {
+      resource.tags.forEach((tag) => {
+        acc[tag] = (acc[tag] || 0) + 1;
+      });
+      return acc;
+    },
+    {} as Record<string, number>
+  );
+
+  // Sort tags by count (descending), then alphabetically
+  const sortedTags = Object.entries(tagCounts).sort((a, b) => {
+    if (b[1] !== a[1]) return b[1] - a[1];
+    return a[0].localeCompare(b[0]);
+  });
+
+  // Separate tags into top (2+ articles) and other (1 article)
+  const topTags = sortedTags.filter(([_, count]) => count >= 2);
+  const otherTags = sortedTags.filter(([_, count]) => count === 1);
+  const visibleTags = showAllTags ? sortedTags : topTags;
+
+  const filteredResources = resources
+    .filter((resource) => {
+      // Filter by tags (OR logic - article must have at least one selected tag)
+      if (selectedTags.length > 0) {
+        const hasMatchingTag = selectedTags.some((tag) => resource.tags.includes(tag));
+        if (!hasMatchingTag) return false;
+      }
+
+      // Filter by search query
+      if (!searchQuery) return true;
+      const query = searchQuery.toLowerCase();
+      return (
+        resource.title.toLowerCase().includes(query) ||
+        (resource.summary && resource.summary.toLowerCase().includes(query)) ||
+        resource.tags.some((tag) => tag.toLowerCase().includes(query))
+      );
+    })
+    .sort((a, b) => {
+      // Sort drafts to the top first
+      if (a.draft && !b.draft) return -1;
+      if (!a.draft && b.draft) return 1;
+
+      // Then sort by selected option
+      switch (sortBy) {
+        case "newest": {
+          const dateA = new Date(a.published_date || a.created_at || 0).getTime();
+          const dateB = new Date(b.published_date || b.created_at || 0).getTime();
+          return dateB - dateA;
+        }
+        case "oldest": {
+          const dateA = new Date(a.published_date || a.created_at || 0).getTime();
+          const dateB = new Date(b.published_date || b.created_at || 0).getTime();
+          return dateA - dateB;
+        }
+        case "recently-updated": {
+          const dateA = new Date(a.updated_date || a.published_date || a.created_at || 0).getTime();
+          const dateB = new Date(b.updated_date || b.published_date || b.created_at || 0).getTime();
+          return dateB - dateA;
+        }
+        case "alphabetical":
+          return a.title.localeCompare(b.title);
+        default:
+          return 0;
+      }
+    });
+
+  const handleTagClick = (tag: string) => {
+    let newTags: string[];
+
+    if (selectedTags.includes(tag)) {
+      // Tag is already selected, remove it
+      newTags = selectedTags.filter((t) => t !== tag);
+    } else {
+      // Tag is not selected, add it
+      newTags = [...selectedTags, tag];
+    }
+
+    // Update URL with new tags
+    if (newTags.length > 0) {
+      router.push(`/knowledge-base/articles?tags=${newTags.map(encodeURIComponent).join(",")}`);
+    } else {
+      router.push("/knowledge-base/articles");
+    }
+  };
+
+  const clearAllFilters = () => {
+    setSearchQuery("");
+    router.push("/knowledge-base/articles");
+  };
+
+  const hasActiveFilters = Boolean(selectedTags.length > 0 || searchQuery);
+
+  return (
+    <div className={styles.container}>
+      {/* AI panel + button island (only shown when LLM features enabled) */}
+      <AIAssistant />
+
+      {/* Header */}
+      <header className={styles.header}>
+        <div className={styles.headerContent}>
+          <div className={styles.breadcrumb}>
+            <Breadcrumb section="articles" toHub />
+          </div>
+          <h1 className={styles.title}>Articles</h1>
+        </div>
+      </header>
+
+      <main className={styles.main}>
+        <div className={styles.contentGrid}>
+          {/* Sidebar - Filters */}
+          <aside className={styles.sidebar}>
+            {/* Search */}
+            <div className={styles.searchBar}>
+              <input
+                type="text"
+                placeholder="Search articles..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className={styles.searchInput}
+                aria-label="Search articles by title, summary, or tags"
+              />
+            </div>
+
+            {/* Sort */}
+            <div className={styles.sortSection}>
+              <label htmlFor="sort-select" className={styles.sortLabel}>
+                Sort by:
+              </label>
+              <select
+                id="sort-select"
+                value={sortBy}
+                onChange={(e) => setSortBy(e.target.value as SortOption)}
+                className={styles.sortSelect}
+              >
+                <option value="newest">Newest</option>
+                <option value="oldest">Oldest</option>
+                <option value="recently-updated">Recently Updated</option>
+                <option value="alphabetical">Alphabetical</option>
+              </select>
+            </div>
+
+            {/* Tag Filter Section */}
+            {sortedTags.length > 0 && (
+              <div className={styles.tagFilterSection}>
+                <div className={styles.tagFilterHeader}>
+                  <span className={styles.tagFilterLabel}>Filter by tag:</span>
+                </div>
+                <div className={styles.tagBadges}>
+                  {visibleTags.map(([tag, count]) => {
+                    const isActive = selectedTags.includes(tag);
+                    // Determine tag size class based on count
+                    let sizeClass = styles.tagLow;
+                    if (count >= 3) sizeClass = styles.tagHigh;
+                    else if (count === 2) sizeClass = styles.tagMedium;
+
+                    return (
+                      <button
+                        key={tag}
+                        onClick={() => handleTagClick(tag)}
+                        className={`${styles.tagBadge} ${sizeClass} ${isActive ? styles.tagBadgeActive : ""}`}
+                        type="button"
+                        aria-label={`Filter by tag: ${tag}, ${count} articles`}
+                        aria-pressed={isActive}
+                      >
+                        #{tag} ({count})
+                      </button>
+                    );
+                  })}
+                </div>
+                {otherTags.length > 0 && !showAllTags && (
+                  <button
+                    onClick={() => setShowAllTags(true)}
+                    className={styles.showMoreButton}
+                    type="button"
+                    aria-label={`Show ${otherTags.length} more tags`}
+                    aria-expanded="false"
+                  >
+                    + Show {otherTags.length} more
+                  </button>
+                )}
+                {showAllTags && otherTags.length > 0 && (
+                  <button
+                    onClick={() => setShowAllTags(false)}
+                    className={styles.showMoreButton}
+                    type="button"
+                    aria-label="Show fewer tags"
+                    aria-expanded="true"
+                  >
+                    − Show fewer
+                  </button>
+                )}
+              </div>
+            )}
+
+            {/* Clear Filters */}
+            {hasActiveFilters && (
+              <button
+                onClick={clearAllFilters}
+                className={styles.clearAllButtonSidebar}
+                aria-label="Clear all active filters"
+              >
+                Clear all filters
+              </button>
+            )}
+          </aside>
+
+          {/* Main Content - Articles */}
+          <div className={styles.articlesContent}>
+            {/* Article Count and Active Filters */}
+            <div className={styles.resultsBar}>
+              <div className={styles.articleCountSection}>
+                {selectedTags.length > 0 && (
+                  <div className={styles.activeFilters}>
+                    Filtering by:{" "}
+                    {selectedTags.map((tag, index) => (
+                      <span key={tag}>
+                        #{tag}
+                        {index < selectedTags.length - 1 && ", "}
+                      </span>
+                    ))}
+                  </div>
+                )}
+                <div className={styles.articleCount}>
+                  Showing {filteredResources.length}
+                  {filteredResources.length !== resources.length && ` of ${resources.length}`}{" "}
+                  {filteredResources.length === 1 ? "article" : "articles"}
+                </div>
+              </div>
+            </div>
+
+            {/* Articles List */}
+            <div className={styles.articlesList}>
+              {filteredResources.length === 0 ? (
+                <div className={styles.emptyState}>
+                  <p className={styles.emptyMessage}>
+                    {searchQuery ? "No articles match your search" : "No articles yet"}
+                  </p>
+                  {searchQuery && (
+                    <button
+                      onClick={() => setSearchQuery("")}
+                      className={styles.clearSearchButton}
+                      aria-label="Clear search query"
+                    >
+                      Clear search
+                    </button>
+                  )}
+                </div>
+              ) : (
+                filteredResources.map((resource) => {
+                  return (
+                    <Link
+                      key={resource.id}
+                      href={`/knowledge-base/articles/${resource.id}`}
+                      className={`${styles.articleCard} ${resource.draft ? styles.draftCard : ""}`}
+                    >
+                      <div className={styles.articleHeader}>
+                        <div className={styles.titleRow}>
+                          <h3 className={styles.articleTitle}>{resource.title}</h3>
+                          {resource.draft && <span className={styles.draftBadge}>Draft</span>}
+                        </div>
+                        <div className={styles.articleMeta}>
+                          {resource.updated_date &&
+                          resource.updated_date !== resource.published_date ? (
+                            <>
+                              Updated{" "}
+                              {new Date(resource.updated_date).toLocaleDateString("en-US", {
+                                year: "numeric",
+                                month: "long",
+                                day: "numeric",
+                              })}
+                            </>
+                          ) : (
+                            <>
+                              Published{" "}
+                              {new Date(
+                                resource.published_date || resource.created_at || ""
+                              ).toLocaleDateString("en-US", {
+                                year: "numeric",
+                                month: "long",
+                                day: "numeric",
+                              })}
+                            </>
+                          )}
+                        </div>
+                      </div>
+
+                      {/* Summary */}
+                      {resource.summary && (
+                        <p className={styles.articlePreview}>{resource.summary}</p>
+                      )}
+
+                      {/* Tags */}
+                      {resource.tags.length > 0 && (
+                        <div className={styles.articleTags}>
+                          <TagPillList tags={resource.tags} showHash onClick={handleTagClick} />
+                        </div>
+                      )}
+
+                      {/* Read more indicator */}
+                      <div className={styles.readMore}>Read more →</div>
+                    </Link>
+                  );
+                })
+              )}
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/app/knowledge-base/articles/[id]/ArticleTags.tsx
+++ b/frontend/src/app/knowledge-base/articles/[id]/ArticleTags.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { TagPillList } from "@/components/TagPill";
+
+/**
+ * Clickable tag list island - navigates to the articles list filtered by tag.
+ */
+export default function ArticleTags({ tags }: { tags: string[] }) {
+  const router = useRouter();
+
+  const handleTagClick = (tag: string) => {
+    router.push(`/knowledge-base/articles?tags=${encodeURIComponent(tag)}`);
+  };
+
+  return <TagPillList tags={tags} showHash onClick={handleTagClick} variant="article" />;
+}

--- a/frontend/src/app/knowledge-base/articles/[id]/RelatedNotes.tsx
+++ b/frontend/src/app/knowledge-base/articles/[id]/RelatedNotes.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { logger } from "@/lib/logger";
+import styles from "./page.module.scss";
+
+interface RelatedNote {
+  id: string;
+  title: string;
+  content?: string;
+  score?: number;
+}
+
+/**
+ * Related-notes sidebar island. Fetched client-side after mount so the
+ * server-rendered article body never waits on the similarity lookup.
+ */
+export default function RelatedNotes({ articleId }: { articleId: number }) {
+  const [relatedNotes, setRelatedNotes] = useState<RelatedNote[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+  useEffect(() => {
+    async function fetchRelatedNotes() {
+      try {
+        const response = await fetch(`${API_URL}/api/articles/${articleId}/related-notes?limit=5`);
+
+        if (response.ok) {
+          const data = await response.json();
+          setRelatedNotes(data.notes || []);
+          logger.info("Related notes loaded", { count: data.count });
+        }
+      } catch (err) {
+        logger.warn("Failed to load related notes", err);
+        // Silently fail - related notes are optional
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchRelatedNotes();
+  }, [articleId, API_URL]);
+
+  if (!loading && relatedNotes.length === 0) return null;
+
+  return (
+    <div className={styles.relatedNotes}>
+      <h3 className={styles.relatedNotesTitle}>Related Notes</h3>
+      {loading ? (
+        <div className={styles.loadingNotes}>Finding related notes...</div>
+      ) : (
+        <ul className={styles.relatedNotesList}>
+          {relatedNotes.map((note) => (
+            <li key={note.id} className={styles.relatedNoteItem}>
+              <Link href={`/knowledge-base/notes/${note.id}`} className={styles.relatedNoteLink}>
+                <span className={styles.noteTitle}>{note.title || note.id}</span>
+                {note.score && (
+                  <span className={styles.noteScore}>{Math.round(note.score * 100)}% match</span>
+                )}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/knowledge-base/articles/[id]/not-found.tsx
+++ b/frontend/src/app/knowledge-base/articles/[id]/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+import styles from "./page.module.scss";
+
+export default function ArticleNotFound() {
+  return (
+    <div className={styles.container}>
+      <div className={styles.errorContainer}>
+        <div className={styles.errorCard}>
+          <h2 className={styles.errorTitle}>Error</h2>
+          <p className={styles.errorMessage}>Article not found</p>
+          <Link href="/knowledge-base/articles" className={styles.backLink}>
+            ← Back to articles
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/knowledge-base/articles/[id]/page.tsx
+++ b/frontend/src/app/knowledge-base/articles/[id]/page.tsx
@@ -67,11 +67,7 @@ export async function generateMetadata({
   };
 }
 
-export default async function ArticleDetailPage({
-  params,
-}: {
-  params: Promise<{ id: string }>;
-}) {
+export default async function ArticleDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const article = await fetchArticle(id);
 

--- a/frontend/src/app/knowledge-base/articles/[id]/page.tsx
+++ b/frontend/src/app/knowledge-base/articles/[id]/page.tsx
@@ -1,24 +1,24 @@
-"use client";
-
-import { useEffect, useState } from "react";
-import { CalendarBlank, PencilSimple, NotePencil } from "@phosphor-icons/react";
-import { useParams, useRouter } from "next/navigation";
+import type { Metadata } from "next";
 import Link from "next/link";
-import dynamic from "next/dynamic";
+import { notFound } from "next/navigation";
+import { CalendarBlank, PencilSimple, NotePencil } from "@phosphor-icons/react/dist/ssr";
 
-const AIPanel = dynamic(() => import("@/components/AIPanel"), { ssr: false });
-// Fallback renderer only; articles normally arrive as pre-rendered HTML,
-// so keep the react-markdown stack out of the first load
-const MarkdownWithWikilinks = dynamic(() => import("@/components/MarkdownWithWikilinks"));
+import AIAssistant from "@/components/AIAssistant";
 import ArticleTableOfContents from "@/components/ArticleTableOfContents";
-import AIButton from "@/components/AIButton";
 import Breadcrumb from "@/components/Breadcrumb";
 import Badge from "@/components/Badge";
-import { TagPillList } from "@/components/TagPill";
-import { logger } from "@/lib/logger";
-import { useFeatureFlags } from "@/hooks/useFeatureFlags";
+import MarkdownWithWikilinks from "@/components/MarkdownWithWikilinks";
 import { sanitizeHtml } from "@/lib/sanitize";
+import { getServerApiUrl } from "@/lib/server-api";
+import ArticleTags from "./ArticleTags";
+import RelatedNotes from "./RelatedNotes";
 import styles from "./page.module.scss";
+
+// Articles are static markdown cached in backend memory - render on the
+// server so content is in the initial HTML (#207). No generateStaticParams:
+// the backend isn't reachable during `docker build`, so pages render on
+// first request and are then cached (ISR) for the revalidate window.
+export const revalidate = 300;
 
 interface Article {
   id: number;
@@ -26,6 +26,7 @@ interface Article {
   content: string;
   html_content?: string; // Pre-rendered HTML from backend
   content_type?: string;
+  summary?: string;
   url?: string;
   tags: string[];
   draft?: boolean;
@@ -34,118 +35,56 @@ interface Article {
   created_at: string; // Legacy fallback
 }
 
-interface RelatedNote {
-  id: string;
-  title: string;
-  content?: string;
-  score?: number;
+async function fetchArticle(id: string): Promise<Article | null> {
+  if (!/^\d+$/.test(id)) return null;
+
+  const response = await fetch(`${getServerApiUrl()}/api/articles/${id}`, {
+    next: { revalidate: 300 },
+  });
+  if (!response.ok) return null;
+
+  const data = await response.json();
+  return data.resource as Article;
 }
 
-export default function ArticleDetailPage() {
-  const { llmFeaturesEnabled } = useFeatureFlags();
-  const params = useParams();
-  const router = useRouter();
-  const articleId = parseInt(params.id as string);
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const article = await fetchArticle(id);
+  if (!article) return { title: "Article not found" };
 
-  const [article, setArticle] = useState<Article | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [aiPanelOpen, setAiPanelOpen] = useState(false);
-  const [relatedNotes, setRelatedNotes] = useState<RelatedNote[]>([]);
-  const [loadingRelated, setLoadingRelated] = useState(false);
-
-  const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
-
-  useEffect(() => {
-    async function fetchArticle() {
-      try {
-        setLoading(true);
-        const response = await fetch(`${API_URL}/api/articles/${articleId}`);
-
-        if (!response.ok) {
-          throw new Error("Article not found");
-        }
-
-        const data = await response.json();
-        setArticle(data.resource);
-        logger.info("Article loaded", { id: articleId });
-      } catch (err) {
-        const message = err instanceof Error ? err.message : "Failed to load article";
-        setError(message);
-        logger.error("Failed to load article", err);
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    fetchArticle();
-  }, [articleId, API_URL]);
-
-  // Fetch related notes after article is loaded
-  useEffect(() => {
-    async function fetchRelatedNotes() {
-      if (!article) return;
-
-      try {
-        setLoadingRelated(true);
-        const response = await fetch(`${API_URL}/api/articles/${articleId}/related-notes?limit=5`);
-
-        if (response.ok) {
-          const data = await response.json();
-          setRelatedNotes(data.notes || []);
-          logger.info("Related notes loaded", { count: data.count });
-        }
-      } catch (err) {
-        logger.warn("Failed to load related notes", err);
-        // Silently fail - related notes are optional
-      } finally {
-        setLoadingRelated(false);
-      }
-    }
-
-    fetchRelatedNotes();
-  }, [article, articleId, API_URL]);
-
-  const handleTagClick = (tag: string) => {
-    router.push(`/knowledge-base/articles?tag=${encodeURIComponent(tag)}`);
+  return {
+    title: article.title,
+    description: article.summary,
+    openGraph: {
+      title: article.title,
+      description: article.summary,
+      type: "article",
+    },
   };
+}
 
-  if (loading) {
-    return (
-      <div className={styles.container}>
-        <div className={styles.loadingContainer}>
-          <div className={styles.loadingSkeleton}>
-            <div className={styles.skeletonTitle}></div>
-            <div className={styles.skeletonContent}></div>
-          </div>
-        </div>
-      </div>
-    );
+export default async function ArticleDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const article = await fetchArticle(id);
+
+  if (!article) {
+    notFound();
   }
 
-  if (error || !article) {
-    return (
-      <div className={styles.container}>
-        <div className={styles.errorContainer}>
-          <div className={styles.errorCard}>
-            <h2 className={styles.errorTitle}>Error</h2>
-            <p className={styles.errorMessage}>{error || "Article not found"}</p>
-            <Link href="/knowledge-base/articles" className={styles.backLink}>
-              ← Back to articles
-            </Link>
-          </div>
-        </div>
-      </div>
-    );
-  }
+  const publishedDate = article.published_date || article.created_at;
 
   return (
     <div className={styles.container}>
-      {/* AI Panel (only when LLM features enabled) */}
-      {llmFeaturesEnabled && <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />}
-
-      {/* AI Button (only when LLM features enabled) */}
-      {llmFeaturesEnabled && !aiPanelOpen && <AIButton onClick={() => setAiPanelOpen(true)} />}
+      {/* AI panel + button island (only shown when LLM features enabled) */}
+      <AIAssistant />
 
       {/* Header */}
       <header className={styles.header}>
@@ -170,15 +109,12 @@ export default function ArticleDetailPage() {
               <CalendarBlank size={14} aria-hidden="true" />
               <span>
                 Published{" "}
-                <time dateTime={article.published_date || article.created_at}>
-                  {new Date(article.published_date || article.created_at).toLocaleDateString(
-                    "en-US",
-                    {
-                      year: "numeric",
-                      month: "long",
-                      day: "numeric",
-                    }
-                  )}
+                <time dateTime={publishedDate}>
+                  {new Date(publishedDate).toLocaleDateString("en-US", {
+                    year: "numeric",
+                    month: "long",
+                    day: "numeric",
+                  })}
                 </time>
               </span>
             </div>
@@ -202,12 +138,7 @@ export default function ArticleDetailPage() {
           {/* Tags */}
           {article.tags.length > 0 && (
             <div className={styles.tags}>
-              <TagPillList
-                tags={article.tags}
-                showHash
-                onClick={handleTagClick}
-                variant="article"
-              />
+              <ArticleTags tags={article.tags} />
             </div>
           )}
 
@@ -273,32 +204,7 @@ export default function ArticleDetailPage() {
             )}
 
             {/* Related Notes Section */}
-            {(relatedNotes.length > 0 || loadingRelated) && (
-              <div className={styles.relatedNotes}>
-                <h3 className={styles.relatedNotesTitle}>Related Notes</h3>
-                {loadingRelated ? (
-                  <div className={styles.loadingNotes}>Finding related notes...</div>
-                ) : (
-                  <ul className={styles.relatedNotesList}>
-                    {relatedNotes.map((note) => (
-                      <li key={note.id} className={styles.relatedNoteItem}>
-                        <Link
-                          href={`/knowledge-base/notes/${note.id}`}
-                          className={styles.relatedNoteLink}
-                        >
-                          <span className={styles.noteTitle}>{note.title || note.id}</span>
-                          {note.score && (
-                            <span className={styles.noteScore}>
-                              {Math.round(note.score * 100)}% match
-                            </span>
-                          )}
-                        </Link>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </div>
-            )}
+            <RelatedNotes articleId={article.id} />
           </div>
         </div>
       </main>

--- a/frontend/src/app/knowledge-base/articles/page.tsx
+++ b/frontend/src/app/knowledge-base/articles/page.tsx
@@ -1,405 +1,35 @@
-"use client";
-import { prefetchOnce } from "@/lib/prefetch";
-
 import { Suspense } from "react";
-import { useState, useEffect, useCallback } from "react";
-import Link from "next/link";
-import dynamic from "next/dynamic";
+import type { Metadata } from "next";
 
-const AIPanel = dynamic(() => import("@/components/AIPanel"), { ssr: false });
-const MarkdownWithWikilinks = dynamic(() => import("@/components/MarkdownWithWikilinks"));
-
-// Warm the browser HTTP cache with the article the user is about to open
-function prefetchArticle(id: number | string): void {
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
-  prefetchOnce(`article:${id}`, () => fetch(`${apiUrl}/api/articles/${id}`));
-}
-import { useRouter, useSearchParams } from "next/navigation";
-import { logger } from "@/lib/logger";
-import AIButton from "@/components/AIButton";
-import Breadcrumb from "@/components/Breadcrumb";
-import { TagPillList } from "@/components/TagPill";
-import { useFeatureFlags } from "@/hooks/useFeatureFlags";
+import { getServerApiUrl } from "@/lib/server-api";
+import ArticlesClient, { type ArticleMetadata } from "./ArticlesClient";
 import styles from "./page.module.scss";
 
-interface ArticleMetadata {
-  id: number;
-  title: string;
-  summary?: string; // Optional 1-2 sentence description
-  url?: string;
-  tags: string[];
-  draft?: boolean;
-  published_date?: string;
-  updated_date?: string;
-  created_at?: string; // Legacy fallback
-}
+export const metadata: Metadata = {
+  title: "Articles",
+};
 
-type SortOption = "newest" | "oldest" | "recently-updated" | "alphabetical";
+// Server-render the list so article titles/summaries are in the initial HTML
+// (#207). force-dynamic keeps `docker build` from prerendering this route
+// (the backend isn't reachable at image-build time); the fetch below still
+// caches the article list in the Next data cache between requests.
+export const dynamic = "force-dynamic";
 
-function ArticlesContent() {
-  const { llmFeaturesEnabled } = useFeatureFlags();
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const tagsParam = searchParams.get("tags");
-  const selectedTags = tagsParam ? tagsParam.split(",") : [];
-
-  const [resources, setResources] = useState<ArticleMetadata[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [aiPanelOpen, setAiPanelOpen] = useState(false);
-  const [searchQuery, setSearchQuery] = useState("");
-  const [sortBy, setSortBy] = useState<SortOption>("newest");
-  const [showAllTags, setShowAllTags] = useState(false);
-
-  const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
-
-  const fetchResources = useCallback(async () => {
-    try {
-      const response = await fetch(`${API_URL}/api/articles`);
-      const data = await response.json();
-      setResources(data.resources);
-      logger.debug("Fetched articles", { count: data.resources.length });
-    } catch (error) {
-      logger.error("Error fetching articles", error);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [API_URL]);
-
-  useEffect(() => {
-    fetchResources();
-  }, [fetchResources]);
-
-  // Calculate tag counts
-  const tagCounts = resources.reduce(
-    (acc, resource) => {
-      resource.tags.forEach((tag) => {
-        acc[tag] = (acc[tag] || 0) + 1;
-      });
-      return acc;
-    },
-    {} as Record<string, number>
-  );
-
-  // Sort tags by count (descending), then alphabetically
-  const sortedTags = Object.entries(tagCounts).sort((a, b) => {
-    if (b[1] !== a[1]) return b[1] - a[1];
-    return a[0].localeCompare(b[0]);
+async function fetchArticles(): Promise<ArticleMetadata[]> {
+  const response = await fetch(`${getServerApiUrl()}/api/articles`, {
+    next: { revalidate: 300 },
   });
+  if (!response.ok) {
+    throw new Error(`Failed to load articles (${response.status})`);
+  }
 
-  // Separate tags into top (2+ articles) and other (1 article)
-  const topTags = sortedTags.filter(([_, count]) => count >= 2);
-  const otherTags = sortedTags.filter(([_, count]) => count === 1);
-  const visibleTags = showAllTags ? sortedTags : topTags;
-
-  const filteredResources = resources
-    .filter((resource) => {
-      // Filter by tags (OR logic - article must have at least one selected tag)
-      if (selectedTags.length > 0) {
-        const hasMatchingTag = selectedTags.some((tag) => resource.tags.includes(tag));
-        if (!hasMatchingTag) return false;
-      }
-
-      // Filter by search query
-      if (!searchQuery) return true;
-      const query = searchQuery.toLowerCase();
-      return (
-        resource.title.toLowerCase().includes(query) ||
-        (resource.summary && resource.summary.toLowerCase().includes(query)) ||
-        resource.tags.some((tag) => tag.toLowerCase().includes(query))
-      );
-    })
-    .sort((a, b) => {
-      // Sort drafts to the top first
-      if (a.draft && !b.draft) return -1;
-      if (!a.draft && b.draft) return 1;
-
-      // Then sort by selected option
-      switch (sortBy) {
-        case "newest": {
-          const dateA = new Date(a.published_date || a.created_at || 0).getTime();
-          const dateB = new Date(b.published_date || b.created_at || 0).getTime();
-          return dateB - dateA;
-        }
-        case "oldest": {
-          const dateA = new Date(a.published_date || a.created_at || 0).getTime();
-          const dateB = new Date(b.published_date || b.created_at || 0).getTime();
-          return dateA - dateB;
-        }
-        case "recently-updated": {
-          const dateA = new Date(a.updated_date || a.published_date || a.created_at || 0).getTime();
-          const dateB = new Date(b.updated_date || b.published_date || b.created_at || 0).getTime();
-          return dateB - dateA;
-        }
-        case "alphabetical":
-          return a.title.localeCompare(b.title);
-        default:
-          return 0;
-      }
-    });
-
-  const handleTagClick = (tag: string) => {
-    let newTags: string[];
-
-    if (selectedTags.includes(tag)) {
-      // Tag is already selected, remove it
-      newTags = selectedTags.filter((t) => t !== tag);
-    } else {
-      // Tag is not selected, add it
-      newTags = [...selectedTags, tag];
-    }
-
-    // Update URL with new tags
-    if (newTags.length > 0) {
-      router.push(`/knowledge-base/articles?tags=${newTags.map(encodeURIComponent).join(",")}`);
-    } else {
-      router.push("/knowledge-base/articles");
-    }
-  };
-
-  const clearAllFilters = () => {
-    setSearchQuery("");
-    router.push("/knowledge-base/articles");
-  };
-
-  const hasActiveFilters = Boolean(selectedTags.length > 0 || searchQuery);
-
-  return (
-    <div className={styles.container}>
-      {/* AI Panel (only when LLM features enabled) */}
-      {llmFeaturesEnabled && <AIPanel isOpen={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />}
-
-      {/* AI Button (only when LLM features enabled) */}
-      {llmFeaturesEnabled && !aiPanelOpen && <AIButton onClick={() => setAiPanelOpen(true)} />}
-
-      {/* Header */}
-      <header className={styles.header}>
-        <div className={styles.headerContent}>
-          <div className={styles.breadcrumb}>
-            <Breadcrumb section="articles" toHub />
-          </div>
-          <h1 className={styles.title}>Articles</h1>
-        </div>
-      </header>
-
-      <main className={styles.main}>
-        <div className={styles.contentGrid}>
-          {/* Sidebar - Filters */}
-          <aside className={styles.sidebar}>
-            {/* Search */}
-            <div className={styles.searchBar}>
-              <input
-                type="text"
-                placeholder="Search articles..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                className={styles.searchInput}
-                aria-label="Search articles by title, summary, or tags"
-              />
-            </div>
-
-            {/* Sort */}
-            <div className={styles.sortSection}>
-              <label htmlFor="sort-select" className={styles.sortLabel}>
-                Sort by:
-              </label>
-              <select
-                id="sort-select"
-                value={sortBy}
-                onChange={(e) => setSortBy(e.target.value as SortOption)}
-                className={styles.sortSelect}
-              >
-                <option value="newest">Newest</option>
-                <option value="oldest">Oldest</option>
-                <option value="recently-updated">Recently Updated</option>
-                <option value="alphabetical">Alphabetical</option>
-              </select>
-            </div>
-
-            {/* Tag Filter Section */}
-            {sortedTags.length > 0 && (
-              <div className={styles.tagFilterSection}>
-                <div className={styles.tagFilterHeader}>
-                  <span className={styles.tagFilterLabel}>Filter by tag:</span>
-                </div>
-                <div className={styles.tagBadges}>
-                  {visibleTags.map(([tag, count]) => {
-                    const isActive = selectedTags.includes(tag);
-                    // Determine tag size class based on count
-                    let sizeClass = styles.tagLow;
-                    if (count >= 3) sizeClass = styles.tagHigh;
-                    else if (count === 2) sizeClass = styles.tagMedium;
-
-                    return (
-                      <button
-                        key={tag}
-                        onClick={() => handleTagClick(tag)}
-                        className={`${styles.tagBadge} ${sizeClass} ${isActive ? styles.tagBadgeActive : ""}`}
-                        type="button"
-                        aria-label={`Filter by tag: ${tag}, ${count} articles`}
-                        aria-pressed={isActive}
-                      >
-                        #{tag} ({count})
-                      </button>
-                    );
-                  })}
-                </div>
-                {otherTags.length > 0 && !showAllTags && (
-                  <button
-                    onClick={() => setShowAllTags(true)}
-                    className={styles.showMoreButton}
-                    type="button"
-                    aria-label={`Show ${otherTags.length} more tags`}
-                    aria-expanded="false"
-                  >
-                    + Show {otherTags.length} more
-                  </button>
-                )}
-                {showAllTags && otherTags.length > 0 && (
-                  <button
-                    onClick={() => setShowAllTags(false)}
-                    className={styles.showMoreButton}
-                    type="button"
-                    aria-label="Show fewer tags"
-                    aria-expanded="true"
-                  >
-                    − Show fewer
-                  </button>
-                )}
-              </div>
-            )}
-
-            {/* Clear Filters */}
-            {hasActiveFilters && (
-              <button
-                onClick={clearAllFilters}
-                className={styles.clearAllButtonSidebar}
-                aria-label="Clear all active filters"
-              >
-                Clear all filters
-              </button>
-            )}
-          </aside>
-
-          {/* Main Content - Articles */}
-          <div className={styles.articlesContent}>
-            {/* Article Count and Active Filters */}
-            <div className={styles.resultsBar}>
-              <div className={styles.articleCountSection}>
-                {selectedTags.length > 0 && (
-                  <div className={styles.activeFilters}>
-                    Filtering by:{" "}
-                    {selectedTags.map((tag, index) => (
-                      <span key={tag}>
-                        #{tag}
-                        {index < selectedTags.length - 1 && ", "}
-                      </span>
-                    ))}
-                  </div>
-                )}
-                <div className={styles.articleCount}>
-                  {isLoading ? (
-                    "Loading..."
-                  ) : (
-                    <>
-                      Showing {filteredResources.length}
-                      {filteredResources.length !== resources.length &&
-                        ` of ${resources.length}`}{" "}
-                      {filteredResources.length === 1 ? "article" : "articles"}
-                    </>
-                  )}
-                </div>
-              </div>
-            </div>
-
-            {/* Articles List */}
-            <div className={styles.articlesList}>
-              {isLoading ? (
-                <div className={styles.loadingState}>
-                  <p>Loading articles...</p>
-                </div>
-              ) : filteredResources.length === 0 ? (
-                <div className={styles.emptyState}>
-                  <p className={styles.emptyMessage}>
-                    {searchQuery ? "No articles match your search" : "No articles yet"}
-                  </p>
-                  {searchQuery && (
-                    <button
-                      onClick={() => setSearchQuery("")}
-                      className={styles.clearSearchButton}
-                      aria-label="Clear search query"
-                    >
-                      Clear search
-                    </button>
-                  )}
-                </div>
-              ) : (
-                filteredResources.map((resource) => {
-                  return (
-                    <Link
-                      key={resource.id}
-                      href={`/knowledge-base/articles/${resource.id}`}
-                      className={`${styles.articleCard} ${resource.draft ? styles.draftCard : ""}`}
-                      onMouseEnter={() => prefetchArticle(resource.id)}
-                      onFocus={() => prefetchArticle(resource.id)}
-                    >
-                      <div className={styles.articleHeader}>
-                        <div className={styles.titleRow}>
-                          <h3 className={styles.articleTitle}>{resource.title}</h3>
-                          {resource.draft && <span className={styles.draftBadge}>Draft</span>}
-                        </div>
-                        <div className={styles.articleMeta}>
-                          {resource.updated_date &&
-                          resource.updated_date !== resource.published_date ? (
-                            <>
-                              Updated{" "}
-                              {new Date(resource.updated_date).toLocaleDateString("en-US", {
-                                year: "numeric",
-                                month: "long",
-                                day: "numeric",
-                              })}
-                            </>
-                          ) : (
-                            <>
-                              Published{" "}
-                              {new Date(
-                                resource.published_date || resource.created_at || ""
-                              ).toLocaleDateString("en-US", {
-                                year: "numeric",
-                                month: "long",
-                                day: "numeric",
-                              })}
-                            </>
-                          )}
-                        </div>
-                      </div>
-
-                      {/* Summary */}
-                      {resource.summary && (
-                        <p className={styles.articlePreview}>{resource.summary}</p>
-                      )}
-
-                      {/* Tags */}
-                      {resource.tags.length > 0 && (
-                        <div className={styles.articleTags}>
-                          <TagPillList tags={resource.tags} showHash onClick={handleTagClick} />
-                        </div>
-                      )}
-
-                      {/* Read more indicator */}
-                      <div className={styles.readMore}>Read more →</div>
-                    </Link>
-                  );
-                })
-              )}
-            </div>
-          </div>
-        </div>
-      </main>
-    </div>
-  );
+  const data = await response.json();
+  return data.resources as ArticleMetadata[];
 }
 
-export default function ArticlesPage() {
+export default async function ArticlesPage() {
+  const resources = await fetchArticles();
+
   return (
     <Suspense
       fallback={
@@ -417,7 +47,7 @@ export default function ArticlesPage() {
         </div>
       }
     >
-      <ArticlesContent />
+      <ArticlesClient resources={resources} />
     </Suspense>
   );
 }

--- a/frontend/src/components/AIAssistant.tsx
+++ b/frontend/src/components/AIAssistant.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useState } from "react";
+import dynamic from "next/dynamic";
+
+const AIPanel = dynamic(() => import("@/components/AIPanel"), { ssr: false });
+import AIButton from "@/components/AIButton";
+import { useFeatureFlags } from "@/hooks/useFeatureFlags";
+
+/**
+ * Self-contained AI panel + trigger button island.
+ * Lets server-rendered pages include the AI assistant without owning its state.
+ */
+export default function AIAssistant() {
+  const { llmFeaturesEnabled } = useFeatureFlags();
+  const [open, setOpen] = useState(false);
+
+  if (!llmFeaturesEnabled) return null;
+
+  return (
+    <>
+      <AIPanel isOpen={open} onClose={() => setOpen(false)} />
+      {!open && <AIButton onClick={() => setOpen(true)} />}
+    </>
+  );
+}

--- a/frontend/src/lib/sanitize.ts
+++ b/frontend/src/lib/sanitize.ts
@@ -4,7 +4,7 @@
  * Uses DOMPurify for safe HTML rendering of user-generated or markdown-converted content.
  */
 
-import DOMPurify from "dompurify";
+import DOMPurify from "isomorphic-dompurify";
 
 /**
  * Configuration for DOMPurify optimized for markdown content.
@@ -123,11 +123,5 @@ const MARKDOWN_CONFIG = {
  * ```
  */
 export function sanitizeHtml(html: string): string {
-  if (typeof window === "undefined") {
-    // Server-side: return as-is (will be sanitized on client hydration)
-    // For full SSR safety, consider using isomorphic-dompurify
-    return html;
-  }
-
   return DOMPurify.sanitize(html, MARKDOWN_CONFIG);
 }

--- a/frontend/src/lib/server-api.ts
+++ b/frontend/src/lib/server-api.ts
@@ -8,7 +8,5 @@
  * outside Docker.
  */
 export function getServerApiUrl(): string {
-  return (
-    process.env.API_URL_INTERNAL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000"
-  );
+  return process.env.API_URL_INTERNAL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 }

--- a/frontend/src/lib/server-api.ts
+++ b/frontend/src/lib/server-api.ts
@@ -1,0 +1,14 @@
+/**
+ * API base URL for server-side fetches (server components, route handlers).
+ *
+ * NEXT_PUBLIC_API_URL is the browser-facing origin (localhost:8000 in dev,
+ * the public API domain in prod), which is not reachable from inside the
+ * frontend container. API_URL_INTERNAL points at the backend over the Docker
+ * network (http://backend:8000); the public URL is the fallback when running
+ * outside Docker.
+ */
+export function getServerApiUrl(): string {
+  return (
+    process.env.API_URL_INTERNAL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000"
+  );
+}


### PR DESCRIPTION
## Summary
Article pages are now Next.js server components: the article HTML, title, and OpenGraph metadata are in the initial response — no client fetch waterfall, real SEO. Fixes #207.

- `articles/[id]`: async server component with ISR (300s revalidate). No `generateStaticParams` — the backend isn't reachable during `docker build`, so pages render on first request and cache from there (the build/runtime coupling concern from the issue).
- Articles list: server component (`force-dynamic` to avoid build-time prerender; list data still cached in the Next data cache) passing data to the existing interactive client UI.
- Client islands: AI panel/button (`AIAssistant`), related notes, tag links, TOC scroll-spy.
- `sanitize.ts` switched to `isomorphic-dompurify` so backend HTML is sanitized server-side too (previously skipped when `window` was undefined). Kept in `serverExternalPackages` — bundling jsdom breaks its stylesheet path resolution (500s).
- `API_URL_INTERNAL=http://backend:8000` in dev/prod compose for server-side fetches.
- Removed the now-useless `/api/articles/{id}` hover prefetch; fixed detail-page tag links using `?tag=` where the list reads `?tags=`.
- Docs: ARTICLES.md overview + DEPLOYMENT.md env table.

## Testing
- Verified against the dev server: article body/headings/`<title>` present in raw HTML, 404 → not-found page.
- Frontend lint, typecheck, and 64 unit tests pass. E2E not runnable in the Alpine dev container (pre-existing); CI covers it.
- Post-merge check: load an article page in prod — jsdom's stylesheet in the standalone output is the one thing not verifiable locally.