### PR TITLE
feat: quick capture modal + 'n' shortcut (#154 Phase 1)

### DIFF
--- a/frontend/src/components/QuickCapture.module.scss
+++ b/frontend/src/components/QuickCapture.module.scss
@@ -1,0 +1,157 @@
+/**
+ * Quick Capture modal (#154 Phase 1)
+ */
+
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 15vh;
+  background-color: rgba($black, 0.5);
+}
+
+.modal {
+  width: 100%;
+  max-width: 34rem;
+  margin: 0 $spacing-4;
+  padding: $spacing-5;
+  border-radius: $border-radius-lg;
+  background-color: $white;
+  box-shadow: $shadow-card-lg;
+}
+
+.header {
+  @include flex-between;
+  margin-bottom: $spacing-3;
+
+  .title {
+    display: inline-flex;
+    align-items: center;
+    gap: $spacing-2;
+    font-size: $font-size-base;
+    font-weight: $font-weight-semibold;
+    color: $color-text-primary;
+  }
+
+  .closeButton {
+    padding: $spacing-1;
+    border: none;
+    background: none;
+    color: $color-text-tertiary;
+    cursor: pointer;
+    transition: color 0.2s ease;
+
+    &:hover {
+      color: $color-text-primary;
+    }
+  }
+}
+
+.errorBox {
+  margin-bottom: $spacing-3;
+  padding: $spacing-3;
+  border: $border-width-thin solid $color-error-border;
+  border-radius: $border-radius-md;
+  background-color: $color-error-bg;
+  color: $color-error-text;
+  font-size: $font-size-sm;
+
+  .errorHint {
+    margin-top: $spacing-1;
+
+    a {
+      color: $color-link-default;
+    }
+  }
+}
+
+.contentInput {
+  width: 100%;
+  padding: $spacing-3;
+  border: $border-default;
+  border-radius: $border-radius-md;
+  background-color: $color-bg-canvas;
+  font-family: $font-family-primary;
+  font-size: $font-size-base;
+  resize: vertical;
+
+  &:focus {
+    outline: none;
+    border-color: $color-input-border-focus;
+    box-shadow: $shadow-focus-primary;
+  }
+
+  &::placeholder {
+    color: $color-input-placeholder;
+  }
+}
+
+.metaRow {
+  display: flex;
+  gap: $spacing-2;
+  margin-top: $spacing-2;
+}
+
+.metaInput {
+  flex: 1;
+  min-width: 0;
+  padding: $spacing-2 $spacing-3;
+  border: $border-default;
+  border-radius: $border-radius-button;
+  background-color: $color-bg-canvas;
+  font-size: $font-size-sm;
+
+  &:focus {
+    outline: none;
+    border-color: $color-input-border-focus;
+    box-shadow: $shadow-focus-primary;
+  }
+
+  &::placeholder {
+    color: $color-input-placeholder;
+  }
+}
+
+.actions {
+  @include flex-between;
+  margin-top: $spacing-3;
+
+  .hint {
+    @include text-tertiary;
+    color: $color-text-tertiary;
+
+    kbd {
+      padding: 1px $spacing-1;
+      border: $border-width-thin solid $color-border;
+      border-radius: $border-radius-sm;
+      font-size: $font-size-xs;
+      font-family: $font-family-mono;
+    }
+  }
+
+  .saveButton {
+    padding: $spacing-2 $spacing-5;
+    border: none;
+    border-radius: $border-radius-button;
+    background-color: $color-link-default;
+    color: $white;
+    font-weight: $font-weight-medium;
+    cursor: pointer;
+    transition: all 0.2s ease;
+
+    &:hover:not(:disabled) {
+      background-color: $color-text-secondary;
+    }
+
+    &:disabled {
+      cursor: not-allowed;
+      opacity: 0.5;
+    }
+  }
+}

