### PR TITLE
fix: pin linkify-it-py so prod markdown rendering works

### DIFF
--- a/backend/requirements-base.txt
+++ b/backend/requirements-base.txt
@@ -16,6 +16,7 @@ rapidfuzz==3.10.1  # Fuzzy string matching for search
 # Markdown rendering (server-side)
 markdown-it-py==4.0.0  # Markdown parser
 mdit-py-plugins==0.5.0  # Plugins for footnotes, front matter, etc.
+linkify-it-py==2.1.0  # Required by the gfm-like preset (linkify); render fails without it
 Pygments==2.19.2  # Syntax highlighting for code blocks
 
 # Production optimizations


### PR DESCRIPTION
## Summary
Fixes #242 — prod served articles (and notes) as raw markdown plaintext while localhost rendered fine.

**Root cause:** `core/markdown_renderer.py` builds `MarkdownIt("gfm-like", {"linkify": True, ...})`, and the gfm-like preset requires `linkify-it-py` at render time. It was never pinned in any requirements file. The dev image happened to contain it as a stray leftover (`pip show` reports no `Required-by`), but prod installs fresh from `requirements-prod.txt` with `--no-cache-dir`, so every render raised `ModuleNotFoundError: Linkify enabled but not installed.` The `except Exception` in `article_loader.py` swallowed the error and served `html_content: null`, and the frontend fell back to dumping raw markdown.

**Fix:** pin `linkify-it-py==2.1.0` in `requirements-base.txt` (used by both dev and prod tiers).

## Verification
- Reproduced the prod failure in the dev container by blocking the `linkify_it` import: `render_markdown_to_html` raises the exact `ModuleNotFoundError` above.
- `pip install --dry-run -r requirements-base.txt` resolves cleanly.
- `pytest tests/unit/test_markdown_renderer.py` — 9 passed.

## Follow-up candidates (not in this PR)
- Construct the `MarkdownIt` instance at module load so a missing dependency crashes at startup instead of silently degrading every render.
- The broad `except Exception` in `article_loader.py` hid this for a full deploy cycle; consider logging at error level or failing health checks.