### PR TITLE
chore: delete stale Article nodes during sync

### DIFF
--- a/backend/adapters/neo4j.py
+++ b/backend/adapters/neo4j.py
@@ -1051,6 +1051,38 @@ class Neo4jAdapter:
                 for record in result
             ]
 
+    def delete_articles_not_in(self, keep_ids: list[str]) -> list[str]:
+        """Delete Article nodes (and their chunks) whose id is not in keep_ids.
+
+        Static articles are the source of truth; nodes for renamed or removed
+        articles otherwise accumulate, get embeddings generated for them, and
+        surface in semantic search for content that no longer exists (#215).
+
+        Args:
+            keep_ids: IDs of the current static article set
+
+        Returns:
+            IDs of the deleted stale Article nodes
+        """
+        if not self._available or not self.driver:
+            return []
+
+        with self.driver.session(database=self.database) as session:
+            result = session.run(
+                """
+                MATCH (a:Article)
+                WHERE NOT a.id IN $keep_ids
+                OPTIONAL MATCH (a)-[:HAS_CHUNK]->(c:Chunk)
+                WITH a, a.id AS article_id, c
+                DETACH DELETE c, a
+                RETURN collect(DISTINCT article_id) AS deleted
+                """,
+                keep_ids=keep_ids,
+            )
+
+            record = result.single()
+            return list(record["deleted"]) if record else []
+
     # ===== EMBEDDING METHODS =====
 
     def store_embedding(

--- a/backend/embedding_sync.py
+++ b/backend/embedding_sync.py
@@ -70,21 +70,22 @@ def _generate_with_retry(
 def sync_articles_to_neo4j(
     articles: list[dict[str, Any]],
     neo4j_adapter: Any,
-) -> tuple[int, int]:
+) -> tuple[int, int, int]:
     """Sync static articles to Neo4j.
 
-    Creates or updates Article nodes based on content_hash.
+    Creates or updates Article nodes based on content_hash, then deletes
+    stale nodes for articles that no longer exist in the static set (#215).
 
     Args:
         articles: List of article dicts from article_loader
         neo4j_adapter: Neo4jAdapter instance
 
     Returns:
-        Tuple of (created_count, updated_count)
+        Tuple of (created_count, updated_count, deleted_count)
     """
     if not neo4j_adapter.is_available():
         logger.warning("Neo4j not available - skipping article sync")
-        return (0, 0)
+        return (0, 0, 0)
 
     created = 0
     updated = 0
@@ -120,8 +121,26 @@ def sync_articles_to_neo4j(
             created += 1
             logger.debug("Created article: %s", article_id)
 
-    logger.info("Article sync complete: %d created, %d updated", created, updated)
-    return (created, updated)
+    # Static articles are the source of truth: drop nodes for renamed or
+    # removed articles. Skip when the loader returned nothing - an empty
+    # list more likely means a load failure than an emptied corpus.
+    deleted_ids: list[str] = []
+    if articles:
+        deleted_ids = neo4j_adapter.delete_articles_not_in(
+            [str(article["id"]) for article in articles]
+        )
+        if deleted_ids:
+            logger.info(
+                "Deleted %d stale article node(s): %s", len(deleted_ids), ", ".join(deleted_ids)
+            )
+
+    logger.info(
+        "Article sync complete: %d created, %d updated, %d deleted",
+        created,
+        updated,
+        len(deleted_ids),
+    )
+    return (created, updated, len(deleted_ids))
 
 
 def needs_embedding_regeneration(
@@ -363,8 +382,8 @@ def sync_embeddings_on_startup(
     logger.info("=" * 60)
 
     # Step 1: Sync articles to Neo4j
-    created, updated = sync_articles_to_neo4j(articles, neo4j_adapter)
-    logger.info("Articles synced: %d created, %d updated", created, updated)
+    created, updated, deleted = sync_articles_to_neo4j(articles, neo4j_adapter)
+    logger.info("Articles synced: %d created, %d updated, %d deleted", created, updated, deleted)
 
     # Step 2: Generate missing embeddings
     stats = sync_embeddings(neo4j_adapter, ollama_client)

--- a/backend/main.py
+++ b/backend/main.py
@@ -666,8 +666,10 @@ def trigger_embedding_sync(
         from embedding_sync import sync_articles_to_neo4j, sync_embeddings
 
         # Sync articles to Neo4j first
-        created, updated = sync_articles_to_neo4j(static_articles, neo4j)
-        logger.info("Articles synced: %d created, %d updated", created, updated)
+        created, updated, deleted = sync_articles_to_neo4j(static_articles, neo4j)
+        logger.info(
+            "Articles synced: %d created, %d updated, %d deleted", created, updated, deleted
+        )
 
         # Generate embeddings for anything that needs it
         stats = sync_embeddings(neo4j, ollama)

--- a/backend/tests/unit/test_embedding_sync.py
+++ b/backend/tests/unit/test_embedding_sync.py
@@ -16,6 +16,7 @@ from embedding_sync import (
     _generate_with_retry,
     _process_embeddings_for_nodes,
     needs_embedding_regeneration,
+    sync_articles_to_neo4j,
     sync_embeddings,
 )
 from utils import calculate_content_hash
@@ -287,3 +288,58 @@ class TestChunkedEmbeddings:
         neo4j.replace_chunk_embeddings.assert_not_called()
         neo4j.store_embedding.assert_not_called()
         assert stats["embeddings_failed"] == 1
+
+
+class TestSyncArticlesToNeo4j:
+    """Tests for sync_articles_to_neo4j, especially stale-node cleanup (#215)."""
+
+    def _articles(self) -> list[dict[str, Any]]:
+        return [
+            {"id": 1, "title": "One", "content": "first article"},
+            {"id": 2, "title": "Two", "content": "second article"},
+        ]
+
+    def test_deletes_stale_articles_after_upsert(self) -> None:
+        neo4j = MagicMock()
+        neo4j.is_available.return_value = True
+        neo4j.get_article.return_value = None
+        neo4j.delete_articles_not_in.return_value = ["7", "9"]
+
+        created, updated, deleted = sync_articles_to_neo4j(self._articles(), neo4j)
+
+        neo4j.delete_articles_not_in.assert_called_once_with(["1", "2"])
+        assert (created, updated, deleted) == (2, 0, 2)
+
+    def test_no_deletion_when_article_list_empty(self) -> None:
+        """An empty static set means a load failure, not an emptied corpus."""
+        neo4j = MagicMock()
+        neo4j.is_available.return_value = True
+
+        created, updated, deleted = sync_articles_to_neo4j([], neo4j)
+
+        neo4j.delete_articles_not_in.assert_not_called()
+        assert (created, updated, deleted) == (0, 0, 0)
+
+    def test_unavailable_neo4j_skips_everything(self) -> None:
+        neo4j = MagicMock()
+        neo4j.is_available.return_value = False
+
+        assert sync_articles_to_neo4j(self._articles(), neo4j) == (0, 0, 0)
+        neo4j.delete_articles_not_in.assert_not_called()
+
+    def test_unchanged_articles_not_reupserted(self) -> None:
+        neo4j = MagicMock()
+        neo4j.is_available.return_value = True
+        neo4j.delete_articles_not_in.return_value = []
+        articles = self._articles()
+        neo4j.get_article.side_effect = lambda article_id: {
+            "id": article_id,
+            "content_hash": calculate_content_hash(
+                next(a["content"] for a in articles if str(a["id"]) == article_id)
+            ),
+        }
+
+        created, updated, deleted = sync_articles_to_neo4j(articles, neo4j)
+
+        neo4j.upsert_article.assert_not_called()
+        assert (created, updated, deleted) == (0, 0, 0)


### PR DESCRIPTION
## Summary
Fixes #215 — prod Neo4j holds 20 Article nodes vs 13 static articles. `sync_articles_to_neo4j()` upserted but never deleted, so nodes for renamed/removed articles accumulated, got embeddings generated (wasted Gemini calls), and could surface in semantic search.

- New `Neo4jAdapter.delete_articles_not_in(keep_ids)`: deletes Article nodes and their `HAS_CHUNK` chunks whose id isn't in the current static set, returning the deleted ids (mirrors the `delete_note` Cypher pattern).
- Called at the end of `sync_articles_to_neo4j()`, which now returns `(created, updated, deleted)`. **Safety guard:** deletion is skipped when the loader returns an empty list — that more likely means a load failure than an emptied corpus.

## Verification
- 4 new unit tests (deletion called with current ids, skipped on empty list, skipped when Neo4j unavailable, unchanged articles not re-upserted); full backend suite green.
- Live in dev: planted a stale Article node with a chunk → sync reported `deleted=1`, removed node + chunk, left the 13 real articles untouched.

## Post-deploy note
The 7 stale prod nodes are only removed when the sync runs — trigger `POST /api/admin/sync-embeddings` once after deploy.

## Related
While verifying, found 100 orphaned Chunk nodes in dev (llama3.2:1b era, no relationships) — filed as #244, not addressed here.

https://claude.ai/code/session_01A7hvzjTMbV5vqbzNucYJWe