### PR TITLE
fix: revalidate note reads after mutations + fix autocomplete truncation (#177)

### DIFF
--- a/frontend/src/__tests__/apiCache.test.ts
+++ b/frontend/src/__tests__/apiCache.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for the mutation-driven revalidation module (src/lib/api/cache.ts)
+ *
+ * Tests cover:
+ * - First-ever fetch of a URL never forces a reload
+ * - Repeated fetches with no invalidation never force a reload
+ * - invalidate() forces a reload on the next fetch of a previously-fetched URL
+ * - After that forced reload, generation is recorded so it doesn't reload again
+ * - A URL invalidated before its first-ever fetch still isn't forced to reload
+ * - Non-ok responses don't record generation, so they still revalidate next time
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { revalidatingFetch, invalidate, __resetForTests } from "@/lib/api/cache";
+
+function okResponse() {
+  return { ok: true, json: async () => ({}) } as Response;
+}
+
+function notOkResponse() {
+  return { ok: false, status: 500, json: async () => ({}) } as Response;
+}
+
+describe("revalidatingFetch", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    __resetForTests();
+  });
+
+  it("does not reload on the first-ever fetch of a URL", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await revalidatingFetch("/api/notes");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init?.cache).toBeUndefined();
+  });
+
+  it("does not reload on a second fetch with no intervening invalidate()", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await revalidatingFetch("/api/notes");
+    await revalidatingFetch("/api/notes");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [, secondInit] = fetchMock.mock.calls[1];
+    expect(secondInit?.cache).toBeUndefined();
+  });
+
+  it("forces a reload on the next fetch of a previously-fetched URL after invalidate()", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await revalidatingFetch("/api/notes");
+    invalidate();
+    await revalidatingFetch("/api/notes");
+
+    const [, secondInit] = fetchMock.mock.calls[1];
+    expect(secondInit?.cache).toBe("reload");
+  });
+
+  it("does not reload again on a subsequent fetch after the forced reload", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await revalidatingFetch("/api/notes");
+    invalidate();
+    await revalidatingFetch("/api/notes"); // forced reload, generation recorded
+    await revalidatingFetch("/api/notes"); // should not reload again
+
+    const [, thirdInit] = fetchMock.mock.calls[2];
+    expect(thirdInit?.cache).toBeUndefined();
+  });
+
+  it("does not reload a URL's first-ever fetch even if invalidate() ran earlier", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    invalidate();
+    await revalidatingFetch("/api/notes/new-url");
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init?.cache).toBeUndefined();
+
+    // Only after the NEXT invalidate does this now-known URL reload
+    invalidate();
+    await revalidatingFetch("/api/notes/new-url");
+    const [, secondInit] = fetchMock.mock.calls[1];
+    expect(secondInit?.cache).toBe("reload");
+  });
+
+  it("does not record generation on a non-ok response, so it still revalidates next time", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(okResponse())
+      .mockResolvedValueOnce(notOkResponse())
+      .mockResolvedValue(okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await revalidatingFetch("/api/notes");
+    invalidate();
+
+    const response = await revalidatingFetch("/api/notes");
+    expect(response.ok).toBe(false);
+
+    // Because the failed fetch never recorded a generation, the URL is still
+    // considered stale (lastGeneration < generation) and reloads again.
+    await revalidatingFetch("/api/notes");
+    const [, thirdInit] = fetchMock.mock.calls[2];
+    expect(thirdInit?.cache).toBe("reload");
+  });
+});

