### PR TITLE
chore: sweep orphaned Chunk nodes during embedding sync

### DIFF
--- a/backend/adapters/neo4j.py
+++ b/backend/adapters/neo4j.py
@@ -1083,6 +1083,32 @@ class Neo4jAdapter:
             record = result.single()
             return list(record["deleted"]) if record else []
 
+    def delete_orphaned_chunks(self) -> int:
+        """Delete Chunk nodes with no HAS_CHUNK parent (#244).
+
+        Orphans are unreachable by search (which traverses HAS_CHUNK) but
+        accumulate as dead weight, e.g. leftovers from earlier embedding
+        experiments before chunk cleanup existed.
+
+        Returns:
+            Number of chunks deleted
+        """
+        if not self._available or not self.driver:
+            return 0
+
+        with self.driver.session(database=self.database) as session:
+            result = session.run(
+                """
+                MATCH (c:Chunk)
+                WHERE NOT (()-[:HAS_CHUNK]->(c))
+                DETACH DELETE c
+                RETURN count(c) AS deleted
+                """
+            )
+
+            record = result.single()
+            return int(record["deleted"]) if record else 0
+
     # ===== EMBEDDING METHODS =====
 
     def store_embedding(

--- a/backend/embedding_sync.py
+++ b/backend/embedding_sync.py
@@ -310,11 +310,19 @@ def sync_embeddings(
         "embeddings_generated": 0,
         "embeddings_cached": 0,
         "embeddings_failed": 0,
+        "orphaned_chunks_deleted": 0,
     }
 
     if not neo4j_adapter.is_available():
         logger.warning("Neo4j not available - skipping embedding sync")
         return stats
+
+    # Sweep chunks with no HAS_CHUNK parent (#244) before generating
+    # anything - runs even when the embedding backend is down
+    orphans = neo4j_adapter.delete_orphaned_chunks()
+    stats["orphaned_chunks_deleted"] = orphans
+    if orphans:
+        logger.info("Deleted %d orphaned chunk node(s)", orphans)
 
     if not ollama_client.embeddings_available():
         logger.warning("Ollama not available - skipping embedding sync")

--- a/backend/tests/unit/test_embedding_sync.py
+++ b/backend/tests/unit/test_embedding_sync.py
@@ -343,3 +343,46 @@ class TestSyncArticlesToNeo4j:
 
         neo4j.upsert_article.assert_not_called()
         assert (created, updated, deleted) == (0, 0, 0)
+
+
+class TestOrphanedChunkCleanup:
+    """Tests for the orphaned-chunk sweep in sync_embeddings (#244)."""
+
+    def test_orphans_deleted_and_counted(self) -> None:
+        neo4j = MagicMock()
+        neo4j.is_available.return_value = True
+        neo4j.delete_orphaned_chunks.return_value = 100
+        neo4j.get_all_articles.return_value = []
+        neo4j.get_all_notes.return_value = []
+        client = MagicMock()
+        client.embeddings_available.return_value = True
+        client.model = MODEL
+
+        stats = sync_embeddings(neo4j, client)
+
+        neo4j.delete_orphaned_chunks.assert_called_once()
+        assert stats["orphaned_chunks_deleted"] == 100
+
+    def test_sweep_runs_even_without_embedding_backend(self) -> None:
+        """Cleanup is pure Neo4j work - no reason to skip it when Ollama is down."""
+        neo4j = MagicMock()
+        neo4j.is_available.return_value = True
+        neo4j.delete_orphaned_chunks.return_value = 7
+        client = MagicMock()
+        client.embeddings_available.return_value = False
+
+        stats = sync_embeddings(neo4j, client)
+
+        neo4j.delete_orphaned_chunks.assert_called_once()
+        assert stats["orphaned_chunks_deleted"] == 7
+        assert stats["embeddings_generated"] == 0
+
+    def test_sweep_skipped_when_neo4j_unavailable(self) -> None:
+        neo4j = MagicMock()
+        neo4j.is_available.return_value = False
+        client = MagicMock()
+
+        stats = sync_embeddings(neo4j, client)
+
+        neo4j.delete_orphaned_chunks.assert_not_called()
+        assert stats["orphaned_chunks_deleted"] == 0


### PR DESCRIPTION
## Summary
Fixes #244 — dev Neo4j had 100 Chunk nodes with no `HAS_CHUNK` parent (all `llama3.2:1b` / seq 0, leftovers from before chunk cleanup existed). They're invisible to search, which traverses `HAS_CHUNK`, but pure dead weight; prod likely has similar cruft.

- New `Neo4jAdapter.delete_orphaned_chunks()`: `MATCH (c:Chunk) WHERE NOT (()-[:HAS_CHUNK]->(c)) DETACH DELETE c`, returns the count.
- Called at the start of `sync_embeddings()` so orphans can't accumulate again. The sweep runs even when the embedding backend is down (it's pure Neo4j work) and reports as `orphaned_chunks_deleted` in the sync stats, so the admin sync response will show what got swept.

## Verification
- 3 new unit tests (swept + counted, runs without embedding backend, skipped when Neo4j down); full backend suite 403 passed.
- Live in dev: 232 chunks / 100 orphans before → 132 chunks / 0 orphans after, all 132 survivors still parented.

## Post-deploy
Nothing manual needed beyond a sync run — the next `POST /api/admin/sync-embeddings` will sweep prod and report the count in `stats.orphaned_chunks_deleted`.

https://claude.ai/code/session_01A7hvzjTMbV5vqbzNucYJWe