### PR TITLE
Chunked embeddings for semantic search (fixes #192)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ docker compose up --build  # Rebuild after dependency changes
 docker compose logs -f backend  # View logs
 ```
 
-> **⚠️ First Startup Note:** The backend generates and stores embeddings for all articles and notes on startup. This takes ~2-5 minutes the first time or after deleting containers/volumes. Subsequent startups are fast (~5-10 seconds) because embeddings are cached in Neo4j. You'll see progress logs like `[3/12] Generating embedding for article...` during this process.
+> **⚠️ Embeddings Note:** Semantic search needs embeddings stored in Neo4j. Sync is triggered manually via `POST /api/admin/sync-embeddings` (admin token required), or on startup if `SYNC_EMBEDDINGS_ON_STARTUP=true`. The first sync takes a few minutes (each document is embedded in section-level chunks); later syncs skip unchanged content via content hashing.
 
 > **📦 Required Ollama Models:** The AI features require these models:
 > - `nomic-embed-text` (embeddings, auto-downloaded)
@@ -116,7 +116,7 @@ docker compose logs -f backend  # View logs
 - pytest, mypy, ruff
 
 **Frontend:**
-- Next.js 14, React 18, TypeScript
+- Next.js 15 (App Router, server components), React 19, TypeScript
 - SCSS Modules (design tokens + mixins), Vitest, Playwright
 
 **DevOps:**
@@ -160,7 +160,7 @@ All existing infrastructure (components, styling, config) is reusable. The `Proj
 ## Current Features
 
 ### Knowledge Base (Implemented)
-- AI-powered semantic search (Ollama embeddings)
+- AI-powered semantic search (chunked embeddings; documents rank by their best-matching section. Ollama in dev, Gemini API in prod)
 - Q&A with context from knowledge base
 - Neo4j graph database for notes
 - Zettelkasten-style bidirectional wikilinks

--- a/backend/adapters/neo4j.py
+++ b/backend/adapters/neo4j.py
@@ -422,8 +422,9 @@ class Neo4jAdapter:
                 """
                 MATCH (n:Note)
                 WHERE n.id = $id
-                DETACH DELETE n
-                RETURN count(n) AS deleted
+                OPTIONAL MATCH (n)-[:HAS_CHUNK]->(c:Chunk)
+                DETACH DELETE c, n
+                RETURN count(DISTINCT n) AS deleted
                 """,
                 id=note_id,
             )
@@ -1179,6 +1180,91 @@ class Neo4jAdapter:
                     "embedding": record["embedding"],
                     "model": record["model"],
                     "version": record["version"],
+                }
+                for record in result
+            ]
+
+    def replace_chunk_embeddings(
+        self,
+        node_type: str,  # "Article" or "Note"
+        node_id: str,
+        chunk_embeddings: list[list[float]],
+        model: str,
+        version: int,
+    ) -> bool:
+        """Replace all chunk embeddings for an article or note (#192).
+
+        Chunks are stored as (parent)-[:HAS_CHUNK]->(:Chunk {seq, embedding})
+        nodes. Existing chunks are deleted first so the set always mirrors the
+        current chunking of the content.
+
+        Args:
+            node_type: "Article" or "Note"
+            node_id: ID of the parent article or note
+            chunk_embeddings: One embedding per chunk, in document order
+            model: Embedding model name
+            version: Embedding version
+
+        Returns:
+            True if successful
+        """
+        if not self._available or not self.driver:
+            return False
+
+        validated_type = self._validate_node_type(node_type)
+
+        with self.driver.session(database=self.database) as session:
+            session.run(
+                f"""
+                MATCH (n:{validated_type} {{id: $id}})
+                OPTIONAL MATCH (n)-[:HAS_CHUNK]->(old:Chunk)
+                DETACH DELETE old
+                WITH DISTINCT n
+                UNWIND range(0, size($embeddings) - 1) AS seq
+                CREATE (n)-[:HAS_CHUNK]->(:Chunk {{
+                    seq: seq,
+                    embedding: $embeddings[seq],
+                    embedding_model: $model,
+                    embedding_version: $version
+                }})
+                """,
+                id=node_id,
+                embeddings=chunk_embeddings,
+                model=model,
+                version=version,
+            )
+            return True
+
+    def get_all_chunk_embeddings(self) -> list[dict[str, Any]]:
+        """Get all chunk embeddings with their parent identity (#192).
+
+        Loads every chunk vector into memory for Python-side scoring. Fine at
+        the current corpus size; at thousands of documents move scoring into a
+        Neo4j vector index instead.
+
+        Returns:
+            List of dicts with parent_id, parent_type, seq, embedding
+        """
+        if not self._available or not self.driver:
+            return []
+
+        with self.driver.session(database=self.database) as session:
+            result = session.run(
+                """
+                MATCH (n)-[:HAS_CHUNK]->(c:Chunk)
+                WHERE n:Article OR n:Note
+                RETURN n.id as parent_id,
+                       labels(n)[0] as parent_type,
+                       c.seq as seq,
+                       c.embedding as embedding
+                """
+            )
+            return [
+                {
+                    "parent_id": record["parent_id"],
+                    "parent_type": record["parent_type"],
+                    "seq": record["seq"],
+                    "embedding": record["embedding"],
                 }
                 for record in result
             ]