--- a/frontend/src/components/QuickCapture.tsx
+++ b/frontend/src/components/QuickCapture.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { Lightning } from "@phosphor-icons/react";
+import { createNote } from "@/lib/api/notes";
+import { saveDraft } from "@/lib/draft";
+import { logger } from "@/lib/logger";
+import Toast from "@/components/Toast";
+import styles from "./QuickCapture.module.scss";
+
+interface QuickCaptureProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Quick Capture modal (#154 Phase 1): capture a thought without leaving the
+ * current page. Opened from the nav button or the global "n" shortcut.
+ *
+ * Save = createNote (auth required; the trigger is only shown when
+ * authenticated). On failure the text is stashed in the shared editor draft
+ * (lib/draft), so nothing is lost - the note editor restores it.
+ */
+export default function QuickCapture({ isOpen, onClose }: QuickCaptureProps) {
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [tags, setTags] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+  const contentRef = useRef<HTMLTextAreaElement>(null);
+
+  // Focus the content field when opening
+  useEffect(() => {
+    if (isOpen) {
+      setError(null);
+      // Next tick so the element exists after the conditional render
+      requestAnimationFrame(() => contentRef.current?.focus());
+    }
+  }, [isOpen]);
+
+  const handleClose = useCallback(() => {
+    setError(null);
+    onClose();
+  }, [onClose]);
+
+  const handleSave = useCallback(async () => {
+    if (!content.trim() || saving) return;
+
+    const tagArray = tags
+      .split(",")
+      .map((t) => t.trim())
+      .filter((t) => t);
+
+    try {
+      setSaving(true);
+      setError(null);
+
+      const note = await createNote({
+        content,
+        title: title.trim() || undefined,
+        tags: tagArray.length > 0 ? tagArray : undefined,
+      });
+
+      logger.info("Quick capture saved", { id: note.id });
+      setTitle("");
+      setContent("");
+      setTags("");
+      setToast(`Captured ${note.id}`);
+      onClose();
+    } catch (err) {
+      // Stash in the shared editor draft so the thought is never lost
+      saveDraft({ title, content, tags, isReference: false });
+      const message = err instanceof Error ? err.message : "Failed to save";
+      setError(message);
+      logger.error("Quick capture failed; stashed as draft", err);
+    } finally {
+      setSaving(false);
+    }
+  }, [content, title, tags, saving, onClose]);
+
+  // Esc closes, Cmd/Ctrl+Enter saves
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        handleClose();
+      } else if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+        e.preventDefault();
+        void handleSave();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, handleClose, handleSave]);
+
+  return (
+    <>
+      {isOpen && (
+        <div className={styles.overlay} onClick={handleClose}>
+          <div
+            className={styles.modal}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Quick capture"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className={styles.header}>
+              <h2 className={styles.title}>
+                <Lightning size={16} aria-hidden="true" /> Quick capture
+              </h2>
+              <button onClick={handleClose} className={styles.closeButton} aria-label="Close">
+                ✕
+              </button>
+            </div>
+
+            {error && (
+              <div className={styles.errorBox} role="alert">
+                <p>{error}</p>
+                <p className={styles.errorHint}>
+                  Your text is preserved as a draft —{" "}
+                  <Link href="/knowledge-base/notes/new" onClick={handleClose}>
+                    open the editor
+                  </Link>{" "}
+                  to continue.
+                </p>
+              </div>
+            )}
+
+            <textarea
+              ref={contentRef}
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder="Capture the thought…"
+              className={styles.contentInput}
+              rows={5}
+            />
+
+            <div className={styles.metaRow}>
+              <input
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="Title (optional)"
+                className={styles.metaInput}
+              />
+              <input
+                type="text"
+                value={tags}
+                onChange={(e) => setTags(e.target.value)}
+                placeholder="Tags (optional)"
+                className={styles.metaInput}
+              />
+            </div>
+
+            <div className={styles.actions}>
+              <span className={styles.hint}>
+                <kbd>⌘↵</kbd> save · <kbd>esc</kbd> close
+              </span>
+              <button
+                onClick={() => void handleSave()}
+                disabled={saving || !content.trim()}
+                className={styles.saveButton}
+              >
+                {saving ? "Saving…" : "Capture"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <Toast
+        message={toast ?? ""}
+        isVisible={toast !== null}
+        onClose={() => setToast(null)}
+        duration={4000}
+      />
+    </>
+  );
+}

--- a/frontend/src/components/TopNavigation.module.scss
+++ b/frontend/src/components/TopNavigation.module.scss
@@ -92,7 +92,8 @@
 }
 
 // Global Search Button (future Phase 5c)
-.searchButton {
+.searchButton,
+.captureButton {
   @include flex-start;
   align-items: center;
   gap: $spacing-2;

--- a/frontend/src/components/TopNavigation.tsx
+++ b/frontend/src/components/TopNavigation.tsx
@@ -13,7 +13,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { MagnifyingGlass } from "@phosphor-icons/react";
+import { MagnifyingGlass, Lightning } from "@phosphor-icons/react";
 import { prefetchOnce } from "@/lib/prefetch";
 
 // The graph payload (100+ notes with edges) is the slowest KB fetch; warm the
@@ -31,11 +31,20 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import HeaderMenu from "./HeaderMenu";
 import SearchModal from "./SearchModal";
+import QuickCapture from "./QuickCapture";
+import { isAuthenticated } from "@/lib/api/client";
 import styles from "./TopNavigation.module.scss";
 
 export default function TopNavigation() {
   const pathname = usePathname();
   const [searchOpen, setSearchOpen] = useState(false);
+  const [captureOpen, setCaptureOpen] = useState(false);
+  // Client-side only to avoid hydration mismatch
+  const [authed, setAuthed] = useState(false);
+
+  useEffect(() => {
+    setAuthed(isAuthenticated());
+  }, []);
 
   // Determine active section
   const isArticlesSection = pathname?.startsWith("/knowledge-base/articles");
@@ -44,12 +53,24 @@ export default function TopNavigation() {
   const isToolboxSection = pathname?.startsWith("/knowledge-base/toolbox");
   const isInspireSection = pathname?.startsWith("/knowledge-base/inspire");
 
-  // Keyboard shortcut: Cmd/Ctrl+K to open search
+  // Keyboard shortcuts: Cmd/Ctrl+K opens search; plain "n" (outside inputs)
+  // opens quick capture (#154) when authenticated
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === "k") {
         e.preventDefault();
         setSearchOpen(true);
+        return;
+      }
+
+      if (e.key === "n" && !e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey) {
+        const target = e.target as HTMLElement;
+        const typing =
+          target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable;
+        if (!typing && isAuthenticated()) {
+          e.preventDefault();
+          setCaptureOpen(true);
+        }
       }
     };
 
@@ -104,8 +125,21 @@ export default function TopNavigation() {
             </Link>
           </div>
 
-          {/* Right: Search + Settings + User Menu */}
+          {/* Right: Capture + Search + Settings + User Menu */}
           <div className={styles.right}>
+            {authed && (
+              <button
+                onClick={() => setCaptureOpen(true)}
+                className={styles.captureButton}
+                aria-label="Quick capture a note"
+              >
+                <span className={styles.searchIcon} aria-hidden="true">
+                  <Lightning size={16} />
+                </span>
+                <span className={styles.searchLabel}>Capture</span>
+                <kbd className={styles.searchKbd}>N</kbd>
+              </button>
+            )}
             <button
               onClick={() => setSearchOpen(true)}
               className={styles.searchButton}
@@ -124,6 +158,9 @@ export default function TopNavigation() {
 
       {/* Search Modal */}
       <SearchModal isOpen={searchOpen} onClose={() => setSearchOpen(false)} />
+
+      {/* Quick Capture Modal */}
+      <QuickCapture isOpen={captureOpen} onClose={() => setCaptureOpen(false)} />
     </>
   );
 }


### PR DESCRIPTION
## Summary

Fixes #154 — Phase 1 of Quick Capture: save a thought without leaving the current page, targeting the issue's "< 5 seconds from thought to captured".

- **Nav "Capture" button** with `N` kbd hint, styled to match the search button. Auth-gated — hidden for anonymous visitors, since persistent notes require admin auth anyway.
- **Global `n` shortcut** (GitHub-style, no modifier — `Cmd+N`/`Cmd+Shift+N` are browser-reserved). Suppressed while typing in inputs, textareas, or contenteditable.
- **Minimal modal**: plain textarea (auto-focused) + optional title/tags. `Cmd/Ctrl+Enter` saves, `Esc` closes.
- **Success**: toast with the new note's id, fields cleared, no navigation — you stay in context.
- **Failure**: the text is stashed via the shared editor draft (`lib/draft`), with a link to the editor, which restores it. This replaces the issue's "works offline (queues for sync)" criterion — a failed save preserves the thought without service-worker machinery.

## Scope

Per the rescoping notes on the issue: Phases 2–4 (CLI, browser extension, iOS shortcut) are deliberately out of scope; file separately when Phase 1 proves out. The CLI phase belongs with #167 (External Brain API).

## Testing

- `make typecheck-frontend`, `make lint-frontend`, `make test-frontend` (64/64) all pass
- Verified live end-to-end: button hidden unauthenticated and visible authenticated; modal opens via button and via `n` with content auto-focused; capture created a real note with content + tags (verified via API, then deleted); `Esc` closes; `n` inside an input types normally