--- a/frontend/src/app/knowledge-base/notes/graph/page.tsx
+++ b/frontend/src/app/knowledge-base/notes/graph/page.tsx
@@ -15,6 +15,7 @@ import {
 import { drag as d3Drag } from "d3-drag";
 import { pointer, select, type BaseType, type Selection } from "d3-selection";
 import { logger } from "@/lib/logger";
+import { revalidatingFetch } from "@/lib/api/cache";
 import { LoadingState, ErrorState, EmptyState } from "@/components/PageState";
 import styles from "./page.module.scss";
 
@@ -141,7 +142,7 @@ function NotesGraphContent() {
           headers["Authorization"] = `Bearer ${token}`;
         }
 
-        const response = await fetch(`${apiUrl}/api/notes/graph/data`, {
+        const response = await revalidatingFetch(`${apiUrl}/api/notes/graph/data`, {
           headers,
           credentials: "include",
           signal: controller.signal,

--- a/frontend/src/app/knowledge-base/toolbox/page.tsx
+++ b/frontend/src/app/knowledge-base/toolbox/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useMemo } from "react";
 import Link from "next/link";
-import { listNotes, Note } from "@/lib/api/notes";
+import { listAllNotes, Note } from "@/lib/api/notes";
 import { logger } from "@/lib/logger";
 import Breadcrumb from "@/components/Breadcrumb";
 import { LoadingState, ErrorState } from "@/components/PageState";
@@ -27,20 +27,7 @@ export default function ToolboxPage() {
         setLoading(true);
         // Fetch ALL references (the API paginates; without a limit it returns
         // only the first 20 and the rest never render). Previews only for performance.
-        const all: Note[] = [];
-        let page = 1;
-        let totalPages = 1;
-        do {
-          const response = await listNotes({
-            is_reference: true,
-            include_full_content: false,
-            page,
-            limit: 100,
-          });
-          all.push(...response.notes);
-          totalPages = response.total_pages;
-          page += 1;
-        } while (page <= totalPages);
+        const all = await listAllNotes({ is_reference: true });
         setReferences(all);
         logger.info("Toolbox references loaded", { count: all.length });
       } catch (err) {

--- a/frontend/src/components/NoteEditorForm.tsx
+++ b/frontend/src/components/NoteEditorForm.tsx
@@ -12,7 +12,7 @@ const NoteEditor = dynamic(() => import("@/components/NoteEditor"), {
 import TemplateSelector from "@/components/TemplateSelector";
 import { ErrorState } from "@/components/PageState";
 import type { PanelTab } from "@/components/AIPanel";
-import { listNotes, Note } from "@/lib/api/notes";
+import { listAllNotes, Note } from "@/lib/api/notes";
 import { listTemplates, getTemplate, TemplateMetadata } from "@/lib/api/templates";
 import { logger } from "@/lib/logger";
 import { useSettings } from "@/hooks/useSettings";
@@ -93,8 +93,7 @@ export default function NoteEditorForm({
   useEffect(() => {
     async function fetchNotes() {
       try {
-        const response = await listNotes();
-        setAllNotes(response.notes);
+        setAllNotes(await listAllNotes());
       } catch (err) {
         logger.error("Failed to load notes for autocomplete", err);
       }

--- a/frontend/src/lib/api/cache.ts
+++ b/frontend/src/lib/api/cache.ts
@@ -1,0 +1,69 @@
+/**
+ * Mutation-driven revalidation for the browser's HTTP cache.
+ *
+ * The API sends `Cache-Control: public, max-age=60, stale-while-revalidate=300`
+ * on GET endpoints. That makes repeat GETs fast, but after a note is
+ * created/edited/deleted, any list/detail/graph view fetched again within
+ * that 60s window would normally be served straight from the browser's HTTP
+ * cache — a stale, pre-mutation response that JS has no way to evict.
+ *
+ * This module is NOT a second cache. It tracks, per URL, the "generation"
+ * at which it was last successfully fetched. `invalidate()` bumps a global
+ * generation counter whenever a mutation succeeds. `revalidatingFetch()`
+ * then forces a real network round-trip (`cache: "reload"`) only for URLs
+ * that were fetched in an older generation — i.e. URLs whose cached copy
+ * might now be stale — and leaves every other request alone so the
+ * prefetch-then-fetch flow (see `prefetch.ts`) still gets its free hit on
+ * the HTTP cache.
+ *
+ * Known limitation: a URL that has never been fetched this session is
+ * always allowed to hit the HTTP cache (see `needsReload` below), even if
+ * a mutation just invalidated the world. If the browser happens to already
+ * have a cached response for that exact URL from a *previous* session
+ * within the last 60s, this can still serve a stale copy on that first
+ * read. This is accepted as low-probability and cheaper than forcing every
+ * first-ever fetch to bypass the cache.
+ */
+
+let generation = 0;
+
+const lastFetchedGeneration = new Map<string, number>();
+
+/**
+ * Marks the current generation as stale. Call this after any successful
+ * mutation (create/update/delete) so subsequent reads of previously-fetched
+ * URLs are forced to revalidate against the network.
+ */
+export function invalidate(): void {
+  generation += 1;
+}
+
+/**
+ * Drop-in replacement for `fetch()` that forces a network reload when the
+ * requested URL was fetched in an older generation (i.e. a mutation has
+ * happened since). First-ever fetches of a URL are never forced to reload,
+ * so the prefetch system can still warm the HTTP cache.
+ */
+export async function revalidatingFetch(url: string, init?: RequestInit): Promise<Response> {
+  const lastGeneration = lastFetchedGeneration.get(url);
+  const needsReload = lastGeneration !== undefined && lastGeneration < generation;
+
+  const response = await fetch(url, {
+    ...init,
+    cache: needsReload ? "reload" : init?.cache,
+  });
+
+  if (response.ok) {
+    lastFetchedGeneration.set(url, generation);
+  }
+
+  return response;
+}
+
+/**
+ * Test-only: resets the generation counter and clears fetch history.
+ */
+export function __resetForTests(): void {
+  generation = 0;
+  lastFetchedGeneration.clear();
+}

--- a/frontend/src/lib/api/notes.ts
+++ b/frontend/src/lib/api/notes.ts
@@ -4,6 +4,7 @@
 
 import { logger } from "@/lib/logger";
 import { getAuthHeaders as getBaseAuthHeaders } from "@/lib/api/client";
+import { invalidate, revalidatingFetch } from "@/lib/api/cache";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
@@ -82,6 +83,7 @@ export async function createNote(request: CreateNoteRequest): Promise<Note> {
   }
 
   const note = await response.json();
+  invalidate();
   logger.info("Note created", { id: note.id });
   return note;
 }
@@ -120,7 +122,7 @@ export async function listNotes(options?: ListNotesOptions): Promise<NotesListRe
 
   const url = `${API_URL}/api/notes?${params.toString()}`;
 
-  const response = await fetch(url, {
+  const response = await revalidatingFetch(url, {
     headers: getHeaders(),
   });
 
@@ -139,10 +141,35 @@ export async function listNotes(options?: ListNotesOptions): Promise<NotesListRe
 }
 
 /**
+ * Fetch every note across all pages (previews only), for callers that need
+ * the complete set rather than a single page — e.g. wikilink autocomplete
+ * or the toolbox reference list. Paginates through `listNotes` with a
+ * limit of 100 per page until all pages have been retrieved.
+ */
+export async function listAllNotes(
+  options?: Omit<ListNotesOptions, "page" | "limit">
+): Promise<Note[]> {
+  const all: Note[] = [];
+  let page = 1;
+  let totalPages = 1;
+  do {
+    const response = await listNotes({
+      ...options,
+      page,
+      limit: 100,
+    });
+    all.push(...response.notes);
+    totalPages = response.total_pages;
+    page += 1;
+  } while (page <= totalPages);
+  return all;
+}
+
+/**
  * Get a specific note by ID
  */
 export async function getNote(noteId: string): Promise<Note> {
-  const response = await fetch(`${API_URL}/api/notes/${noteId}`, {
+  const response = await revalidatingFetch(`${API_URL}/api/notes/${noteId}`, {
     headers: getHeaders(),
   });
 
@@ -163,7 +190,7 @@ export async function getNote(noteId: string): Promise<Note> {
  * Get a random note for serendipitous discovery
  */
 export async function getRandomNote(): Promise<Note> {
-  const response = await fetch(`${API_URL}/api/notes/random`, {
+  const response = await revalidatingFetch(`${API_URL}/api/notes/random`, {
     headers: getHeaders(),
   });
 
@@ -197,6 +224,7 @@ export async function updateNote(noteId: string, request: UpdateNoteRequest): Pr
   }
 
   const note = await response.json();
+  invalidate();
   logger.info("Note updated", { id: note.id });
   return note;
 }
@@ -216,6 +244,7 @@ export async function deleteNote(noteId: string): Promise<void> {
     throw new Error(error.detail || "Failed to delete note");
   }
 
+  invalidate();
   logger.info("Note deleted", { id: noteId });
 }
 
@@ -223,7 +252,7 @@ export async function deleteNote(noteId: string): Promise<void> {
  * Get notes that link to this note (backlinks)
  */
 export async function getBacklinks(noteId: string): Promise<BacklinksResponse> {
-  const response = await fetch(`${API_URL}/api/notes/${noteId}/backlinks`, {
+  const response = await revalidatingFetch(`${API_URL}/api/notes/${noteId}/backlinks`, {
     headers: getHeaders(),
   });
 
@@ -241,7 +270,7 @@ export async function getBacklinks(noteId: string): Promise<BacklinksResponse> {
  * Get notes this note links to (outbound links)
  */
 export async function getOutboundLinks(noteId: string): Promise<OutboundLinksResponse> {
-  const response = await fetch(`${API_URL}/api/notes/${noteId}/links`, {
+  const response = await revalidatingFetch(`${API_URL}/api/notes/${noteId}/links`, {
     headers: getHeaders(),
   });
 
@@ -268,7 +297,7 @@ export function extractWikilinks(content: string): string[] {
  * Get orphan notes (no links and no backlinks)
  */
 export async function getOrphanNotes(): Promise<NotesListResponse> {
-  const response = await fetch(`${API_URL}/api/notes/orphans`, {
+  const response = await revalidatingFetch(`${API_URL}/api/notes/orphans`, {
     headers: getHeaders(),
   });
 
@@ -286,7 +315,7 @@ export async function getOrphanNotes(): Promise<NotesListResponse> {
  * Get dead-end notes (no outbound links)
  */
 export async function getDeadEndNotes(): Promise<NotesListResponse> {
-  const response = await fetch(`${API_URL}/api/notes/dead-ends`, {
+  const response = await revalidatingFetch(`${API_URL}/api/notes/dead-ends`, {
     headers: getHeaders(),
   });
 
@@ -304,7 +333,7 @@ export async function getDeadEndNotes(): Promise<NotesListResponse> {
  * Get hub notes (notes with many outbound links)
  */
 export async function getHubNotes(minLinks: number = 3): Promise<NotesListResponse> {
-  const response = await fetch(`${API_URL}/api/notes/hubs?min_links=${minLinks}`, {
+  const response = await revalidatingFetch(`${API_URL}/api/notes/hubs?min_links=${minLinks}`, {
     headers: getHeaders(),
   });
 
@@ -322,9 +351,12 @@ export async function getHubNotes(minLinks: number = 3): Promise<NotesListRespon
  * Get central concept notes (notes with many backlinks)
  */
 export async function getCentralNotes(minBacklinks: number = 3): Promise<NotesListResponse> {
-  const response = await fetch(`${API_URL}/api/notes/central?min_backlinks=${minBacklinks}`, {
-    headers: getHeaders(),
-  });
+  const response = await revalidatingFetch(
+    `${API_URL}/api/notes/central?min_backlinks=${minBacklinks}`,
+    {
+      headers: getHeaders(),
+    }
+  );
 
   if (!response.ok) {
     logger.error("Failed to get central notes", { status: response.status });
@@ -349,9 +381,12 @@ export async function getStaleNotes(
   days: number = 60,
   limit: number = 50
 ): Promise<StaleNotesResponse> {
-  const response = await fetch(`${API_URL}/api/notes/stale?days=${days}&limit=${limit}`, {
-    headers: getHeaders(),
-  });
+  const response = await revalidatingFetch(
+    `${API_URL}/api/notes/stale?days=${days}&limit=${limit}`,
+    {
+      headers: getHeaders(),
+    }
+  );
 
   if (!response.ok) {
     logger.error("Failed to get stale notes", { status: response.status });
@@ -373,7 +408,7 @@ export interface NoteOfDayResponse {
  * Get note of the day (prioritizes stale notes, falls back to random)
  */
 export async function getNoteOfDay(days: number = 60): Promise<NoteOfDayResponse> {
-  const response = await fetch(`${API_URL}/api/notes/note-of-day?days=${days}`, {
+  const response = await revalidatingFetch(`${API_URL}/api/notes/note-of-day?days=${days}`, {
     headers: getHeaders(),
   });
 
@@ -409,6 +444,7 @@ export async function markNoteReviewed(noteId: string): Promise<Note> {
   }
 
   const note = await response.json();
+  invalidate();
   logger.info("Note marked as reviewed", { id: note.id });
   return note;
 }


### PR DESCRIPTION
Partially addresses #177 (does **not** auto-close it — see bookkeeping note below).

## What this does
The backend sends `Cache-Control: public, max-age=60, stale-while-revalidate=300` on all API GETs. Great for read speed, but after a note is created/edited/deleted, any list/detail/graph view fetched again within 60s is served the **stale pre-mutation response** from the browser HTTP cache — which JS has no way to evict. Quick capture (#154) made this obvious: capture a note, open the notes list, it's missing.

This adds a small **mutation-driven revalidation** module (`frontend/src/lib/api/cache.ts`) — not a second cache:
- A module-level generation counter + a per-URL `Map` of the generation each URL was last fetched at.
- `invalidate()` bumps the counter; it's called after every successful `createNote` / `updateNote` / `deleteNote` / `markNoteReviewed`.
- `revalidatingFetch()` forces `cache: "reload"` **only** for a URL that was already fetched in an older generation. First-ever fetches of a URL are never forced to reload, so the prefetch-then-fetch warmup (`prefetch.ts`) still gets its free HTTP-cache hit. Generation is recorded only on `response.ok`, so a failed read stays stale and revalidates next time.

All 11 note read functions route through `revalidatingFetch`; the graph-data fetch does too, so the graph reflects mutations.

**Folded-in bug fix (separate from caching):** `NoteEditorForm` loaded wikilink autocomplete via `listNotes()` with no options, so it only ever saw the **first 20 notes** (server default limit) — some notes were silently un-linkable. Added `listAllNotes()` (paginate-all) and used it for autocomplete and the toolbox reference list (which had hand-rolled the identical loop).

## ⚠️ Changes from this session's initial plan
The original issue #177 said "add SWR or React Query to dedupe requests and cache responses." **This PR deliberately does not do that**, following the preference order in the [sequencing comment already on #177](https://github.com/DEGoodman/mongado/issues/177#issuecomment-5028571176) ("audit which routes actually re-fetch redundantly… a 20-line module-level cache may beat a new dependency… reach for SWR only if invalidation gets hairy"). The audit found:

1. **The dedupe/caching premise is already solved.** `backend/main.py` sends the `max-age=60` cache headers and `frontend/src/lib/prefetch.ts` was purpose-built on top of them. The three `listNotes()` call sites query genuinely different URLs (`is_reference` / `page` / `limit`), so there was nothing to dedupe. Adding SWR/React Query would layer a second (JS) cache over a working HTTP cache — and cuts against the dependency-pruning direction from #235.
2. **The real defect is the inverse: staleness after mutations.** No app code set `cache: "reload"`/`no-store` anywhere except `useFeatureFlags`. That's what this PR targets — ~40 lines, no new dependency.
3. **A second, unrelated bug surfaced during the audit** (the 20-note autocomplete truncation), folded in since it's the same data-fetching surface.

## 📌 Bookkeeping: #177 stays open
This uses `refs #177`, not `Closes #177`, on purpose. The original issue also asked for **optimistic UI updates** and **improved loading/error states** — this PR does the opposite of optimistic (it forces a post-mutation round-trip, which is correct for the quick-capture flow) and doesn't touch loading states. That remaining scope is carved out in a comment on #177 and stays tracked there.

### Known trade-offs (acceptable at this app's scale)
- **Broad invalidation:** a single global generation means any note mutation revalidates every note URL on next access (including heavier ones like `graph/data`, `stale`, `hubs`). Safe-by-construction (over-invalidates, never under); the price of not using SWR's per-key `mutate`.
- **`listAllNotes` is O(notes):** the autocomplete fix swaps 1 request for N (100/page) per editor open. Warm-cached and negligible for a personal KB, but noted.
- **Derived surfaces not invalidated:** `/api/inspire/*` and `/api/search` reflect notes but aren't invalidated here — inspire is fuzzy discovery, and search staleness is dominated by async embedding-sync, not the HTTP cache. Neither is in the quick-capture critical path.
- **Cross-session first read:** a mutation followed by a *first-ever* read of a URL within 60s of a **previous session's** fetch can still serve a stale HTTP-cached copy that once. Low-probability; documented in the module header.

## Testing
- New unit suite `frontend/src/__tests__/apiCache.test.ts` (6 cases): first-ever fetch never reloads; repeat with no invalidate never reloads; invalidate forces one reload; no double-reload after that; invalidate-before-first-fetch still isn't forced; non-ok responses stay stale and revalidate next time.
- `make lint-frontend` ✅ · `make typecheck-frontend` ✅ · `make test-frontend` ✅ **70/70 pass**

https://claude.ai/code/session_01JPMNUiK7X53GeGTqDSWySc