--- a/backend/core/ai.py
+++ b/backend/core/ai.py
@@ -71,6 +71,68 @@ def rank_documents_by_similarity(
     return [doc for _, doc in scored_docs[:top_k]]
 
 
+def mean_vector(vectors: list[list[float]]) -> list[float]:
+    """Element-wise mean of equal-length vectors.
+
+    Pure function: No I/O, no side effects, deterministic.
+
+    Used to derive a whole-document embedding from its chunk embeddings
+    without extra embedding-API calls. Magnitude is irrelevant for cosine
+    similarity, so the mean is not re-normalized.
+
+    Args:
+        vectors: Non-empty list of equal-length vectors
+
+    Returns:
+        Mean vector ([] for empty input)
+    """
+    if not vectors:
+        return []
+    dim = len(vectors[0])
+    if any(len(v) != dim for v in vectors):
+        logger.warning("mean_vector: mismatched vector lengths, returning []")
+        return []
+    return [sum(v[i] for v in vectors) / len(vectors) for i in range(dim)]
+
+
+def rank_parents_by_chunk_similarity(
+    query_embedding: list[float],
+    chunks: list[dict[str, Any]],
+    top_k: int = 5,
+) -> list[dict[str, Any]]:
+    """Rank parent documents by their best-matching chunk (#192).
+
+    Pure function: No I/O, no side effects, deterministic.
+
+    Max-aggregation is the point: a document with one strongly matching
+    section ranks on that section alone, instead of having the signal
+    diluted across the whole document.
+
+    Args:
+        query_embedding: Query embedding vector
+        chunks: Chunk dicts with 'parent_id', 'parent_type', 'embedding'
+        top_k: Maximum number of parents to return
+
+    Returns:
+        Top K parents as {'id', 'type', 'score'} sorted by score descending
+    """
+    best: dict[tuple[str, str], float] = {}
+    for chunk in chunks:
+        embedding = chunk.get("embedding")
+        if not embedding:
+            continue
+        key = (chunk["parent_type"], chunk["parent_id"])
+        similarity = cosine_similarity(query_embedding, embedding)
+        if similarity > best.get(key, -1.0):
+            best[key] = similarity
+
+    ranked = sorted(best.items(), key=lambda item: item[1], reverse=True)
+    return [
+        {"id": parent_id, "type": parent_type, "score": score}
+        for (parent_type, parent_id), score in ranked[:top_k]
+    ]
+
+
 def build_context_from_documents(documents: list[dict[str, Any]], max_docs: int = 5) -> str:
     """Build context string from documents for AI prompts.
 

--- a/backend/core/chunking.py
+++ b/backend/core/chunking.py
@@ -1,0 +1,113 @@
+"""Pure document chunking logic for embeddings (Functional Core).
+
+Whole-document embeddings dilute topical signal in longer documents (#192):
+a query matching one section gets averaged away by the rest of the article.
+Chunking embeds sections separately so a strong local match ranks the
+document highly.
+
+All functions are pure: no I/O, deterministic.
+"""
+
+import re
+
+# Target size keeps chunks comfortably inside embedding-model context windows
+# while staying large enough to carry meaning. Characters, not tokens: close
+# enough for chunk sizing and avoids a tokenizer dependency.
+CHUNK_TARGET_CHARS = 1500
+# Paragraphs longer than this are hard-split (rare: giant code blocks/tables)
+CHUNK_MAX_CHARS = 2500
+
+_HEADING_RE = re.compile(r"^#{1,6}\s", re.MULTILINE)
+
+
+def _split_sections(content: str) -> list[str]:
+    """Split markdown into sections at heading boundaries.
+
+    Each section starts at a heading line (or the document start) and runs to
+    the next heading. Headings stay with their section so chunks keep their
+    local context.
+    """
+    starts = [m.start() for m in _HEADING_RE.finditer(content)]
+    if not starts:
+        return [content]
+
+    boundaries = ([0] if starts[0] != 0 else []) + starts + [len(content)]
+    sections = [content[a:b] for a, b in zip(boundaries, boundaries[1:], strict=False)]
+    return [s for s in sections if s.strip()]
+
+
+def _split_oversized(text: str, max_chars: int) -> list[str]:
+    """Hard-split text that exceeds max_chars, preferring paragraph breaks."""
+    if len(text) <= max_chars:
+        return [text]
+
+    pieces: list[str] = []
+    current = ""
+    for paragraph in text.split("\n\n"):
+        candidate = f"{current}\n\n{paragraph}" if current else paragraph
+        if len(candidate) <= max_chars:
+            current = candidate
+            continue
+        if current:
+            pieces.append(current)
+        # A single paragraph over the limit gets sliced at the limit
+        while len(paragraph) > max_chars:
+            pieces.append(paragraph[:max_chars])
+            paragraph = paragraph[max_chars:]
+        current = paragraph
+    if current.strip():
+        pieces.append(current)
+    return pieces
+
+
+def chunk_document(
+    title: str,
+    content: str,
+    target_chars: int = CHUNK_TARGET_CHARS,
+    max_chars: int = CHUNK_MAX_CHARS,
+) -> list[str]:
+    """Split a document into embedding-sized chunks, title prefixed to each.
+
+    Sections (split at markdown headings) are packed greedily into chunks of
+    roughly target_chars. The title is prepended to every chunk so title terms
+    contribute to every chunk's embedding (previously titles were not embedded
+    at all - part of the #192 miss).
+
+    Short documents produce a single chunk, which keeps behavior for typical
+    notes identical to whole-document embedding (plus the title).
+
+    Args:
+        title: Document title, prepended to each chunk
+        content: Markdown content
+        target_chars: Soft chunk size; sections are packed up to this
+        max_chars: Hard limit; oversized sections are split
+
+    Returns:
+        List of chunk texts (at least one, unless title and content are empty)
+    """
+    title = title.strip()
+    content = content.strip()
+
+    if not content:
+        return [title] if title else []
+
+    sections: list[str] = []
+    for section in _split_sections(content):
+        sections.extend(_split_oversized(section.strip(), max_chars))
+
+    # Greedily pack sections into chunks up to target_chars
+    chunks: list[str] = []
+    current = ""
+    for section in sections:
+        candidate = f"{current}\n\n{section}" if current else section
+        if current and len(candidate) > target_chars:
+            chunks.append(current)
+            current = section
+        else:
+            current = candidate
+    if current:
+        chunks.append(current)
+
+    if title:
+        return [f"{title}\n\n{chunk}" for chunk in chunks]
+    return chunks

--- a/backend/embedding_sync.py
+++ b/backend/embedding_sync.py
@@ -17,12 +17,15 @@ import logging
 import time
 from typing import Any
 
+from core.ai import mean_vector
+from core.chunking import chunk_document
 from utils import calculate_content_hash
 
 logger = logging.getLogger(__name__)
 
 # Embedding version - increment when model or logic changes
-EMBEDDING_VERSION = 1
+# v2: chunked embeddings with title prefix (#192)
+EMBEDDING_VERSION = 2
 
 # Retry-with-backoff settings for rate-limited embedding APIs (e.g. Gemini 429s).
 # The whole sync shares one time budget; per-item retries back off exponentially.
@@ -203,28 +206,50 @@ def _process_embeddings_for_nodes(
 
         if needs_embedding_regeneration(node, current_model, current_version, content):
             start_time = time.time()
+
+            # Chunk the document (title prefixed to each chunk, #192)
+            chunks = chunk_document(node.get("title") or "", content)
             logger.info(
-                "  [%d/%d] Generating embedding for %s: %s",
+                "  [%d/%d] Generating %d chunk embedding(s) for %s: %s",
                 idx,
                 len(nodes),
+                len(chunks),
                 node_type.lower(),
                 title,
             )
 
-            embedding = _generate_with_retry(ollama_client, content, deadline)
+            chunk_embeddings: list[list[float]] = []
+            for chunk in chunks:
+                embedding = _generate_with_retry(ollama_client, chunk, deadline)
+                if embedding is None:
+                    break
+                chunk_embeddings.append(embedding)
 
-            if embedding:
+            if chunks and len(chunk_embeddings) == len(chunks):
+                # Chunks first, node embedding last: the node's metadata is
+                # what needs_embedding_regeneration checks, so a partial write
+                # is retried on the next sync.
+                neo4j_adapter.replace_chunk_embeddings(
+                    node_type, node_id, chunk_embeddings, current_model, current_version
+                )
+                # Whole-document embedding (used by related-notes/suggest-links)
+                # is the mean of chunk embeddings - no extra API calls
                 neo4j_adapter.store_embedding(
                     node_type,
                     node_id,
-                    embedding,
+                    mean_vector(chunk_embeddings),
                     current_model,
                     current_version,
                     calculate_content_hash(content),
                 )
                 duration = time.time() - start_time
                 logger.info(
-                    "  [%d/%d] ✓ Embedding generated in %.1fs: %s", idx, len(nodes), duration, title
+                    "  [%d/%d] ✓ %d embedding(s) generated in %.1fs: %s",
+                    idx,
+                    len(nodes),
+                    len(chunk_embeddings),
+                    duration,
+                    title,
                 )
                 stats["embeddings_generated"] += 1
                 stats[f"{stat_key}_processed"] += 1

--- a/backend/notes_service.py
+++ b/backend/notes_service.py
@@ -351,15 +351,17 @@ class NotesService:
         self._require_neo4j()
         return self.neo4j.get_all_note_ids()
 
-    def generate_embedding_for_note(self, note_id: str, content: str) -> None:
-        """Generate and store embedding for a note in Neo4j.
+    def generate_embedding_for_note(self, note_id: str, content: str, title: str = "") -> None:
+        """Generate and store chunked embeddings for a note in Neo4j (#192).
 
         This can be called as a background task to avoid blocking API responses.
-        Embeddings are stored in Neo4j for fast semantic search.
+        Chunk embeddings serve semantic search; their mean is stored as the
+        note's whole-document embedding for related-notes/link suggestions.
 
         Args:
             note_id: Note ID
-            content: Note content to generate embedding from
+            content: Note content to generate embeddings from
+            title: Note title (prefixed to each chunk)
         """
         import os
 
@@ -373,21 +375,39 @@ class NotesService:
             return
 
         try:
-            logger.debug("Generating embedding for note: %s", note_id)
-            embedding = self.ollama.generate_embedding(content, use_cache=True)
+            from core.ai import mean_vector
+            from core.chunking import chunk_document
+            from utils import calculate_content_hash
 
-            if embedding:
-                from utils import calculate_content_hash
+            chunks = chunk_document(title, content)
+            logger.debug("Generating %d chunk embedding(s) for note: %s", len(chunks), note_id)
 
+            chunk_embeddings: list[list[float]] = []
+            for chunk in chunks:
+                embedding = self.ollama.generate_embedding(chunk, use_cache=True)
+                if embedding is None:
+                    break
+                chunk_embeddings.append(embedding)
+
+            if chunks and len(chunk_embeddings) == len(chunks):
+                # Chunks first, node embedding last: node metadata drives
+                # staleness checks, so a partial write is retried by sync
+                self.neo4j.replace_chunk_embeddings(
+                    "Note", note_id, chunk_embeddings, self.ollama.model, EMBEDDING_VERSION
+                )
                 self.neo4j.store_embedding(
                     "Note",
                     note_id,
-                    embedding,
+                    mean_vector(chunk_embeddings),
                     self.ollama.model,
                     EMBEDDING_VERSION,
                     calculate_content_hash(content),
                 )
-                logger.info("Generated and stored embedding for note: %s", note_id)
+                logger.info(
+                    "Generated and stored %d embedding(s) for note: %s",
+                    len(chunk_embeddings),
+                    note_id,
+                )
             else:
                 logger.warning("Failed to generate embedding for note: %s", note_id)
         except Exception as e:

--- a/backend/routers/notes.py
+++ b/backend/routers/notes.py
@@ -82,7 +82,7 @@ async def create_note(
     content = note.content
     title = note.title or ""
 
-    background_tasks.add_task(notes_service.generate_embedding_for_note, note_id, content)
+    background_tasks.add_task(notes_service.generate_embedding_for_note, note_id, content, title)
     background_tasks.add_task(notes_service.generate_ai_content_for_note, note_id, content, title)
     logger.debug("Scheduled background tasks for note: %s", note_id)
 
@@ -355,7 +355,7 @@ async def update_note(
     content = note_update.content
     title = note_update.title or ""
 
-    background_tasks.add_task(notes_service.generate_embedding_for_note, note_id, content)
+    background_tasks.add_task(notes_service.generate_embedding_for_note, note_id, content, title)
     background_tasks.add_task(notes_service.generate_ai_content_for_note, note_id, content, title)
     logger.debug("Scheduled background tasks for note update: %s", note_id)
 

--- a/backend/routers/search.py
+++ b/backend/routers/search.py
@@ -11,6 +11,7 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, Request
 from rapidfuzz import fuzz
 
+from core.ai import rank_parents_by_chunk_similarity
 from core.search import extract_snippet
 from dependencies import get_neo4j, get_notes, get_ollama, get_static_articles, get_user_resources
 from feature_flags import FeatureFlagService, get_feature_flags
@@ -247,6 +248,46 @@ def search_resources(
     # Try to use fast semantic search with precomputed embeddings from Neo4j
     if neo4j.is_available():
         logger.info("Using fast semantic search with precomputed embeddings from Neo4j")
+
+        # Preferred: chunk-level scoring (#192). A document ranks on its
+        # best-matching section instead of one diluted whole-document vector.
+        chunk_data = neo4j.get_all_chunk_embeddings()
+        if chunk_data:
+            logger.info("Scoring %d chunk embeddings", len(chunk_data))
+            query_embedding = ollama.generate_embedding(search_request.query, use_cache=False)
+            if not query_embedding:
+                logger.warning("Failed to generate query embedding")
+                return SearchResponse(results=[], count=0)
+
+            ranked = rank_parents_by_chunk_similarity(
+                query_embedding, chunk_data, search_request.top_k
+            )
+
+            results = []
+            for item in ranked:
+                full_doc = next(
+                    (
+                        doc
+                        for doc in all_resources
+                        if (item["type"] == "Article" and str(doc.get("id")) == item["id"])
+                        or (item["type"] == "Note" and doc.get("note_id") == item["id"])
+                    ),
+                    None,
+                )
+                if full_doc:
+                    results.append(
+                        _normalize_search_result(
+                            full_doc, search_request.query, score=item["score"]
+                        )
+                    )
+
+            duration = time.time() - start_time
+            logger.info(
+                "Chunked semantic search complete: %d results in %.2fs", len(results), duration
+            )
+            return SearchResponse(results=results, count=len(results))
+
+        logger.info("No chunk embeddings found, using whole-document embeddings")
 
         # Fetch precomputed embeddings for articles and notes
         embeddings_data = neo4j.get_all_embeddings()

--- a/backend/tests/unit/test_core_ai.py
+++ b/backend/tests/unit/test_core_ai.py
@@ -258,3 +258,72 @@ class TestPromptBuilders:
         assert "Current Note" in prompt
         assert "Candidate 1" in prompt
         assert "note-1" in prompt
+
+
+class TestMeanVector:
+    """Tests for mean_vector (chunk -> whole-document embedding, #192)."""
+
+    def test_single_vector_is_identity(self):
+        assert ai.mean_vector([[1.0, 2.0, 3.0]]) == [1.0, 2.0, 3.0]
+
+    def test_mean_of_two_vectors(self):
+        result = ai.mean_vector([[1.0, 0.0], [0.0, 1.0]])
+        assert result == pytest.approx([0.5, 0.5])
+
+    def test_empty_input(self):
+        assert ai.mean_vector([]) == []
+
+    def test_mismatched_lengths_return_empty(self):
+        assert ai.mean_vector([[1.0, 2.0], [1.0]]) == []
+
+
+class TestRankParentsByChunkSimilarity:
+    """Tests for chunk-level ranking with max aggregation (#192)."""
+
+    def test_parent_ranks_on_best_chunk(self):
+        """One strongly matching section outranks uniformly mediocre documents."""
+        query = [1.0, 0.0, 0.0]
+        chunks = [
+            # doc-a: one great chunk among poor ones
+            {"parent_type": "Article", "parent_id": "a", "embedding": [0.0, 1.0, 0.0]},
+            {"parent_type": "Article", "parent_id": "a", "embedding": [1.0, 0.0, 0.0]},
+            # doc-b: all chunks mediocre
+            {"parent_type": "Article", "parent_id": "b", "embedding": [0.7, 0.7, 0.0]},
+            {"parent_type": "Article", "parent_id": "b", "embedding": [0.6, 0.8, 0.0]},
+        ]
+
+        results = ai.rank_parents_by_chunk_similarity(query, chunks, top_k=5)
+
+        assert [r["id"] for r in results] == ["a", "b"]
+        assert results[0]["score"] == pytest.approx(1.0)
+
+    def test_respects_top_k(self):
+        query = [1.0, 0.0]
+        chunks = [
+            {"parent_type": "Note", "parent_id": str(i), "embedding": [1.0, i / 10]}
+            for i in range(5)
+        ]
+        results = ai.rank_parents_by_chunk_similarity(query, chunks, top_k=2)
+        assert len(results) == 2
+
+    def test_skips_chunks_without_embedding(self):
+        query = [1.0, 0.0]
+        chunks = [
+            {"parent_type": "Note", "parent_id": "x", "embedding": None},
+            {"parent_type": "Note", "parent_id": "y", "embedding": [1.0, 0.0]},
+        ]
+        results = ai.rank_parents_by_chunk_similarity(query, chunks, top_k=5)
+        assert [r["id"] for r in results] == ["y"]
+
+    def test_mixed_types_keep_identity(self):
+        query = [1.0, 0.0]
+        chunks = [
+            {"parent_type": "Article", "parent_id": "1", "embedding": [1.0, 0.0]},
+            {"parent_type": "Note", "parent_id": "wise-mountain", "embedding": [0.9, 0.1]},
+        ]
+        results = ai.rank_parents_by_chunk_similarity(query, chunks, top_k=5)
+        assert results[0] == {"id": "1", "type": "Article", "score": pytest.approx(1.0)}
+        assert results[1]["type"] == "Note"
+
+    def test_empty_chunks(self):
+        assert ai.rank_parents_by_chunk_similarity([1.0], [], top_k=5) == []

--- a/backend/tests/unit/test_core_chunking.py
+++ b/backend/tests/unit/test_core_chunking.py
@@ -1,0 +1,68 @@
+"""Unit tests for core.chunking (pure document chunking, #192)."""
+
+from core.chunking import CHUNK_MAX_CHARS, CHUNK_TARGET_CHARS, chunk_document
+
+
+class TestChunkDocument:
+    def test_short_document_single_chunk_with_title(self) -> None:
+        chunks = chunk_document("My Title", "Short content.")
+        assert chunks == ["My Title\n\nShort content."]
+
+    def test_empty_content_returns_title_only(self) -> None:
+        assert chunk_document("My Title", "") == ["My Title"]
+
+    def test_empty_title_and_content(self) -> None:
+        assert chunk_document("", "") == []
+
+    def test_empty_title_keeps_content(self) -> None:
+        chunks = chunk_document("", "Just content.")
+        assert chunks == ["Just content."]
+
+    def test_long_document_splits_at_headings(self) -> None:
+        section_a = "## Alpha\n\n" + ("aaa " * 300)
+        section_b = "## Beta\n\n" + ("bbb " * 300)
+        content = f"{section_a}\n\n{section_b}"
+
+        chunks = chunk_document("Title", content)
+
+        assert len(chunks) == 2
+        assert chunks[0].startswith("Title\n\n## Alpha")
+        assert chunks[1].startswith("Title\n\n## Beta")
+
+    def test_title_prefixed_to_every_chunk(self) -> None:
+        content = "\n\n".join(f"## H{i}\n\n" + ("word " * 250) for i in range(4))
+        chunks = chunk_document("The Title", content)
+
+        assert len(chunks) > 1
+        assert all(chunk.startswith("The Title\n\n") for chunk in chunks)
+
+    def test_small_sections_packed_together(self) -> None:
+        content = "\n\n".join(f"## H{i}\n\nshort section {i}" for i in range(5))
+        chunks = chunk_document("Title", content)
+        # All sections fit well within the target, so they stay in one chunk
+        assert len(chunks) == 1
+        assert "short section 4" in chunks[0]
+
+    def test_oversized_paragraph_hard_split(self) -> None:
+        content = "x" * (CHUNK_MAX_CHARS * 2 + 100)  # no headings, no paragraph breaks
+        chunks = chunk_document("T", content)
+
+        assert len(chunks) >= 2
+        # Every chunk stays within max size (plus the title prefix)
+        assert all(len(chunk) <= CHUNK_MAX_CHARS + len("T\n\n") for chunk in chunks)
+        # No content lost
+        assert sum(len(chunk) - len("T\n\n") for chunk in chunks) == len(content)
+
+    def test_preamble_before_first_heading_kept(self) -> None:
+        content = "Intro paragraph before headings.\n\n## First\n\nBody"
+        chunks = chunk_document("Title", content)
+        joined = "\n".join(chunks)
+        assert "Intro paragraph before headings." in joined
+        assert "## First" in joined
+
+    def test_typical_note_matches_whole_document_embedding_shape(self) -> None:
+        # A typical note stays a single chunk: behavior identical to
+        # whole-document embedding, just with the title included
+        content = "A note about barnacles.\n\nThey accumulate on ships."
+        chunks = chunk_document("Rocks and Barnacles", content, target_chars=CHUNK_TARGET_CHARS)
+        assert len(chunks) == 1

--- a/backend/tests/unit/test_embedding_sync.py
+++ b/backend/tests/unit/test_embedding_sync.py
@@ -9,6 +9,8 @@ import time
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from embedding_sync import (
     EMBEDDING_VERSION,
     _generate_with_retry,
@@ -187,3 +189,101 @@ class TestSyncEmbeddings:
         client.generate_embedding.assert_not_called()
         assert stats["embeddings_cached"] == 1
         assert stats["embeddings_failed"] == 0
+
+
+class TestChunkedEmbeddings:
+    """Chunked embedding generation (#192)."""
+
+    def _stats(self) -> dict[str, int]:
+        return {
+            "articles_processed": 0,
+            "notes_processed": 0,
+            "embeddings_generated": 0,
+            "embeddings_cached": 0,
+            "embeddings_failed": 0,
+        }
+
+    def _long_node(self) -> dict[str, Any]:
+        """A stale node whose content splits into two chunks."""
+        content = "## Alpha\n\n" + ("a" * 1600) + "\n\n## Beta\n\n" + ("b" * 1600)
+        return {"id": "1", "title": "Long Article", "content": content}
+
+    def test_multi_chunk_node_stores_chunks_and_mean_embedding(self) -> None:
+        neo4j = MagicMock()
+        client = MagicMock()
+        client.generate_embedding.side_effect = [[0.1, 0.3], [0.3, 0.5]]
+        stats = self._stats()
+        node = self._long_node()
+
+        _process_embeddings_for_nodes(
+            [node],
+            "Article",
+            "articles",
+            MODEL,
+            EMBEDDING_VERSION,
+            neo4j,
+            client,
+            stats,
+            deadline=time.monotonic() + 600,
+        )
+
+        # Two chunks embedded, both stored
+        assert client.generate_embedding.call_count == 2
+        neo4j.replace_chunk_embeddings.assert_called_once_with(
+            "Article", "1", [[0.1, 0.3], [0.3, 0.5]], MODEL, EMBEDDING_VERSION
+        )
+        # Whole-document embedding is the mean of the chunk embeddings
+        args = neo4j.store_embedding.call_args[0]
+        assert args[0] == "Article"
+        assert args[1] == "1"
+        assert args[2] == pytest.approx([0.2, 0.4])
+        assert args[3] == MODEL
+        assert args[4] == EMBEDDING_VERSION
+        assert args[5] == calculate_content_hash(node["content"])
+        assert stats["embeddings_generated"] == 1
+
+    def test_chunk_text_includes_title(self) -> None:
+        neo4j = MagicMock()
+        client = MagicMock()
+        client.generate_embedding.return_value = [0.1]
+        stats = self._stats()
+        node = {"id": "n1", "title": "Rocks and Barnacles", "content": "Short content."}
+
+        _process_embeddings_for_nodes(
+            [node],
+            "Note",
+            "notes",
+            MODEL,
+            EMBEDDING_VERSION,
+            neo4j,
+            client,
+            stats,
+            deadline=time.monotonic() + 600,
+        )
+
+        embedded_text = client.generate_embedding.call_args[0][0]
+        assert embedded_text.startswith("Rocks and Barnacles\n\n")
+        assert "Short content." in embedded_text
+
+    def test_partial_chunk_failure_stores_nothing(self) -> None:
+        """If any chunk fails, neither chunks nor the node embedding are written."""
+        neo4j = MagicMock()
+        client = MagicMock()
+        client.generate_embedding.side_effect = [[0.1, 0.3], None]
+        stats = self._stats()
+
+        _process_embeddings_for_nodes(
+            [self._long_node()],
+            "Article",
+            "articles",
+            MODEL,
+            EMBEDDING_VERSION,
+            neo4j,
+            client,
+            stats,
+            deadline=time.monotonic() - 1,  # no retries
+        )
+
+        neo4j.replace_chunk_embeddings.assert_not_called()
+        neo4j.store_embedding.assert_not_called()
+        assert stats["embeddings_failed"] == 1

--- a/backend/tests/unit/test_search_api.py
+++ b/backend/tests/unit/test_search_api.py
@@ -7,6 +7,7 @@ Tests the /api/search endpoint including:
 - Error handling
 """
 
+import pytest
 from fastapi.testclient import TestClient
 
 
@@ -202,3 +203,78 @@ class TestSearchSnippets:
             # Snippet should not be longer than ~250 chars (with some buffer for ellipsis)
             if len(content) > 300:
                 assert len(snippet) < 300, f"Snippet too long: {len(snippet)} chars"
+
+
+class TestChunkedSemanticSearch:
+    """Semantic search via chunk embeddings (#192)."""
+
+    def _client_with_chunk_neo4j(self, client: TestClient, chunks: list[dict]) -> None:
+        """Override the Neo4j dependency with a mock that serves chunk embeddings."""
+        from unittest.mock import MagicMock
+
+        import main
+        from dependencies import get_neo4j
+
+        neo4j = MagicMock()
+        neo4j.is_available.return_value = True
+        neo4j.get_all_chunk_embeddings.return_value = chunks
+        main.app.dependency_overrides[get_neo4j] = lambda: neo4j
+
+    def test_best_chunk_ranks_document_first(self, client: TestClient) -> None:
+        """A document whose chunk matches the query embedding exactly ranks first."""
+        # Pick two real articles from the corpus
+        articles = client.get("/api/articles").json()["resources"]
+        assert len(articles) >= 2
+        target_id = str(articles[0]["id"])
+        other_id = str(articles[1]["id"])
+
+        # The mock Ollama client's query embedding is deterministic per text,
+        # so use it as the target chunk's embedding (cosine similarity 1.0)
+        from tests.conftest import MockOllamaClient
+
+        query = "rocks and barnacles"
+        query_embedding = MockOllamaClient().generate_embedding(query)
+        assert query_embedding is not None
+        orthogonal = list(reversed(query_embedding))
+
+        self._client_with_chunk_neo4j(
+            client,
+            [
+                {"parent_type": "Article", "parent_id": other_id, "seq": 0, "embedding": orthogonal},
+                {"parent_type": "Article", "parent_id": target_id, "seq": 0, "embedding": orthogonal},
+                {"parent_type": "Article", "parent_id": target_id, "seq": 1, "embedding": query_embedding},
+            ],
+        )
+
+        response = client.post("/api/search", json={"query": query, "semantic": True, "top_k": 5})
+        assert response.status_code == 200
+        results = response.json()["results"]
+
+        assert len(results) >= 1
+        assert results[0]["id"] == target_id
+        assert results[0]["type"] == "article"
+        assert results[0]["score"] == pytest.approx(1.0)
+
+    def test_falls_back_to_document_embeddings_without_chunks(self, client: TestClient) -> None:
+        """With no chunk data, search uses the whole-document embedding path."""
+        from unittest.mock import MagicMock
+
+        import main
+        from dependencies import get_neo4j
+
+        articles = client.get("/api/articles").json()["resources"]
+        target_id = str(articles[0]["id"])
+
+        neo4j = MagicMock()
+        neo4j.is_available.return_value = True
+        neo4j.get_all_chunk_embeddings.return_value = []
+        neo4j.get_all_embeddings.return_value = [
+            {"id": target_id, "type": "Article", "embedding": [0.1] * 768, "model": "m", "version": 2}
+        ]
+        main.app.dependency_overrides[get_neo4j] = lambda: neo4j
+
+        response = client.post("/api/search", json={"query": "anything", "semantic": True, "top_k": 5})
+        assert response.status_code == 200
+        results = response.json()["results"]
+        assert len(results) == 1
+        assert results[0]["id"] == target_id

--- a/docs/AI_OPTIMIZATION.md
+++ b/docs/AI_OPTIMIZATION.md
@@ -16,8 +16,8 @@ AI features (Q&A, semantic search, tag/link suggestions) are slow and constraine
 
 | Concern | Implementation | Location |
 |---|---|---|
-| Embeddings | Ollama `nomic-embed-text`, precomputed and stored in Neo4j | `ollama_client.py`, `embedding_sync.py` |
-| Semantic search | Query embedding + cosine similarity vs. precomputed vectors | `routers/search.py`, `core/ai.py` |
+| Embeddings | Ollama `nomic-embed-text` (dev) / Gemini (prod), precomputed per section-level chunk and stored in Neo4j (#192) | `ollama_client.py`, `embedding_sync.py`, `core/chunking.py` |
+| Semantic search | Query embedding + cosine similarity vs. precomputed chunk vectors; each document ranks by its best-matching chunk | `routers/search.py`, `core/ai.py` |
 | Q&A | RAG: top-5 docs as context → `llama3.2:1b` | `routers/ai.py` `/api/ask` |
 | Tag/link suggestions | `qwen2.5:1.5b` JSON output, cached in Neo4j, SSE streaming | `routers/ai.py`, `notes_service.py` |
 | Gating | Runtime feature flag (`llm_features`), rate limiting | `feature_flags.py`, `rate_limiter.py` |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -36,7 +36,11 @@ backend/
 │   │   ├── build_qa_prompt()
 │   │   ├── parse_json_response()
 │   │   ├── build_tag_suggestion_prompt()
-│   │   └── filter_link_candidates()
+│   │   ├── filter_link_candidates()
+│   │   ├── mean_vector()
+│   │   └── rank_parents_by_chunk_similarity()
+│   ├── chunking.py           # Document chunking for embeddings (#192)
+│   │   └── chunk_document()
 │   └── notes.py              # Notes/graph algorithms
 │       ├── extract_wikilinks()
 │       ├── validate_note_id()

--- a/docs/knowledge-base/README.md
+++ b/docs/knowledge-base/README.md
@@ -32,8 +32,8 @@ Both articles and notes are treated as "resources" in the API, allowing:
 - **Articles**: Static markdown files, cached at startup, auto-reload on changes
 - **Notes**: Database-backed (Neo4j), for admin-created content
 
-### 3. AI Integration (Ollama)
-- Semantic search across articles and notes
+### 3. AI Integration
+- Semantic search across articles and notes (chunked embeddings: documents are embedded per section and rank by their best-matching chunk, #192)
 - AI-suggested related content and wikilinks
 - Auto-generated summaries for navigation
 - Q&A with context from knowledge base
@@ -111,12 +111,12 @@ GET    /api/articles/{id}/summary         # AI-generated article summary
 - **Framework**: FastAPI (Python 3.13)
 - **Database**: Neo4j (graph database for notes and relationships)
 - **Storage**: Filesystem (articles) + Database (notes)
-- **AI**: Ollama (local LLM for embeddings and chat)
+- **AI**: Ollama in dev (local embeddings + chat); prod uses hosted APIs (Groq/Gemini) with Ollama removed
 - **Caching**: In-memory with file modification time tracking
 
 ### Frontend Stack
-- **Framework**: Next.js 14 with App Router
-- **UI**: React 18 + TypeScript + SCSS Modules
+- **Framework**: Next.js 15 with App Router (article pages are server-rendered)
+- **UI**: React 19 + TypeScript + SCSS Modules
 - **Graph**: react-force-graph (2D/3D force-directed graphs)
 - **Editor**: TipTap (markdown with wikilink autocomplete)
 


### PR DESCRIPTION
## Summary
Whole-document embeddings diluted topical signal: "rocks and barnacles" ranked the actual Rocks & Barnacles article 3rd (0.355) behind unrelated articles. With chunked embeddings it ranks 1st with a clear margin (0.684 vs 0.464 runner-up). Fixes #192.

- `core/chunking.py` (pure): split at markdown headings, pack to ~1500 chars, hard-split oversized sections, **title prefixed to every chunk** (titles were never embedded before).
- Chunks stored as `(parent)-[:HAS_CHUNK]->(:Chunk)` nodes in Neo4j, replaced wholesale on content change, deleted with their note.
- Search scores every chunk and ranks each document by its best chunk (max aggregation, `core.ai.rank_parents_by_chunk_similarity`); falls back to whole-document embeddings when no chunks exist yet.
- Whole-document embedding = mean of chunk embeddings (no extra API calls) so related-notes/link-suggestions keep working.
- Runtime note create/update generates chunks too.
- `EMBEDDING_VERSION` 1→2 forces a one-time re-embed. **Post-merge:** the next admin `sync-embeddings` in prod regenerates the whole corpus via Gemini — retry/backoff (#213) should absorb 429s, but worth watching the first run.
- Scale ceiling (per the issue comment): chunk vectors are still loaded and scored in Python (~4x vector count). Fine at current size; `get_all_chunk_embeddings` is the seam for a Neo4j vector index later.

## Testing
- New unit tests: chunking, mean/max-aggregation ranking, sync chunk storage + partial-failure atomicity, chunk-path and fallback search API. 373 backend tests, mypy, ruff pass.
- Verified end-to-end in dev (113 docs re-embedded via Ollama, 0 failures): before/after rankings above, plus sanity queries.