### PR TITLE
ci: first-load JS bundle budget guardrail (#239)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,32 @@ jobs:
       - name: Format check
         run: npx prettier --check "src/**/*.{ts,tsx,js,jsx,json,css,md}"
 
+  frontend-bundle-budget:
+    name: Frontend - Bundle Budget
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Check first-load JS budgets
+        run: npm run check-bundle-budget
+
   frontend-tests:
     name: Frontend - Tests
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,9 @@ build-frontend: ## Build frontend for production
 build-frontend-analyze: ## Build frontend with bundle analysis
 	docker compose exec frontend npm run build:analyze
 
+check-bundle-budget: ## Check first-load JS budgets (requires a prior build)
+	docker compose exec frontend npm run check-bundle-budget
+
 ##@ Combined Code Quality
 
 lint: lint-backend lint-frontend ## Run all linters

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "check-bundle-budget": "node scripts/check-bundle-budget.mjs",
     "build:analyze": "ANALYZE=true next build",
     "start": "next start",
     "lint": "next lint",

--- a/frontend/scripts/check-bundle-budget.mjs
+++ b/frontend/scripts/check-bundle-budget.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * First-load JS budget check (#239).
+ *
+ * Reads .next/app-build-manifest.json after `next build` and computes the
+ * gzipped size of each route's first-load scripts. Fails (exit 1) if any
+ * route exceeds its budget, so bundle regressions fail loudly in CI.
+ *
+ * Budgets are gzipped bytes. DEFAULT_BUDGET covers any route not listed in
+ * ROUTE_BUDGETS. Baselines were measured after the #233/#235 pruning; keep
+ * headroom modest so regressions are caught early. If a legitimate feature
+ * needs more, raise the budget in the same PR and say why.
+ */
+
+import { readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { gzipSync } from "node:zlib";
+
+const NEXT_DIR = join(process.cwd(), ".next");
+
+// Default budget for any app route's first-load JS (gzipped).
+// Largest route measured 134 kB after the #233/#235 pruning; 150 kB leaves
+// ~12% headroom before the check fires.
+const DEFAULT_BUDGET = 150 * 1024;
+
+// Per-route overrides (gzipped bytes); empty today - every route fits the default
+const ROUTE_BUDGETS = {};
+
+function fail(msg) {
+  console.error(`❌ ${msg}`);
+  process.exitCode = 1;
+}
+
+let manifest;
+try {
+  manifest = JSON.parse(readFileSync(join(NEXT_DIR, "app-build-manifest.json"), "utf8"));
+} catch (err) {
+  console.error(`Cannot read .next/app-build-manifest.json - run \`next build\` first (${err.message})`);
+  process.exit(2);
+}
+
+const gzipCache = new Map();
+function gzippedSize(file) {
+  if (!gzipCache.has(file)) {
+    const path = join(NEXT_DIR, file);
+    try {
+      statSync(path);
+      gzipCache.set(file, gzipSync(readFileSync(path)).length);
+    } catch {
+      // Non-file entries (rare) count as zero rather than crashing the check
+      gzipCache.set(file, 0);
+    }
+  }
+  return gzipCache.get(file);
+}
+
+const rows = [];
+for (const [route, files] of Object.entries(manifest.pages)) {
+  const jsFiles = files.filter((f) => f.endsWith(".js"));
+  const size = jsFiles.reduce((sum, f) => sum + gzippedSize(f), 0);
+  const budget = ROUTE_BUDGETS[route] ?? DEFAULT_BUDGET;
+  rows.push({ route, size, budget, over: size > budget });
+}
+
+rows.sort((a, b) => b.size - a.size);
+
+const kb = (n) => `${(n / 1024).toFixed(1)} kB`;
+const width = Math.max(...rows.map((r) => r.route.length));
+console.log(`\nFirst-load JS (gzipped) vs budget:\n`);
+for (const { route, size, budget, over } of rows) {
+  const mark = over ? "❌ OVER" : "✓";
+  console.log(`  ${route.padEnd(width)}  ${kb(size).padStart(9)} / ${kb(budget).padStart(9)}  ${mark}`);
+}
+console.log();
+
+const overs = rows.filter((r) => r.over);
+if (overs.length > 0) {
+  fail(
+    `${overs.length} route(s) over budget. If the growth is intentional, raise the budget in scripts/check-bundle-budget.mjs in the same PR and explain why.`
+  );
+} else {
+  console.log(`✓ All ${rows.length} routes within budget.`);
+}


### PR DESCRIPTION
## Summary

Fixes #239 — locks in the #233/#235 bundle wins with a CI guardrail.

- **`scripts/check-bundle-budget.mjs`**: reads `.next/app-build-manifest.json` after `next build`, computes gzipped first-load JS per route, prints a table, exits non-zero if any route exceeds its budget. No new services — plain Node stdlib (zlib).
- **Budget**: 150 kB gzipped default for all 20 routes. Largest route (`/knowledge-base/notes/[id]`) measures 134 kB post-pruning, so ~12% headroom. Per-route overrides supported but currently empty — raising a budget is an explicit, reviewed change made in the same PR as the growth it permits.
- **CI**: new `Frontend - Bundle Budget` job (npm ci → build → check), parallel to the existing frontend jobs.
- **Local**: `make check-bundle-budget` (after a build).

## Measured baseline (gzipped first-load JS)

| Route | Size |
|---|---|
| /knowledge-base/notes/[id] | 134.3 kB |
| /knowledge-base/notes | 122.2 kB |
| /knowledge-base/notes/graph | 121.9 kB |
| all other routes | ≤ 121.5 kB |

Script numbers track Next's own build-output figures (134 vs 137 kB for the largest route).

## Testing

- Positive path: all 20 routes pass at 150 kB
- Negative path: with a deliberately absurd 50 kB budget the script exits 1
- Dev environment restored after the measurement build (cleared `.next`, restarted the container — the known prod-build/dev-server conflict)
