### PR TITLE
fix: realign Inspire suggestions with Zettelkasten design (fixes #259)

### DIFF
--- a/backend/core/inspire.py
+++ b/backend/core/inspire.py
@@ -2,77 +2,205 @@
 
 This module contains pure functions with no I/O or side effects.
 All functions are deterministic and fully unit-testable.
+
+Suggestion philosophy (see #259):
+    A short note is not a defect. In a Zettelkasten an atomic note *should*
+    be brief -- the note editor itself calls 300-500 chars the ideal band
+    (see NoteEditorForm.tsx). Suggestions therefore describe *structural*
+    problems (orphaned, oversized, duplicated, uncovered) and never ask the
+    author to pad a well-formed note.
 """
 
+import hashlib
 import json
 import logging
+import re
 from typing import Any
 
 from core.ai import cosine_similarity
 
 logger = logging.getLogger(__name__)
 
+# --- thresholds ------------------------------------------------------------
+# These deliberately mirror the guidance the note editor shows while typing
+# (NoteEditorForm.tsx). If you change one, change both, or Inspire will start
+# contradicting the editor again.
 
-def find_underdeveloped_topics(
-    notes: list[dict[str, Any]],
-    min_content_length: int = 500,
-    max_links: int = 1,
-    limit: int = 10,
-) -> list[dict[str, Any]]:
-    """Find notes that are short and have few connections.
+SPLIT_MIN_LENGTH = 1000
+"""Editor says '>1000: consider splitting into multiple notes'."""
+
+PROMOTE_MIN_BACKLINKS = 5
+"""A note this many others reference is load-bearing -- article material."""
+
+DUPLICATE_MIN_SIMILARITY = 0.85
+"""Embedding similarity at/above which a pair *may* be redundant."""
+
+DUPLICATE_MIN_TITLE_OVERLAP = 0.8
+"""Title agreement required to call a similar pair an actual duplicate.
+
+Embedding similarity alone cannot separate "5 Dysfunctions of a Team" /
+"Five Dysfunctions of a Team" (a true duplicate, 0.87) from "Developer
+Productivity: People Factors" / "...: Process Factors" (deliberate siblings,
+0.86). Normalized title overlap does.
+"""
+
+CONNECTION_MIN_SIMILARITY = 0.70
+"""Floor for suggesting a wikilink between two unlinked notes."""
+
+HUB_MIN_CLUSTER_SIZE = 3
+"""Mutually-similar notes at/above this count want a hub note."""
+
+ARTICLE_GAP_MIN_NOTES = 4
+"""Notes sharing a tag before an uncovered tag becomes an article idea."""
+
+# Number words, so "5 Dysfunctions" and "Five Dysfunctions" normalize alike.
+_NUMBER_WORDS = {
+    "0": "zero", "1": "one", "2": "two", "3": "three", "4": "four",
+    "5": "five", "6": "six", "7": "seven", "8": "eight", "9": "nine",
+    "10": "ten", "11": "eleven", "12": "twelve",
+}
+
+_STOPWORDS = frozenset({"a", "an", "the", "of", "for", "and", "to", "in", "on"})
+
+
+def normalize_tag(tag: str) -> str:
+    """Normalize a tag for comparison (prod has both 'Leadership' and 'leadership')."""
+    return tag.strip().lower().replace("_", "-").replace(" ", "-")
+
+
+def _title_tokens(title: str) -> frozenset[str]:
+    """Tokenize a title for duplicate detection.
+
+    Lowercases, drops punctuation and stopwords, and spells out small numbers
+    so numeric and written forms of the same title agree.
+    """
+    words = re.findall(r"[a-z0-9]+", title.lower())
+    return frozenset(
+        _NUMBER_WORDS.get(w, w) for w in words if _NUMBER_WORDS.get(w, w) not in _STOPWORDS
+    )
+
+
+def title_overlap(title_a: str, title_b: str) -> float:
+    """Jaccard overlap of two normalized titles (0.0 to 1.0). Pure."""
+    tokens_a = _title_tokens(title_a)
+    tokens_b = _title_tokens(title_b)
+    if not tokens_a or not tokens_b:
+        return 0.0
+    return len(tokens_a & tokens_b) / len(tokens_a | tokens_b)
+
+
+# --- structural gap detection ----------------------------------------------
+
+
+def find_orphan_notes(notes: list[dict[str, Any]], limit: int = 10) -> list[dict[str, Any]]:
+    """Find notes with no inbound or outbound links.
 
     Pure function: No I/O, no side effects, deterministic.
-    Identifies notes that could benefit from expansion or more links.
+
+    An orphan is unreachable by traversal, so its ideas are effectively lost
+    regardless of how well written it is. Sorted by content length descending:
+    a substantial disconnected note is a bigger loss than a stub.
 
     Args:
-        notes: List of notes with content_length, link_count, backlink_count
-        min_content_length: Notes shorter than this are considered underdeveloped
-        max_links: Notes with this many or fewer total links are candidates
+        notes: Notes with link_count and backlink_count
         limit: Maximum results to return
 
     Returns:
-        List of underdeveloped notes sorted by potential (shortest first)
+        List of orphan note dicts, most substantial first
     """
-    underdeveloped = []
+    orphans = [
+        {
+            "note_id": note["id"],
+            "title": note.get("title", note["id"]),
+            "content_length": note.get("content_length", len(note.get("content", ""))),
+            "tags": [normalize_tag(t) for t in note.get("tags") or []],
+        }
+        for note in notes
+        if note.get("link_count", 0) == 0 and note.get("backlink_count", 0) == 0
+    ]
+    orphans.sort(key=lambda x: int(x["content_length"]), reverse=True)
+    return orphans[:limit]
 
-    for note in notes:
-        content_length = note.get("content_length", len(note.get("content", "")))
-        link_count = note.get("link_count", 0)
-        backlink_count = note.get("backlink_count", 0)
-        total_links = link_count + backlink_count
 
-        # Check if note qualifies as underdeveloped
-        is_short = content_length < min_content_length
-        has_few_links = total_links <= max_links
+def find_oversized_notes(
+    notes: list[dict[str, Any]],
+    min_length: int = SPLIT_MIN_LENGTH,
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    """Find notes long enough that they likely hold more than one idea.
 
-        if is_short or has_few_links:
-            underdeveloped.append(
-                {
-                    "note_id": note["id"],
-                    "title": note.get("title", note["id"]),
-                    "content_length": content_length,
-                    "link_count": link_count,
-                    "backlink_count": backlink_count,
-                    "is_short": is_short,
-                    "has_few_links": has_few_links,
-                }
-            )
+    Pure function: No I/O, no side effects, deterministic.
+    Mirrors the editor's own '>1000 chars: consider splitting' guidance.
 
-    # Sort by content length (shortest first) to prioritize most underdeveloped
-    underdeveloped.sort(key=lambda x: x["content_length"])
-    return underdeveloped[:limit]
+    Args:
+        notes: Notes with content_length
+        min_length: Length at/above which a note is a split candidate
+        limit: Maximum results to return
+
+    Returns:
+        List of oversized note dicts, longest first
+    """
+    oversized = [
+        {
+            "note_id": note["id"],
+            "title": note.get("title", note["id"]),
+            "content_length": note.get("content_length", len(note.get("content", ""))),
+        }
+        for note in notes
+        if note.get("content_length", len(note.get("content", ""))) > min_length
+    ]
+    oversized.sort(key=lambda x: int(x["content_length"]), reverse=True)
+    return oversized[:limit]
+
+
+def find_promotion_candidates(
+    notes: list[dict[str, Any]],
+    min_backlinks: int = PROMOTE_MIN_BACKLINKS,
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    """Find well-referenced notes that could anchor a full article.
+
+    Pure function: No I/O, no side effects, deterministic.
+    This is #148's "this note has 8 backlinks - consider a full article?".
+
+    Args:
+        notes: Notes with backlink_count
+        min_backlinks: Inbound links required to qualify
+        limit: Maximum results to return
+
+    Returns:
+        List of promotion candidate dicts, most referenced first
+    """
+    candidates = [
+        {
+            "note_id": note["id"],
+            "title": note.get("title", note["id"]),
+            "backlink_count": note.get("backlink_count", 0),
+            "content_length": note.get("content_length", len(note.get("content", ""))),
+        }
+        for note in notes
+        if note.get("backlink_count", 0) >= min_backlinks
+    ]
+    candidates.sort(key=lambda x: int(x["backlink_count"]), reverse=True)
+    return candidates[:limit]
+
+
+# --- similarity-based opportunities ----------------------------------------
 
 
 def find_unlinked_similar_notes(
     note_embeddings: list[tuple[str, str, list[float]]],
     existing_links: dict[str, set[str]],
-    similarity_threshold: float = 0.7,
+    similarity_threshold: float = CONNECTION_MIN_SIMILARITY,
     limit: int = 10,
 ) -> list[dict[str, Any]]:
     """Find semantically similar notes that aren't linked to each other.
 
     Pure function: No I/O, no side effects, deterministic.
-    Identifies connection opportunities based on semantic similarity.
+
+    Each pair carries a "kind": "duplicate" when the notes are both
+    semantically and lexically near-identical (merge them), or "connection"
+    when they are merely related (link them).
 
     Args:
         note_embeddings: List of (note_id, title, embedding) tuples
@@ -81,12 +209,11 @@ def find_unlinked_similar_notes(
         limit: Maximum results to return
 
     Returns:
-        List of connection opportunities with similarity scores
+        List of opportunities with similarity scores and kind, highest first
     """
     opportunities: list[dict[str, Any]] = []
     n = len(note_embeddings)
 
-    # Compare all pairs (only check each pair once)
     for i in range(n):
         note_a_id, note_a_title, embedding_a = note_embeddings[i]
 
@@ -99,92 +226,469 @@ def find_unlinked_similar_notes(
             if note_b_id in a_links or note_a_id in b_links:
                 continue
 
-            # Calculate similarity
             similarity = cosine_similarity(embedding_a, embedding_b)
+            if similarity < similarity_threshold:
+                continue
 
-            if similarity >= similarity_threshold:
-                opportunities.append(
-                    {
-                        "note_a_id": note_a_id,
-                        "note_a_title": note_a_title,
-                        "note_b_id": note_b_id,
-                        "note_b_title": note_b_title,
-                        "similarity": round(similarity, 3),
-                    }
-                )
+            overlap = title_overlap(note_a_title, note_b_title)
+            is_duplicate = (
+                similarity >= DUPLICATE_MIN_SIMILARITY and overlap >= DUPLICATE_MIN_TITLE_OVERLAP
+            )
 
-    # Sort by similarity (highest first)
+            opportunities.append(
+                {
+                    "note_a_id": note_a_id,
+                    "note_a_title": note_a_title,
+                    "note_b_id": note_b_id,
+                    "note_b_title": note_b_title,
+                    "similarity": round(similarity, 3),
+                    "title_overlap": round(overlap, 3),
+                    "kind": "duplicate" if is_duplicate else "connection",
+                }
+            )
+
     opportunities.sort(key=lambda x: float(x["similarity"]), reverse=True)
     return opportunities[:limit]
 
 
-def build_inspiration_prompt(
-    gap_notes: list[dict[str, Any]],
-    connection_opportunities: list[dict[str, Any]],
-) -> str:
-    """Build prompt for Ollama to generate human-friendly suggestions.
+def find_hub_opportunities(
+    pairs: list[dict[str, Any]],
+    min_cluster_size: int = HUB_MIN_CLUSTER_SIZE,
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    """Group mutually-similar notes into clusters that want a hub note.
 
     Pure function: No I/O, no side effects, deterministic.
 
+    Builds an undirected graph from similar-but-unlinked pairs and returns
+    connected components of at least min_cluster_size. This is #148's "this
+    concept appears in N places - create a hub note?".
+
     Args:
-        gap_notes: Underdeveloped notes from find_underdeveloped_topics()
-        connection_opportunities: Connections from find_unlinked_similar_notes()
+        pairs: Output of find_unlinked_similar_notes()
+        min_cluster_size: Minimum notes in a cluster to report it
+        limit: Maximum clusters to return
+
+    Returns:
+        List of cluster dicts with note_ids and titles, largest first
+    """
+    adjacency: dict[str, set[str]] = {}
+    titles: dict[str, str] = {}
+
+    for pair in pairs:
+        a, b = pair["note_a_id"], pair["note_b_id"]
+        titles[a] = pair["note_a_title"]
+        titles[b] = pair["note_b_title"]
+        adjacency.setdefault(a, set()).add(b)
+        adjacency.setdefault(b, set()).add(a)
+
+    clusters: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    # Iterate sorted keys so component discovery order is deterministic
+    for start in sorted(adjacency):
+        if start in seen:
+            continue
+
+        component: list[str] = []
+        queue = [start]
+        seen.add(start)
+        while queue:
+            current = queue.pop(0)
+            component.append(current)
+            for neighbor in sorted(adjacency[current]):
+                if neighbor not in seen:
+                    seen.add(neighbor)
+                    queue.append(neighbor)
+
+        if len(component) >= min_cluster_size:
+            component.sort()
+            clusters.append(
+                {
+                    "note_ids": component,
+                    "titles": [titles[note_id] for note_id in component],
+                    "size": len(component),
+                }
+            )
+
+    clusters.sort(key=lambda x: int(x["size"]), reverse=True)
+    return clusters[:limit]
+
+
+# --- article-aware opportunities -------------------------------------------
+
+
+def find_uncovered_tag_clusters(
+    notes: list[dict[str, Any]],
+    articles: list[dict[str, Any]],
+    min_notes: int = ARTICLE_GAP_MIN_NOTES,
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    """Find topics with many notes but no article covering them.
+
+    Pure function: No I/O, no side effects, deterministic.
+    This is #148's "your SRE articles don't cover incident management".
+
+    Tags are normalized before comparison, so 'Leadership' and 'leadership'
+    count as one topic.
+
+    Args:
+        notes: Notes with tags
+        articles: Articles with tags
+        min_notes: Notes sharing a tag before it counts as a real cluster
+        limit: Maximum results to return
+
+    Returns:
+        List of uncovered topic dicts, largest cluster first
+    """
+    covered = {
+        normalize_tag(tag) for article in articles for tag in (article.get("tags") or [])
+    }
+
+    by_tag: dict[str, list[dict[str, str]]] = {}
+    for note in notes:
+        for tag in note.get("tags") or []:
+            by_tag.setdefault(normalize_tag(tag), []).append(
+                {"note_id": note["id"], "title": note.get("title", note["id"])}
+            )
+
+    uncovered: list[dict[str, Any]] = [
+        {
+            "tag": tag,
+            "note_count": len(tagged),
+            "note_ids": [n["note_id"] for n in tagged[:5]],
+            "titles": [n["title"] for n in tagged[:5]],
+        }
+        for tag, tagged in by_tag.items()
+        if tag not in covered and len(tagged) >= min_notes
+    ]
+
+    # Sort by size, then tag name, so equal-sized clusters have a stable order
+    uncovered.sort(key=lambda x: (-int(x["note_count"]), str(x["tag"])))
+    return uncovered[:limit]
+
+
+# --- composition ------------------------------------------------------------
+
+SUGGESTION_TYPES = ("orphan", "duplicate", "connection", "hub", "promote", "split", "article")
+
+# Round-robin order. Highest-signal problems come first so that when the
+# requested limit is small, the user sees the things most worth fixing.
+_ROTATION_ORDER = ("duplicate", "orphan", "article", "hub", "promote", "connection", "split")
+
+
+def compose_candidates(
+    candidates: dict[str, list[dict[str, Any]]],
+    limit: int,
+    offset: int = 0,
+) -> list[dict[str, Any]]:
+    """Interleave candidates across types so no single type dominates.
+
+    Pure function: No I/O, no side effects, deterministic.
+
+    Round-robins through _ROTATION_ORDER taking one candidate per type per
+    pass. The offset rotates each type's own list, so pressing Refresh yields
+    a different slice of the same analysis without re-running it.
+
+    Args:
+        candidates: Mapping of suggestion type -> candidate list
+        limit: Total candidates to return
+        offset: Rotation offset applied within each type's list
+
+    Returns:
+        Interleaved list of {"type": ..., "data": ...} dicts
+    """
+    if limit <= 0:
+        return []
+
+    # Rotate each type's list by offset so refresh surfaces different items
+    rotated: dict[str, list[dict[str, Any]]] = {}
+    for suggestion_type, items in candidates.items():
+        if not items:
+            continue
+        start = offset % len(items)
+        rotated[suggestion_type] = items[start:] + items[:start]
+
+    composed: list[dict[str, Any]] = []
+    cursors = dict.fromkeys(rotated, 0)
+
+    while len(composed) < limit:
+        progressed = False
+        for suggestion_type in _ROTATION_ORDER:
+            if len(composed) >= limit:
+                break
+            pool = rotated.get(suggestion_type)
+            if not pool:
+                continue
+            cursor = cursors[suggestion_type]
+            if cursor >= len(pool):
+                continue
+            composed.append({"type": suggestion_type, "data": pool[cursor]})
+            cursors[suggestion_type] = cursor + 1
+            progressed = True
+        if not progressed:
+            break
+
+    return composed
+
+
+def compute_kb_fingerprint(
+    notes: list[dict[str, Any]], articles: list[dict[str, Any]]
+) -> str:
+    """Compute a stable fingerprint of KB state, for cache invalidation.
+
+    Pure function: No I/O, no side effects, deterministic.
+    Changes when a note or article is added, removed, edited, or relinked.
+
+    Args:
+        notes: Notes with id, content_length, link_count, backlink_count
+        articles: Articles with id
+
+    Returns:
+        Hex digest string
+    """
+    parts = sorted(
+        f"{n['id']}:{n.get('content_length', 0)}:"
+        f"{n.get('link_count', 0)}:{n.get('backlink_count', 0)}"
+        for n in notes
+    )
+    parts += sorted(f"a:{a['id']}" for a in articles)
+    return hashlib.sha256("|".join(parts).encode()).hexdigest()[:16]
+
+
+# --- prompting --------------------------------------------------------------
+
+_TYPE_BRIEFS = {
+    "orphan": (
+        "ORPHANED NOTES (no links in or out - their ideas are unreachable). "
+        "Suggest which existing note each should connect to, or what bridging "
+        "note would give it a home."
+    ),
+    "duplicate": (
+        "LIKELY DUPLICATES (near-identical topic and title). "
+        "Suggest merging them into one note and keeping the better title."
+    ),
+    "connection": (
+        "RELATED BUT UNLINKED (distinct notes covering adjacent ground). "
+        "Suggest the wikilink and say what the relationship is."
+    ),
+    "hub": (
+        "CLUSTERS WANTING A HUB (several mutually-related notes with no index). "
+        "Suggest a hub note that indexes them and names the shared theme."
+    ),
+    "promote": (
+        "WELL-REFERENCED NOTES (many other notes point here). "
+        "Suggest developing this into a full article."
+    ),
+    "split": (
+        "OVERSIZED NOTES (long enough to hold several ideas). "
+        "Suggest how to split it into atomic notes."
+    ),
+    "article": (
+        "UNCOVERED TOPICS (many notes on a topic, but no article about it). "
+        "Suggest an article that would draw on those notes."
+    ),
+}
+
+
+def _describe_candidate(suggestion_type: str, data: dict[str, Any]) -> str:
+    """Render one candidate as a prompt line. Pure."""
+    if suggestion_type == "orphan":
+        return f'- "{data["title"]}" (id: {data["note_id"]}, no links in or out)'
+    if suggestion_type in ("duplicate", "connection"):
+        return (
+            f'- "{data["note_a_title"]}" (id: {data["note_a_id"]}) and '
+            f'"{data["note_b_title"]}" (id: {data["note_b_id"]}) '
+            f'- {data["similarity"]:.0%} similar'
+        )
+    if suggestion_type == "hub":
+        listed = ", ".join(f'"{t}"' for t in data["titles"])
+        return f'- {data["size"]} related notes: {listed} (ids: {", ".join(data["note_ids"])})'
+    if suggestion_type == "promote":
+        return (
+            f'- "{data["title"]}" (id: {data["note_id"]}, '
+            f'{data["backlink_count"]} notes reference it)'
+        )
+    if suggestion_type == "split":
+        return f'- "{data["title"]}" (id: {data["note_id"]}, {data["content_length"]} chars)'
+    if suggestion_type == "article":
+        listed = ", ".join(f'"{t}"' for t in data["titles"])
+        return (
+            f'- tag "{data["tag"]}": {data["note_count"]} notes ({listed}) but no article '
+            f'(ids: {", ".join(data["note_ids"])})'
+        )
+    return ""
+
+
+def candidate_note_ids(data: dict[str, Any]) -> list[str]:
+    """Extract the note IDs a single candidate refers to. Pure."""
+    ids = [str(data[key]) for key in ("note_id", "note_a_id", "note_b_id") if key in data]
+    ids += [str(note_id) for note_id in data.get("note_ids") or []]
+    return ids
+
+
+def sanitize_suggestions(
+    suggestions: list[dict[str, Any]], composed: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Reconcile LLM suggestions against the analysis that produced them.
+
+    Pure function: No I/O, no side effects, deterministic.
+
+    The LLM is only trusted for wording. Two things it gets wrong regularly
+    are corrected here against the authoritative candidate list:
+
+    1. Invented note IDs -- notably echoing a tag name ("sre") where note IDs
+       were wanted. These would render as dead links, so they are dropped.
+    2. Mislabelled types -- e.g. tagging a "promote" finding as "hub", which
+       shows the wrong badge and routes the action button wrongly.
+
+    A suggestion is matched to its candidate by note-ID overlap, and takes
+    that candidate's type. Suggestions matching no candidate are dropped.
+
+    Args:
+        suggestions: Parsed LLM suggestions
+        composed: The candidates the suggestions were generated from
+
+    Returns:
+        Suggestions with real note IDs and authoritative types
+    """
+    candidates = [(item["type"], set(candidate_note_ids(item["data"]))) for item in composed]
+    valid_ids = {note_id for _, ids in candidates for note_id in ids}
+
+    sanitized = []
+    for suggestion in suggestions:
+        kept = [note_id for note_id in suggestion["related_notes"] if note_id in valid_ids]
+        if not kept:
+            logger.debug(
+                "Dropping suggestion %r: no valid note IDs in %s",
+                suggestion.get("title"),
+                suggestion["related_notes"],
+            )
+            continue
+
+        # Take the type from whichever candidate these notes came from
+        kept_set = set(kept)
+        best_type, best_overlap = suggestion["type"], 0
+        for candidate_type, candidate_ids in candidates:
+            overlap = len(kept_set & candidate_ids)
+            if overlap > best_overlap:
+                best_type, best_overlap = candidate_type, overlap
+
+        if best_type != suggestion["type"]:
+            logger.debug(
+                "Retyping suggestion %r: %s -> %s",
+                suggestion.get("title"),
+                suggestion["type"],
+                best_type,
+            )
+
+        sanitized.append({**suggestion, "related_notes": kept, "type": best_type})
+    return sanitized
+
+
+def build_inspiration_prompt(composed: list[dict[str, Any]]) -> str:
+    """Build prompt for the LLM to phrase suggestions in natural language.
+
+    Pure function: No I/O, no side effects, deterministic.
+
+    The analysis is already done -- the LLM's only job is wording. It is told
+    explicitly not to invent suggestions and not to ask for longer notes.
+
+    Args:
+        composed: Output of compose_candidates()
 
     Returns:
         Complete prompt string for LLM
     """
-    gap_section = ""
-    if gap_notes:
-        gap_items = []
-        for note in gap_notes[:5]:
-            reasons = []
-            if note.get("is_short"):
-                reasons.append(f"only {note['content_length']} chars")
-            if note.get("has_few_links"):
-                total = note.get("link_count", 0) + note.get("backlink_count", 0)
-                reasons.append(f"only {total} connections")
-            reason_str = ", ".join(reasons)
-            gap_items.append(f"- \"{note['title']}\" ({reason_str})")
-        gap_section = "Knowledge Gaps (underdeveloped notes):\n" + "\n".join(gap_items)
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for item in composed:
+        grouped.setdefault(item["type"], []).append(item["data"])
 
-    conn_section = ""
-    if connection_opportunities:
-        conn_items = []
-        for conn in connection_opportunities[:5]:
-            conn_items.append(
-                f"- \"{conn['note_a_title']}\" and \"{conn['note_b_title']}\" "
-                f"(similarity: {conn['similarity']:.0%})"
-            )
-        conn_section = "Connection Opportunities (similar but unlinked):\n" + "\n".join(
-            conn_items
-        )
+    sections = []
+    for suggestion_type in _ROTATION_ORDER:
+        items = grouped.get(suggestion_type)
+        if not items:
+            continue
+        lines = [_describe_candidate(suggestion_type, data) for data in items]
+        sections.append(f"{_TYPE_BRIEFS[suggestion_type]}\n" + "\n".join(lines))
 
-    sections = [s for s in [gap_section, conn_section] if s]
-    analysis = "\n\n".join(sections) if sections else "No significant gaps or opportunities found."
+    analysis = "\n\n".join(sections) if sections else "No opportunities found."
 
-    return f"""You are helping a knowledge base owner improve their notes.
-Based on this analysis, provide 3-5 actionable suggestions.
+    return f"""You are helping the owner of a Zettelkasten knowledge base.
+
+The analysis below is already complete. Your ONLY job is to phrase each \
+finding as a clear, actionable suggestion. Write exactly one suggestion per \
+finding listed. Do not invent findings that are not listed.
+
+CRITICAL RULE: never suggest making a note longer or adding more content to \
+it. In a Zettelkasten a short note is correct -- atomic notes are the goal. \
+Suggest connecting, merging, splitting, indexing, or promoting notes instead.
 
 {analysis}
 
-For each suggestion, provide:
-- type: "gap" (expand content) or "connection" (add link)
-- title: A short, actionable title (e.g., "Expand: Technical Debt" or "Connect: Leadership & Motivation")
-- description: 1-2 sentences explaining why and how to improve
-- related_notes: Array of note IDs involved
-- action_text: Short button label (e.g., "Edit Note" or "Add Link")
+For each finding, produce an object with:
+- type: one of {", ".join(f'"{t}"' for t in SUGGESTION_TYPES)} (use the category it was listed under)
+- title: short actionable title (e.g. "Merge: Five Dysfunctions duplicates")
+- description: 1-2 sentences on what to do and why it helps
+- related_notes: array of the note IDs given for that finding
+- action_text: short button label (e.g. "Merge Notes", "Add Link", "Draft Article")
 
-Return ONLY a JSON array of suggestions.
-Example: [{{"type": "gap", "title": "Expand: Note Title", "description": "...", "related_notes": ["note-id"], "action_text": "Edit Note"}}]
+Return ONLY a JSON array. No preamble, no explanation, no markdown fences.
+Example: [{{"type": "orphan", "title": "Connect: Note Title", \
+"description": "...", "related_notes": ["note-id"], "action_text": "Connect Note"}}]
 
 JSON:"""
+
+
+# --- parsing ----------------------------------------------------------------
+
+
+def _extract_json_array(text: str) -> str | None:
+    """Extract the first balanced top-level JSON array from text. Pure.
+
+    Small models routinely wrap the array in prose or fences ("Here is the
+    JSON: [...]  Hope this helps!"). Bracket matching recovers the payload
+    where a plain json.loads would fail. Quote- and escape-aware so brackets
+    inside string values don't throw off the depth count.
+    """
+    start = text.find("[")
+    if start == -1:
+        return None
+
+    depth = 0
+    in_string = False
+    escaped = False
+
+    for index in range(start, len(text)):
+        char = text[index]
+
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char == '"':
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+
+        if char == "[":
+            depth += 1
+        elif char == "]":
+            depth -= 1
+            if depth == 0:
+                return text[start : index + 1]
+
+    return None
 
 
 def parse_inspiration_response(raw_response: str) -> list[dict[str, Any]]:
     """Parse LLM response into structured suggestions.
 
     Pure function: No I/O, no side effects, deterministic.
-    Handles common LLM output issues (markdown wrappers, etc.).
+    Tolerates markdown fences and surrounding prose.
 
     Args:
         raw_response: Raw text response from LLM
@@ -204,91 +708,157 @@ def parse_inspiration_response(raw_response: str) -> list[dict[str, Any]]:
         response = response[3:]
     if response.endswith("```"):
         response = response[:-3]
-
     response = response.strip()
 
     try:
         data = json.loads(response)
-
-        if isinstance(data, dict):
-            data = [data]
-        elif not isinstance(data, list):
-            logger.warning("Unexpected JSON type: %s (expected array)", type(data))
+    except json.JSONDecodeError:
+        # Model wrapped the array in prose - recover it
+        extracted = _extract_json_array(response)
+        if extracted is None:
+            logger.warning("No JSON array found in inspiration response")
+            logger.debug("Raw response (first 500 chars): %s", raw_response[:500])
+            return []
+        try:
+            data = json.loads(extracted)
+        except json.JSONDecodeError:
+            logger.warning("Extracted inspiration payload is not valid JSON")
+            logger.debug("Extracted (first 500 chars): %s", extracted[:500])
             return []
 
-        # Validate each suggestion has required fields
-        valid_suggestions = []
-        required_fields = {"type", "title", "description", "related_notes", "action_text"}
-
-        for item in data:
-            if not isinstance(item, dict):
-                continue
-            if not required_fields.issubset(item.keys()):
-                missing = required_fields - set(item.keys())
-                logger.debug("Suggestion missing fields: %s", missing)
-                continue
-            if item["type"] not in ("gap", "connection"):
-                logger.debug("Invalid suggestion type: %s", item["type"])
-                continue
-            valid_suggestions.append(item)
-
-        return valid_suggestions
-
-    except json.JSONDecodeError:
-        logger.error("Failed to parse inspiration response as JSON")
-        logger.debug("Raw response (first 500 chars): %s", raw_response[:500])
+    if isinstance(data, dict):
+        data = [data]
+    elif not isinstance(data, list):
+        logger.warning("Unexpected JSON type: %s (expected array)", type(data))
         return []
+
+    valid_suggestions = []
+    required_fields = {"type", "title", "description", "related_notes", "action_text"}
+
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        if not required_fields.issubset(item.keys()):
+            logger.debug("Suggestion missing fields: %s", required_fields - set(item.keys()))
+            continue
+        if item["type"] not in SUGGESTION_TYPES:
+            logger.debug("Invalid suggestion type: %s", item["type"])
+            continue
+        if not isinstance(item["related_notes"], list):
+            logger.debug("related_notes is not a list: %s", type(item["related_notes"]))
+            continue
+        valid_suggestions.append(item)
+
+    return valid_suggestions
+
+
+# --- fallback (no LLM) ------------------------------------------------------
+
+
+def _fallback_for(suggestion_type: str, data: dict[str, Any]) -> dict[str, Any] | None:
+    """Build one templated suggestion without an LLM. Pure."""
+    if suggestion_type == "orphan":
+        return {
+            "type": "orphan",
+            "title": f"Connect: {data['title']}",
+            "description": (
+                "This note has no links in or out, so nothing in the graph leads to it. "
+                "Add a wikilink to a related note so it becomes reachable."
+            ),
+            "related_notes": [data["note_id"]],
+            "action_text": "Connect Note",
+        }
+    if suggestion_type == "duplicate":
+        return {
+            "type": "duplicate",
+            "title": f"Merge: {data['note_a_title']}",
+            "description": (
+                f"\"{data['note_a_title']}\" and \"{data['note_b_title']}\" are "
+                f"{data['similarity']:.0%} similar with nearly the same title. "
+                "They look like the same idea captured twice - merge them."
+            ),
+            "related_notes": [data["note_a_id"], data["note_b_id"]],
+            "action_text": "Compare Notes",
+        }
+    if suggestion_type == "connection":
+        return {
+            "type": "connection",
+            "title": f"Link: {data['note_a_title']}",
+            "description": (
+                f"\"{data['note_a_title']}\" and \"{data['note_b_title']}\" cover related "
+                f"ground ({data['similarity']:.0%} similar) but aren't linked. Add a wikilink."
+            ),
+            "related_notes": [data["note_a_id"], data["note_b_id"]],
+            "action_text": "Add Link",
+        }
+    if suggestion_type == "hub":
+        return {
+            "type": "hub",
+            "title": f"Hub note for {data['size']} related notes",
+            "description": (
+                f"{data['size']} notes cover the same theme without an index: "
+                f"{', '.join(data['titles'][:3])}. A hub note linking them would "
+                "make the cluster navigable."
+            ),
+            "related_notes": data["note_ids"],
+            "action_text": "Create Hub Note",
+        }
+    if suggestion_type == "promote":
+        return {
+            "type": "promote",
+            "title": f"Article from: {data['title']}",
+            "description": (
+                f"{data['backlink_count']} notes reference this one, so it is already "
+                "load-bearing in your graph. That is usually a sign there is a full "
+                "article in it."
+            ),
+            "related_notes": [data["note_id"]],
+            "action_text": "Start Article",
+        }
+    if suggestion_type == "split":
+        return {
+            "type": "split",
+            "title": f"Split: {data['title']}",
+            "description": (
+                f"At {data['content_length']} characters this note likely holds more than "
+                "one idea. Split it into atomic notes and link them together."
+            ),
+            "related_notes": [data["note_id"]],
+            "action_text": "Split Note",
+        }
+    if suggestion_type == "article":
+        return {
+            "type": "article",
+            "title": f"Article idea: {data['tag']}",
+            "description": (
+                f"You have {data['note_count']} notes tagged \"{data['tag']}\" but no "
+                "article covering it. Those notes are the raw material for one."
+            ),
+            "related_notes": data["note_ids"],
+            "action_text": "Draft Article",
+        }
+    return None
 
 
 def build_fallback_suggestions(
-    gap_notes: list[dict[str, Any]],
-    connection_opportunities: list[dict[str, Any]],
-    limit: int = 5,
+    composed: list[dict[str, Any]], limit: int = 5
 ) -> list[dict[str, Any]]:
-    """Build suggestions without LLM (fallback when Ollama unavailable).
+    """Build suggestions without an LLM (fallback when generation fails).
 
     Pure function: No I/O, no side effects, deterministic.
 
     Args:
-        gap_notes: Underdeveloped notes from find_underdeveloped_topics()
-        connection_opportunities: Connections from find_unlinked_similar_notes()
+        composed: Output of compose_candidates()
         limit: Maximum suggestions to return
 
     Returns:
         List of suggestion dicts
     """
     suggestions = []
-
-    # Add gap suggestions
-    for note in gap_notes:
-        reasons = []
-        if note.get("is_short"):
-            reasons.append(f"only {note['content_length']} characters")
-        if note.get("has_few_links"):
-            total = note.get("link_count", 0) + note.get("backlink_count", 0)
-            reasons.append(f"only {total} connections")
-        reason_str = " and ".join(reasons)
-
-        suggestions.append(
-            {
-                "type": "gap",
-                "title": f"Expand: {note['title']}",
-                "description": f"This note has {reason_str}. Consider expanding the content or adding links to related notes.",
-                "related_notes": [note["note_id"]],
-                "action_text": "Edit Note",
-            }
-        )
-
-    # Add connection suggestions
-    for conn in connection_opportunities:
-        suggestions.append(
-            {
-                "type": "connection",
-                "title": f"Connect: {conn['note_a_title'][:20]}... & {conn['note_b_title'][:20]}...",
-                "description": f"These notes are {conn['similarity']:.0%} similar but not linked. Consider adding a wikilink.",
-                "related_notes": [conn["note_a_id"], conn["note_b_id"]],
-                "action_text": "Add Link",
-            }
-        )
-
-    return suggestions[:limit]
+    for item in composed:
+        suggestion = _fallback_for(item["type"], item["data"])
+        if suggestion is not None:
+            suggestions.append(suggestion)
+        if len(suggestions) >= limit:
+            break
+    return suggestions

--- a/backend/llm_client.py
+++ b/backend/llm_client.py
@@ -110,6 +110,7 @@ class ApiLLMClient:
         role: str = "chat",
         num_ctx: int | None = None,
         max_tokens: int | None = None,
+        timeout: float | None = None,
     ) -> str | None:
         """Generate a completion, trying each provider in order.
 
@@ -119,6 +120,10 @@ class ApiLLMClient:
                 OllamaClient; hosted models handle both with one model)
             num_ctx: Ignored for API providers (hosted context windows are large)
             max_tokens: Response length cap (defaults to settings)
+            timeout: Per-provider timeout override. Interactive callers should
+                pass a short value: the default is sized for long generations,
+                and a hung primary provider otherwise delays the fallback by
+                the full timeout before the secondary is even tried.
 
         Returns:
             Generated text, or None if all providers failed
@@ -131,7 +136,7 @@ class ApiLLMClient:
                     f"{provider.base_url}/chat/completions",
                     headers={"Authorization": f"Bearer {provider.api_key}"},
                     json=self._request_body(provider, prompt, max_tokens, stream=False),
-                    timeout=self.timeout,
+                    timeout=timeout or self.timeout,
                 )
                 response.raise_for_status()
                 data = response.json()

--- a/backend/ollama_client.py
+++ b/backend/ollama_client.py
@@ -182,6 +182,7 @@ class OllamaClient:
         role: str = "chat",
         num_ctx: int | None = None,
         max_tokens: int | None = None,
+        timeout: float | None = None,
     ) -> str | None:
         """Generate a completion using the model configured for the role.
 
@@ -190,6 +191,8 @@ class OllamaClient:
             role: "chat" (llama) or "structured" (qwen, reliable JSON)
             num_ctx: Context window size (defaults to configured num_ctx)
             max_tokens: Response length cap (Ollama num_predict)
+            timeout: Accepted for interface parity with ApiLLMClient; local
+                inference has no per-request network timeout to apply
 
         Returns:
             Generated text, or None if unavailable or failed

--- a/backend/routers/inspire.py
+++ b/backend/routers/inspire.py
@@ -2,188 +2,284 @@
 
 Uses FastAPI dependency injection for testability. Dependencies can be
 overridden in tests using app.dependency_overrides.
+
+The analysis (graph + similarity + tag coverage) is pure and cheap enough to
+recompute, but it is cached against a KB fingerprint so that pressing Refresh
+rotates through an existing candidate pool instead of re-running an O(n^2)
+similarity sweep and a fresh LLM call every time (#259).
 """
 
 import logging
 import time
+from dataclasses import dataclass, field
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends
 
 from core import inspire as inspire_core
-from dependencies import get_notes, get_ollama
+from dependencies import get_llm, get_notes, get_static_articles
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/inspire", tags=["inspire"])
 
 # Type aliases for cleaner signatures
-OllamaDep = Annotated[Any, Depends(get_ollama)]
+LlmDep = Annotated[Any, Depends(get_llm)]
 NotesDep = Annotated[Any, Depends(get_notes)]
+ArticlesDep = Annotated[list[dict[str, Any]], Depends(get_static_articles)]
+
+# Interactive endpoint: fall through to the backup provider fast rather than
+# making the user wait out the default 30s timeout on a hung primary.
+LLM_TIMEOUT_SECONDS = 8.0
+
+CACHE_TTL_SECONDS = 900.0
+
+
+@dataclass
+class _SuggestionCache:
+    """Per-process cache of generated suggestions, keyed by KB fingerprint."""
+
+    fingerprint: str = ""
+    generated_at: float = 0.0
+    refresh_count: int = 0
+    entries: dict[int, tuple[list[dict[str, Any]], bool]] = field(default_factory=dict)
+
+    def is_valid(self, fingerprint: str) -> bool:
+        return (
+            self.fingerprint == fingerprint
+            and time.monotonic() - self.generated_at < CACHE_TTL_SECONDS
+        )
+
+    def reset(self, fingerprint: str) -> None:
+        self.fingerprint = fingerprint
+        self.generated_at = time.monotonic()
+        self.refresh_count = 0
+        self.entries = {}
+
+
+_cache = _SuggestionCache()
+
+
+def _analyze(
+    notes_service: Any, articles: list[dict[str, Any]]
+) -> tuple[dict[str, list[dict[str, Any]]], str]:
+    """Run the full KB analysis and return candidates by type + a fingerprint.
+
+    Everything here is I/O plus calls into the pure core; no business logic.
+    """
+    notes_with_stats = notes_service.get_notes_with_stats()
+    notes_with_embeddings = notes_service.get_notes_with_embeddings()
+    all_links = notes_service.get_all_links()
+
+    note_embeddings = [
+        (note["id"], note["title"], note["embedding"]) for note in notes_with_embeddings
+    ]
+    pairs = inspire_core.find_unlinked_similar_notes(
+        note_embeddings=note_embeddings,
+        existing_links=all_links,
+        limit=30,
+    )
+
+    candidates: dict[str, list[dict[str, Any]]] = {
+        "orphan": inspire_core.find_orphan_notes(notes_with_stats),
+        "split": inspire_core.find_oversized_notes(notes_with_stats),
+        "promote": inspire_core.find_promotion_candidates(notes_with_stats),
+        "duplicate": [p for p in pairs if p["kind"] == "duplicate"],
+        "connection": [p for p in pairs if p["kind"] == "connection"],
+        "hub": inspire_core.find_hub_opportunities(pairs),
+        "article": inspire_core.find_uncovered_tag_clusters(notes_with_stats, articles),
+    }
+
+    fingerprint = inspire_core.compute_kb_fingerprint(notes_with_stats, articles)
+
+    logger.info(
+        "KB analysis: %s",
+        ", ".join(f"{k}={len(v)}" for k, v in candidates.items() if v) or "no opportunities",
+    )
+    return candidates, fingerprint
 
 
 @router.get("/suggestions", response_model=dict[str, Any])
 def get_suggestions(
     notes_service: NotesDep,
-    ollama: OllamaDep,
+    llm: LlmDep,
+    articles: ArticlesDep,
     limit: int = 5,
+    refresh: bool = False,
+    skip_llm: bool = False,
 ) -> dict[str, Any]:
-    """Get AI-powered content suggestions for knowledge base improvement.
+    """Get AI-phrased content suggestions for knowledge base improvement.
 
-    Analyzes the knowledge base to find:
-    - Knowledge gaps (underdeveloped topics)
-    - Connection opportunities (similar but unlinked notes)
+    Analyzes the knowledge base for structural opportunities: orphaned notes,
+    likely duplicates, unlinked but related notes, clusters wanting a hub,
+    notes worth promoting to articles, oversized notes worth splitting, and
+    topics with many notes but no article.
 
-    Uses Ollama to generate human-friendly suggestion descriptions.
-    Falls back to structured suggestions if Ollama is unavailable.
+    Note length is deliberately not a signal on its own - short atomic notes
+    are the goal, not a defect (#259).
+
+    Uses the LLM only to phrase the findings. Falls back to templated wording
+    if generation fails, and reports which happened via has_llm.
 
     Args:
         limit: Maximum number of suggestions to return (default: 5)
+        refresh: Rotate to a different slice of the candidate pool
+        skip_llm: Return templated wording immediately without calling the LLM.
+            Lets the page paint real suggestions first and swap in the phrased
+            ones when they arrive, without reimplementing the wording client-side.
 
     Returns:
-        Dict with suggestions, generated_at timestamp, and has_llm indicator
+        Dict with suggestions, generated_at, has_llm, and cached indicators
     """
-    # Get data for analysis
-    notes_with_stats = notes_service.get_notes_with_stats()
-    notes_with_embeddings = notes_service.get_notes_with_embeddings()
-    all_links = notes_service.get_all_links()
+    candidates, fingerprint = _analyze(notes_service, articles)
 
-    # Find underdeveloped topics
-    gap_notes = inspire_core.find_underdeveloped_topics(
-        notes=notes_with_stats,
-        min_content_length=500,
-        max_links=1,
-        limit=limit,
-    )
-    logger.info("Found %d underdeveloped topics", len(gap_notes))
+    if not _cache.is_valid(fingerprint):
+        _cache.reset(fingerprint)
+    elif refresh:
+        _cache.refresh_count += 1
 
-    # Find unlinked similar notes
-    note_embeddings = [
-        (note["id"], note["title"], note["embedding"]) for note in notes_with_embeddings
-    ]
-    connection_opportunities = inspire_core.find_unlinked_similar_notes(
-        note_embeddings=note_embeddings,
-        existing_links=all_links,
-        similarity_threshold=0.7,
-        limit=limit,
-    )
-    logger.info("Found %d connection opportunities", len(connection_opportunities))
+    offset = _cache.refresh_count
+    cache_key = hash((limit, offset))
 
-    # Try to use LLM for human-friendly suggestions
+    if skip_llm:
+        composed = inspire_core.compose_candidates(candidates, limit=limit, offset=offset)
+        return {
+            "suggestions": inspire_core.build_fallback_suggestions(composed, limit=limit),
+            "generated_at": _cache.generated_at,
+            "has_llm": False,
+            "cached": False,
+        }
+
+    if not refresh and cache_key in _cache.entries:
+        cached_suggestions, cached_has_llm = _cache.entries[cache_key]
+        return {
+            "suggestions": cached_suggestions,
+            "generated_at": _cache.generated_at,
+            "has_llm": cached_has_llm,
+            "cached": True,
+        }
+
+    composed = inspire_core.compose_candidates(candidates, limit=limit, offset=offset)
+
     suggestions: list[dict[str, Any]] = []
     has_llm = False
 
-    if ollama.is_available() and (gap_notes or connection_opportunities):
+    if composed and llm.is_available():
         try:
-            # Build prompt for LLM
-            prompt = inspire_core.build_inspiration_prompt(
-                gap_notes=gap_notes,
-                connection_opportunities=connection_opportunities,
+            prompt = inspire_core.build_inspiration_prompt(composed)
+            response_text = llm.generate(
+                prompt,
+                role="structured",
+                num_ctx=4096,
+                max_tokens=1024,
+                timeout=LLM_TIMEOUT_SECONDS,
             )
-
-            # Generate suggestions
-            response_text = ollama.generate(
-                prompt, role="structured", num_ctx=4096, max_tokens=1024
-            )
-
             if response_text:
                 parsed = inspire_core.parse_inspiration_response(response_text)
+                # Trust the LLM for wording only - IDs and types come from the analysis
+                parsed = inspire_core.sanitize_suggestions(parsed, composed)
                 if parsed:
                     suggestions = parsed[:limit]
                     has_llm = True
-                    logger.info("Generated %d AI-powered suggestions", len(suggestions))
-
+                    logger.info("Generated %d AI-phrased suggestions", len(suggestions))
+                else:
+                    logger.warning("LLM response was unparseable - using templated wording")
+            else:
+                logger.warning("LLM returned no content - using templated wording")
         except Exception as e:
             logger.error("Error generating AI suggestions: %s", e)
 
-    # Fallback to structured suggestions without LLM
     if not suggestions:
-        suggestions = inspire_core.build_fallback_suggestions(
-            gap_notes=gap_notes,
-            connection_opportunities=connection_opportunities,
-            limit=limit,
-        )
-        logger.info("Generated %d fallback suggestions (no LLM)", len(suggestions))
+        suggestions = inspire_core.build_fallback_suggestions(composed, limit=limit)
+        logger.info("Generated %d templated suggestions (no LLM)", len(suggestions))
+
+    _cache.entries[cache_key] = (suggestions, has_llm)
 
     return {
         "suggestions": suggestions,
-        "generated_at": time.time(),
+        "generated_at": _cache.generated_at,
         "has_llm": has_llm,
+        "cached": False,
     }
 
 
 @router.get("/gaps", response_model=dict[str, Any])
 def get_knowledge_gaps(
     notes_service: NotesDep,
-    min_content_length: int = 500,
-    max_links: int = 1,
+    articles: ArticlesDep,
     limit: int = 10,
 ) -> dict[str, Any]:
-    """Get underdeveloped topics without LLM (fast endpoint).
+    """Get structural gaps without an LLM (fast endpoint).
 
-    Finds notes that are short and/or have few connections.
-    These are candidates for expansion.
+    Returns orphaned notes (unreachable in the graph), oversized notes (split
+    candidates), well-referenced notes (article candidates), and tag clusters
+    with no covering article.
 
     Args:
-        min_content_length: Notes shorter than this are considered underdeveloped
-        max_links: Notes with this many or fewer total links are candidates
-        limit: Maximum results to return
+        limit: Maximum results per category
 
     Returns:
-        Dict with gaps list and count
+        Dict with orphans, oversized, promotable, uncovered_topics and counts
     """
     notes_with_stats = notes_service.get_notes_with_stats()
 
-    gaps = inspire_core.find_underdeveloped_topics(
-        notes=notes_with_stats,
-        min_content_length=min_content_length,
-        max_links=max_links,
-        limit=limit,
+    orphans = inspire_core.find_orphan_notes(notes_with_stats, limit=limit)
+    oversized = inspire_core.find_oversized_notes(notes_with_stats, limit=limit)
+    promotable = inspire_core.find_promotion_candidates(notes_with_stats, limit=limit)
+    uncovered = inspire_core.find_uncovered_tag_clusters(
+        notes_with_stats, articles, limit=limit
     )
 
     return {
-        "gaps": gaps,
-        "count": len(gaps),
-        "min_content_length": min_content_length,
-        "max_links": max_links,
+        "orphans": orphans,
+        "oversized": oversized,
+        "promotable": promotable,
+        "uncovered_topics": uncovered,
+        "count": len(orphans) + len(oversized) + len(promotable) + len(uncovered),
     }
 
 
 @router.get("/connections", response_model=dict[str, Any])
 def get_connection_opportunities(
     notes_service: NotesDep,
-    similarity_threshold: float = 0.7,
+    similarity_threshold: float = inspire_core.CONNECTION_MIN_SIMILARITY,
     limit: int = 10,
 ) -> dict[str, Any]:
-    """Get unlinked similar notes without LLM (fast endpoint).
+    """Get unlinked similar notes without an LLM (fast endpoint).
 
-    Finds pairs of notes that are semantically similar but not linked.
-    These are candidates for adding wikilinks.
+    Each pair is classified as a "duplicate" (same idea captured twice - merge)
+    or a "connection" (related but distinct - link). Clusters of three or more
+    mutually similar notes are also returned as hub-note opportunities.
 
     Args:
         similarity_threshold: Minimum cosine similarity to consider (0.0 to 1.0)
         limit: Maximum results to return
 
     Returns:
-        Dict with connections list and count
+        Dict with connections, duplicates, hubs and counts
     """
     notes_with_embeddings = notes_service.get_notes_with_embeddings()
     all_links = notes_service.get_all_links()
 
-    # Format for the pure function
     note_embeddings = [
         (note["id"], note["title"], note["embedding"]) for note in notes_with_embeddings
     ]
 
-    connections = inspire_core.find_unlinked_similar_notes(
+    pairs = inspire_core.find_unlinked_similar_notes(
         note_embeddings=note_embeddings,
         existing_links=all_links,
         similarity_threshold=similarity_threshold,
-        limit=limit,
+        limit=max(limit, 30),
     )
+
+    duplicates = [p for p in pairs if p["kind"] == "duplicate"][:limit]
+    connections = [p for p in pairs if p["kind"] == "connection"][:limit]
+    hubs = inspire_core.find_hub_opportunities(pairs, limit=limit)
 
     return {
         "connections": connections,
-        "count": len(connections),
+        "duplicates": duplicates,
+        "hubs": hubs,
+        "count": len(connections) + len(duplicates) + len(hubs),
         "similarity_threshold": similarity_threshold,
     }

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -141,6 +141,7 @@ class MockOllamaClient:
         role: str = "chat",
         num_ctx: int | None = None,
         max_tokens: int | None = None,
+        timeout: float | None = None,
     ) -> str | None:
         """Mock generation (same JSON payload as the raw client mock)."""
         if not self._available:

--- a/backend/tests/unit/test_inspire.py
+++ b/backend/tests/unit/test_inspire.py
@@ -1,6 +1,13 @@
-"""Unit tests for content inspiration features."""
+"""Unit tests for content inspiration features (#259 rewrite).
+
+Note length is deliberately not a signal (see core/inspire.py module
+docstring): a short, atomic note is correct in a Zettelkasten. Tests here
+guard against that heuristic creeping back in.
+"""
 
 import os
+from collections.abc import Generator
+from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
@@ -8,119 +15,316 @@ from fastapi.testclient import TestClient
 # Set testing mode before importing app modules
 os.environ["TESTING"] = "1"
 
-from config import get_settings
 from core import inspire as inspire_core
 from main import app
-from notes_service import get_notes_service
+from routers.inspire import _cache
 
-# Test admin token constant
-TEST_ADMIN_TOKEN = "test-admin-token-for-ci"
-
-
-@pytest.fixture
-def client() -> TestClient:
-    """Get test client for API testing."""
-    return TestClient(app)
+# ============================================================================
+# Fixtures
+# ============================================================================
 
 
 @pytest.fixture
-def admin_headers() -> dict[str, str]:
-    """Get admin authentication headers for testing."""
-    settings = get_settings()
-    token = settings.admin_token or TEST_ADMIN_TOKEN
-    return {"Authorization": f"Bearer {token}"}
+def client() -> Generator[TestClient]:
+    """Get test client for API testing (no default dependency overrides)."""
+    with TestClient(app) as test_client:
+        yield test_client
+    app.dependency_overrides.clear()
 
 
 @pytest.fixture(autouse=True)
-def clean_notes() -> None:
-    """Clean up notes before and after each test."""
-    notes_service = get_notes_service()
+def reset_inspire_cache() -> Generator[None]:
+    """Reset the module-level suggestion cache between tests.
 
-    # Clear Neo4j notes before test
-    if notes_service.neo4j.is_available():
-        notes_service.neo4j.driver.execute_query("MATCH (n:Note) DETACH DELETE n")
-
+    routers/inspire.py holds a process-wide `_cache` singleton keyed by a KB
+    fingerprint. Without resetting it, one test's cached suggestions would
+    leak into the next test that happens to produce the same fingerprint.
+    """
+    _cache.reset("")
     yield
-
-    # Clear Neo4j notes after test
-    if notes_service.neo4j.is_available():
-        notes_service.neo4j.driver.execute_query("MATCH (n:Note) DETACH DELETE n")
+    _cache.reset("")
 
 
-class TestCoreInspire:
-    """Unit tests for pure functions in core/inspire.py."""
+class FakeNotesService:
+    """Minimal stand-in for NotesService, exposing only what inspire needs."""
 
-    def test_find_underdeveloped_topics_empty(self) -> None:
-        """Test with empty notes list."""
-        result = inspire_core.find_underdeveloped_topics([])
-        assert result == []
+    def __init__(
+        self,
+        notes_with_stats: list[dict[str, Any]] | None = None,
+        notes_with_embeddings: list[dict[str, Any]] | None = None,
+        all_links: dict[str, set[str]] | None = None,
+    ) -> None:
+        self._notes_with_stats = notes_with_stats or []
+        self._notes_with_embeddings = notes_with_embeddings or []
+        self._all_links = all_links or {}
 
-    def test_find_underdeveloped_topics_short_content(self) -> None:
-        """Test finding notes with short content."""
+    def get_notes_with_stats(self) -> list[dict[str, Any]]:
+        return self._notes_with_stats
+
+    def get_notes_with_embeddings(self) -> list[dict[str, Any]]:
+        return self._notes_with_embeddings
+
+    def get_all_links(self) -> dict[str, set[str]]:
+        return self._all_links
+
+
+class FakeLLM:
+    """Minimal stand-in for the LLM client used by /api/inspire/suggestions."""
+
+    def __init__(
+        self,
+        available: bool = True,
+        response: str | None = None,
+        raise_error: bool = False,
+    ) -> None:
+        self._available = available
+        self._response = response
+        self._raise_error = raise_error
+
+    def is_available(self) -> bool:
+        return self._available
+
+    def generate(
+        self,
+        prompt: str,
+        *,
+        role: str = "chat",
+        num_ctx: int | None = None,
+        max_tokens: int | None = None,
+        timeout: float | None = None,
+    ) -> str | None:
+        if self._raise_error:
+            raise RuntimeError("simulated LLM failure")
+        return self._response
+
+
+def _override_dependencies(
+    notes_service: FakeNotesService | None = None,
+    llm: FakeLLM | None = None,
+    articles: list[dict[str, Any]] | None = None,
+) -> None:
+    """Install dependency_overrides for the inspire router's dependencies."""
+    from dependencies import get_llm, get_notes, get_static_articles
+
+    if notes_service is not None:
+        app.dependency_overrides[get_notes] = lambda: notes_service
+    if llm is not None:
+        app.dependency_overrides[get_llm] = lambda: llm
+    if articles is not None:
+        app.dependency_overrides[get_static_articles] = lambda: articles
+
+
+def _note(
+    note_id: str,
+    title: str | None = None,
+    content_length: int = 100,
+    link_count: int = 0,
+    backlink_count: int = 0,
+    tags: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build a minimal note-with-stats dict."""
+    return {
+        "id": note_id,
+        "title": title or note_id,
+        "content_length": content_length,
+        "link_count": link_count,
+        "backlink_count": backlink_count,
+        "tags": tags or [],
+    }
+
+
+# ============================================================================
+# Pure function tests: core/inspire.py
+# ============================================================================
+
+
+class TestNormalizeTag:
+    """normalize_tag: casing and separator normalization."""
+
+    def test_lowercases(self) -> None:
+        assert inspire_core.normalize_tag("Leadership") == "leadership"
+
+    def test_normalizes_underscores(self) -> None:
+        assert inspire_core.normalize_tag("one_on_ones") == "one-on-ones"
+
+    def test_normalizes_spaces(self) -> None:
+        assert inspire_core.normalize_tag("site reliability") == "site-reliability"
+
+    def test_strips_whitespace(self) -> None:
+        assert inspire_core.normalize_tag("  leadership  ") == "leadership"
+
+
+class TestTitleOverlap:
+    """title_overlap: the heart of duplicate-vs-sibling detection (#259)."""
+
+    def test_number_word_normalization_makes_titles_identical(self) -> None:
+        """'5 Dysfunctions' and 'Five Dysfunctions' are the same title."""
+        overlap = inspire_core.title_overlap(
+            "5 Dysfunctions of a Team", "Five Dysfunctions of a Team"
+        )
+        assert overlap >= 0.8
+
+    def test_deliberate_siblings_are_not_duplicates(self) -> None:
+        """Distinct sibling topics must not score as near-identical titles."""
+        overlap = inspire_core.title_overlap(
+            "Developer Productivity: People Factors",
+            "Developer Productivity: Process Factors",
+        )
+        assert overlap < 0.8
+
+    def test_identical_titles_score_one(self) -> None:
+        assert inspire_core.title_overlap("Same Title", "Same Title") == 1.0
+
+    def test_completely_different_titles_score_zero(self) -> None:
+        assert inspire_core.title_overlap("Apples", "Xylophone") == 0.0
+
+    def test_empty_title_scores_zero(self) -> None:
+        assert inspire_core.title_overlap("", "Something") == 0.0
+        assert inspire_core.title_overlap("Something", "") == 0.0
+
+    def test_stopwords_ignored(self) -> None:
+        overlap = inspire_core.title_overlap("The Team of Leaders", "Team Leaders")
+        assert overlap == 1.0
+
+
+class TestFindOrphanNotes:
+    """find_orphan_notes: link_count==0 AND backlink_count==0 only."""
+
+    def test_empty_notes(self) -> None:
+        assert inspire_core.find_orphan_notes([]) == []
+
+    def test_only_fully_disconnected_notes_are_orphans(self) -> None:
         notes = [
-            {"id": "short-note", "title": "Short", "content_length": 100, "link_count": 5, "backlink_count": 3},
-            {"id": "long-note", "title": "Long", "content_length": 1000, "link_count": 5, "backlink_count": 3},
+            _note("orphan-1", content_length=100, link_count=0, backlink_count=0),
+            _note("has-outbound", content_length=100, link_count=1, backlink_count=0),
+            _note("has-inbound", content_length=100, link_count=0, backlink_count=1),
+            _note("well-connected", content_length=100, link_count=2, backlink_count=2),
         ]
-        result = inspire_core.find_underdeveloped_topics(notes, min_content_length=500)
+        result = inspire_core.find_orphan_notes(notes)
 
-        assert len(result) == 1
-        assert result[0]["note_id"] == "short-note"
-        assert result[0]["is_short"] is True
+        assert [r["note_id"] for r in result] == ["orphan-1"]
 
-    def test_find_underdeveloped_topics_few_links(self) -> None:
-        """Test finding notes with few links."""
+    def test_short_but_well_linked_note_is_not_returned(self) -> None:
+        """Regression test for #259: length is not a signal on its own."""
         notes = [
-            {"id": "isolated-note", "title": "Isolated", "content_length": 1000, "link_count": 0, "backlink_count": 0},
-            {"id": "connected-note", "title": "Connected", "content_length": 1000, "link_count": 5, "backlink_count": 3},
+            _note("short-but-linked", content_length=50, link_count=3, backlink_count=2),
+            _note("true-orphan", content_length=500, link_count=0, backlink_count=0),
         ]
-        result = inspire_core.find_underdeveloped_topics(notes, max_links=1)
+        result = inspire_core.find_orphan_notes(notes)
 
-        assert len(result) == 1
-        assert result[0]["note_id"] == "isolated-note"
-        assert result[0]["has_few_links"] is True
+        note_ids = [r["note_id"] for r in result]
+        assert "short-but-linked" not in note_ids
+        assert "true-orphan" in note_ids
 
-    def test_find_underdeveloped_topics_sorted_by_length(self) -> None:
-        """Test that results are sorted by content length (shortest first)."""
+    def test_sorted_by_content_length_descending(self) -> None:
         notes = [
-            {"id": "medium", "title": "Medium", "content_length": 200, "link_count": 0, "backlink_count": 0},
-            {"id": "shortest", "title": "Shortest", "content_length": 50, "link_count": 0, "backlink_count": 0},
-            {"id": "long", "title": "Long", "content_length": 400, "link_count": 0, "backlink_count": 0},
+            _note("small", content_length=100),
+            _note("large", content_length=900),
+            _note("medium", content_length=400),
         ]
-        result = inspire_core.find_underdeveloped_topics(notes, min_content_length=500, limit=10)
+        result = inspire_core.find_orphan_notes(notes)
+
+        assert [r["note_id"] for r in result] == ["large", "medium", "small"]
+
+    def test_respects_limit(self) -> None:
+        notes = [_note(f"orphan-{i}", content_length=i) for i in range(10)]
+        result = inspire_core.find_orphan_notes(notes, limit=3)
 
         assert len(result) == 3
-        assert result[0]["note_id"] == "shortest"
-        assert result[1]["note_id"] == "medium"
-        assert result[2]["note_id"] == "long"
 
-    def test_find_underdeveloped_topics_respects_limit(self) -> None:
-        """Test that limit parameter is respected."""
+    def test_tags_are_normalized(self) -> None:
+        notes = [_note("orphan-1", tags=["Leadership", "one_on_ones"])]
+        result = inspire_core.find_orphan_notes(notes)
+
+        assert result[0]["tags"] == ["leadership", "one-on-ones"]
+
+
+class TestFindOversizedNotes:
+    """find_oversized_notes: content_length > min_length only."""
+
+    def test_empty_notes(self) -> None:
+        assert inspire_core.find_oversized_notes([]) == []
+
+    def test_strictly_greater_than_min_length(self) -> None:
         notes = [
-            {"id": f"note-{i}", "title": f"Note {i}", "content_length": 100, "link_count": 0, "backlink_count": 0}
-            for i in range(10)
+            _note("at-boundary", content_length=1000),
+            _note("just-over", content_length=1001),
+            _note("well-under", content_length=999),
         ]
-        result = inspire_core.find_underdeveloped_topics(notes, limit=3)
+        result = inspire_core.find_oversized_notes(notes, min_length=1000)
+
+        assert [r["note_id"] for r in result] == ["just-over"]
+
+    def test_sorted_longest_first(self) -> None:
+        notes = [
+            _note("medium", content_length=1500),
+            _note("longest", content_length=3000),
+            _note("shortest-oversized", content_length=1100),
+        ]
+        result = inspire_core.find_oversized_notes(notes, min_length=1000)
+
+        assert [r["note_id"] for r in result] == ["longest", "medium", "shortest-oversized"]
+
+    def test_respects_limit(self) -> None:
+        notes = [_note(f"note-{i}", content_length=2000 + i) for i in range(10)]
+        result = inspire_core.find_oversized_notes(notes, limit=2)
+
+        assert len(result) == 2
+
+    def test_default_threshold_matches_editor_guidance(self) -> None:
+        assert inspire_core.SPLIT_MIN_LENGTH == 1000
+
+
+class TestFindPromotionCandidates:
+    """find_promotion_candidates: backlink_count >= min_backlinks only."""
+
+    def test_empty_notes(self) -> None:
+        assert inspire_core.find_promotion_candidates([]) == []
+
+    def test_boundary_is_inclusive(self) -> None:
+        notes = [
+            _note("at-threshold", backlink_count=5),
+            _note("below-threshold", backlink_count=4),
+        ]
+        result = inspire_core.find_promotion_candidates(notes, min_backlinks=5)
+
+        assert [r["note_id"] for r in result] == ["at-threshold"]
+
+    def test_sorted_most_referenced_first(self) -> None:
+        notes = [
+            _note("moderate", backlink_count=6),
+            _note("most", backlink_count=20),
+            _note("least", backlink_count=5),
+        ]
+        result = inspire_core.find_promotion_candidates(notes, min_backlinks=5)
+
+        assert [r["note_id"] for r in result] == ["most", "moderate", "least"]
+
+    def test_respects_limit(self) -> None:
+        notes = [_note(f"note-{i}", backlink_count=10 + i) for i in range(10)]
+        result = inspire_core.find_promotion_candidates(notes, limit=3)
 
         assert len(result) == 3
 
-    def test_find_unlinked_similar_notes_empty(self) -> None:
-        """Test with empty embeddings list."""
-        result = inspire_core.find_unlinked_similar_notes([], {})
-        assert result == []
+    def test_default_threshold(self) -> None:
+        assert inspire_core.PROMOTE_MIN_BACKLINKS == 5
 
-    def test_find_unlinked_similar_notes_similar_pair(self) -> None:
-        """Test finding similar unlinked notes."""
-        # Create embeddings that are similar (same normalized vector)
+
+class TestFindUnlinkedSimilarNotes:
+    """find_unlinked_similar_notes: similarity + link exclusion + kind."""
+
+    def test_empty_embeddings(self) -> None:
+        assert inspire_core.find_unlinked_similar_notes([], {}) == []
+
+    def test_similar_unlinked_pair_is_found(self) -> None:
         embedding = [1.0, 0.0, 0.0]
         note_embeddings = [
             ("note-a", "Note A", embedding),
-            ("note-b", "Note B", embedding),  # Same embedding = 100% similar
+            ("note-b", "Note B", embedding),
         ]
-        existing_links: dict[str, set[str]] = {}
-
         result = inspire_core.find_unlinked_similar_notes(
             note_embeddings=note_embeddings,
-            existing_links=existing_links,
+            existing_links={},
             similarity_threshold=0.7,
         )
 
@@ -129,14 +333,10 @@ class TestCoreInspire:
         assert result[0]["note_b_id"] == "note-b"
         assert result[0]["similarity"] == 1.0
 
-    def test_find_unlinked_similar_notes_excludes_linked(self) -> None:
-        """Test that already linked notes are excluded."""
+    def test_excludes_pair_linked_forward(self) -> None:
         embedding = [1.0, 0.0, 0.0]
-        note_embeddings = [
-            ("note-a", "Note A", embedding),
-            ("note-b", "Note B", embedding),
-        ]
-        existing_links = {"note-a": {"note-b"}}  # Already linked
+        note_embeddings = [("note-a", "Note A", embedding), ("note-b", "Note B", embedding)]
+        existing_links = {"note-a": {"note-b"}}
 
         result = inspire_core.find_unlinked_similar_notes(
             note_embeddings=note_embeddings,
@@ -144,233 +344,724 @@ class TestCoreInspire:
             similarity_threshold=0.7,
         )
 
-        assert len(result) == 0
-
-    def test_find_unlinked_similar_notes_below_threshold(self) -> None:
-        """Test that dissimilar notes are excluded."""
-        note_embeddings = [
-            ("note-a", "Note A", [1.0, 0.0, 0.0]),
-            ("note-b", "Note B", [0.0, 1.0, 0.0]),  # Orthogonal = 0% similar
-        ]
-        existing_links: dict[str, set[str]] = {}
-
-        result = inspire_core.find_unlinked_similar_notes(
-            note_embeddings=note_embeddings,
-            existing_links=existing_links,
-            similarity_threshold=0.7,
-        )
-
-        assert len(result) == 0
-
-    def test_build_inspiration_prompt_gaps_only(self) -> None:
-        """Test prompt building with only gap notes."""
-        gap_notes = [
-            {"title": "Test Note", "content_length": 100, "is_short": True, "has_few_links": False, "link_count": 0, "backlink_count": 0},
-        ]
-        prompt = inspire_core.build_inspiration_prompt(gap_notes, [])
-
-        assert "Knowledge Gaps" in prompt
-        assert "Test Note" in prompt
-        assert "100 chars" in prompt
-
-    def test_build_inspiration_prompt_connections_only(self) -> None:
-        """Test prompt building with only connection opportunities."""
-        connections = [
-            {"note_a_title": "Note A", "note_b_title": "Note B", "similarity": 0.85},
-        ]
-        prompt = inspire_core.build_inspiration_prompt([], connections)
-
-        assert "Connection Opportunities" in prompt
-        assert "Note A" in prompt
-        assert "Note B" in prompt
-        assert "85%" in prompt
-
-    def test_build_inspiration_prompt_empty(self) -> None:
-        """Test prompt building with no data."""
-        prompt = inspire_core.build_inspiration_prompt([], [])
-
-        assert "No significant gaps or opportunities found" in prompt
-
-    def test_parse_inspiration_response_valid_json(self) -> None:
-        """Test parsing valid JSON response."""
-        response = """[
-            {
-                "type": "gap",
-                "title": "Expand: Test Note",
-                "description": "This note needs expansion.",
-                "related_notes": ["test-note"],
-                "action_text": "Edit Note"
-            }
-        ]"""
-        result = inspire_core.parse_inspiration_response(response)
-
-        assert len(result) == 1
-        assert result[0]["type"] == "gap"
-        assert result[0]["title"] == "Expand: Test Note"
-
-    def test_parse_inspiration_response_with_markdown(self) -> None:
-        """Test parsing JSON wrapped in markdown code blocks."""
-        response = """```json
-        [{"type": "gap", "title": "Test", "description": "Test", "related_notes": ["a"], "action_text": "Edit"}]
-        ```"""
-        result = inspire_core.parse_inspiration_response(response)
-
-        assert len(result) == 1
-        assert result[0]["type"] == "gap"
-
-    def test_parse_inspiration_response_invalid_type(self) -> None:
-        """Test that invalid types are filtered out."""
-        response = """[
-            {"type": "invalid", "title": "Test", "description": "Test", "related_notes": ["a"], "action_text": "Edit"}
-        ]"""
-        result = inspire_core.parse_inspiration_response(response)
-
-        assert len(result) == 0
-
-    def test_parse_inspiration_response_missing_fields(self) -> None:
-        """Test that suggestions with missing fields are filtered out."""
-        response = """[{"type": "gap", "title": "Test"}]"""  # Missing required fields
-        result = inspire_core.parse_inspiration_response(response)
-
-        assert len(result) == 0
-
-    def test_parse_inspiration_response_empty(self) -> None:
-        """Test parsing empty response."""
-        result = inspire_core.parse_inspiration_response("")
         assert result == []
 
-    def test_build_fallback_suggestions_gaps(self) -> None:
-        """Test fallback suggestion generation for gaps."""
-        gap_notes = [
-            {"note_id": "test-note", "title": "Test Note", "content_length": 100, "is_short": True, "has_few_links": True, "link_count": 0, "backlink_count": 0},
+    def test_excludes_pair_linked_backward(self) -> None:
+        embedding = [1.0, 0.0, 0.0]
+        note_embeddings = [("note-a", "Note A", embedding), ("note-b", "Note B", embedding)]
+        existing_links = {"note-b": {"note-a"}}
+
+        result = inspire_core.find_unlinked_similar_notes(
+            note_embeddings=note_embeddings,
+            existing_links=existing_links,
+            similarity_threshold=0.7,
+        )
+
+        assert result == []
+
+    def test_below_threshold_excluded(self) -> None:
+        note_embeddings = [
+            ("note-a", "Note A", [1.0, 0.0, 0.0]),
+            ("note-b", "Note B", [0.0, 1.0, 0.0]),
         ]
-        result = inspire_core.build_fallback_suggestions(gap_notes, [], limit=5)
+        result = inspire_core.find_unlinked_similar_notes(
+            note_embeddings=note_embeddings,
+            existing_links={},
+            similarity_threshold=0.7,
+        )
+
+        assert result == []
+
+    def test_high_similarity_high_title_overlap_is_duplicate(self) -> None:
+        embedding = [1.0, 0.0, 0.0]
+        note_embeddings = [
+            ("note-a", "5 Dysfunctions of a Team", embedding),
+            ("note-b", "Five Dysfunctions of a Team", embedding),
+        ]
+        result = inspire_core.find_unlinked_similar_notes(
+            note_embeddings=note_embeddings, existing_links={}
+        )
 
         assert len(result) == 1
-        assert result[0]["type"] == "gap"
-        assert result[0]["title"] == "Expand: Test Note"
-        assert "test-note" in result[0]["related_notes"]
+        assert result[0]["kind"] == "duplicate"
 
-    def test_build_fallback_suggestions_connections(self) -> None:
-        """Test fallback suggestion generation for connections."""
-        connections = [
-            {"note_a_id": "note-a", "note_a_title": "Note A", "note_b_id": "note-b", "note_b_title": "Note B", "similarity": 0.85},
+    def test_high_similarity_low_title_overlap_is_connection(self) -> None:
+        """Same embeddings, unrelated titles: siblings, not duplicates."""
+        embedding = [1.0, 0.0, 0.0]
+        note_embeddings = [
+            ("note-a", "Developer Productivity: People Factors", embedding),
+            ("note-b", "Developer Productivity: Process Factors", embedding),
         ]
-        result = inspire_core.build_fallback_suggestions([], connections, limit=5)
+        result = inspire_core.find_unlinked_similar_notes(
+            note_embeddings=note_embeddings, existing_links={}
+        )
 
         assert len(result) == 1
-        assert result[0]["type"] == "connection"
-        assert "note-a" in result[0]["related_notes"]
-        assert "note-b" in result[0]["related_notes"]
+        assert result[0]["kind"] == "connection"
+
+    def test_respects_limit(self) -> None:
+        embedding = [1.0, 0.0, 0.0]
+        note_embeddings = [(f"note-{i}", f"Note {i}", embedding) for i in range(5)]
+        result = inspire_core.find_unlinked_similar_notes(
+            note_embeddings=note_embeddings, existing_links={}, limit=2
+        )
+
+        assert len(result) == 2
 
 
-class TestInspireAPI:
-    """Integration tests for inspire API endpoints."""
+class TestFindHubOpportunities:
+    """find_hub_opportunities: connected components over similar-pairs."""
 
-    def test_get_suggestions_empty(self, client: TestClient) -> None:
-        """Test getting suggestions with no notes."""
-        response = client.get("/api/inspire/suggestions")
+    def _pair(
+        self, a: str, a_title: str, b: str, b_title: str, similarity: float = 0.9
+    ) -> dict[str, Any]:
+        return {
+            "note_a_id": a,
+            "note_a_title": a_title,
+            "note_b_id": b,
+            "note_b_title": b_title,
+            "similarity": similarity,
+            "title_overlap": 0.0,
+            "kind": "connection",
+        }
 
-        assert response.status_code == 200
-        data = response.json()
-        assert "suggestions" in data
-        assert "generated_at" in data
-        assert "has_llm" in data
+    def test_empty_pairs(self) -> None:
+        assert inspire_core.find_hub_opportunities([]) == []
 
-    def test_get_suggestions_with_notes(
-        self, client: TestClient, admin_headers: dict[str, str]
-    ) -> None:
-        """Test getting suggestions with some notes."""
-        # Create a short note (underdeveloped)
-        client.post(
-            "/api/notes",
-            json={"content": "Short note", "title": "Short"},
-            headers=admin_headers,
+    def test_builds_connected_component_of_three(self) -> None:
+        pairs = [
+            self._pair("a", "A", "b", "B"),
+            self._pair("b", "B", "c", "C"),
+        ]
+        result = inspire_core.find_hub_opportunities(pairs, min_cluster_size=3)
+
+        assert len(result) == 1
+        assert result[0]["note_ids"] == ["a", "b", "c"]
+        assert result[0]["size"] == 3
+
+    def test_below_min_cluster_size_excluded(self) -> None:
+        pairs = [self._pair("d", "D", "e", "E")]
+        result = inspire_core.find_hub_opportunities(pairs, min_cluster_size=3)
+
+        assert result == []
+
+    def test_largest_cluster_first(self) -> None:
+        pairs = [
+            # cluster of 3: a-b-c
+            self._pair("a", "A", "b", "B"),
+            self._pair("b", "B", "c", "C"),
+            # cluster of 4: w-x-y-z
+            self._pair("w", "W", "x", "X"),
+            self._pair("x", "X", "y", "Y"),
+            self._pair("y", "Y", "z", "Z"),
+        ]
+        result = inspire_core.find_hub_opportunities(pairs, min_cluster_size=3)
+
+        assert [r["size"] for r in result] == [4, 3]
+
+    def test_deterministic_ordering(self) -> None:
+        pairs = [
+            self._pair("c", "C", "a", "A"),
+            self._pair("a", "A", "b", "B"),
+        ]
+        result = inspire_core.find_hub_opportunities(pairs, min_cluster_size=3)
+
+        assert result[0]["note_ids"] == ["a", "b", "c"]
+
+    def test_respects_limit(self) -> None:
+        pairs = []
+        # Three independent clusters of 3
+        for group in (("a1", "a2", "a3"), ("b1", "b2", "b3"), ("c1", "c2", "c3")):
+            pairs.append(self._pair(group[0], group[0], group[1], group[1]))
+            pairs.append(self._pair(group[1], group[1], group[2], group[2]))
+
+        result = inspire_core.find_hub_opportunities(pairs, min_cluster_size=3, limit=1)
+
+        assert len(result) == 1
+
+
+class TestFindUncoveredTagClusters:
+    """find_uncovered_tag_clusters: tag frequency vs. article coverage."""
+
+    def test_empty(self) -> None:
+        assert inspire_core.find_uncovered_tag_clusters([], []) == []
+
+    def test_uncovered_tag_with_enough_notes_is_returned(self) -> None:
+        notes = [_note(f"note-{i}", tags=["leadership"]) for i in range(4)]
+        result = inspire_core.find_uncovered_tag_clusters(notes, [], min_notes=4)
+
+        assert len(result) == 1
+        assert result[0]["tag"] == "leadership"
+        assert result[0]["note_count"] == 4
+
+    def test_below_min_notes_excluded(self) -> None:
+        notes = [_note(f"note-{i}", tags=["leadership"]) for i in range(3)]
+        result = inspire_core.find_uncovered_tag_clusters(notes, [], min_notes=4)
+
+        assert result == []
+
+    def test_covered_tag_is_excluded(self) -> None:
+        notes = [_note(f"note-{i}", tags=["leadership"]) for i in range(4)]
+        articles = [{"id": "article-1", "tags": ["leadership"]}]
+
+        result = inspire_core.find_uncovered_tag_clusters(notes, articles, min_notes=4)
+
+        assert result == []
+
+    def test_tag_casing_normalized_on_both_sides(self) -> None:
+        notes = [_note(f"note-{i}", tags=["Leadership"]) for i in range(4)]
+        articles = [{"id": "article-1", "tags": ["leadership"]}]
+
+        result = inspire_core.find_uncovered_tag_clusters(notes, articles, min_notes=4)
+
+        assert result == []
+
+    def test_respects_limit(self) -> None:
+        notes: list[dict[str, Any]] = []
+        for tag_num in range(5):
+            notes.extend(
+                _note(f"note-{tag_num}-{i}", tags=[f"tag-{tag_num}"]) for i in range(4)
+            )
+        result = inspire_core.find_uncovered_tag_clusters(notes, [], min_notes=4, limit=2)
+
+        assert len(result) == 2
+
+
+class TestComposeCandidates:
+    """compose_candidates: round-robin interleaving across types."""
+
+    def test_limit_zero_or_negative_returns_empty(self) -> None:
+        candidates = {"orphan": [{"note_id": "a"}]}
+        assert inspire_core.compose_candidates(candidates, limit=0) == []
+        assert inspire_core.compose_candidates(candidates, limit=-1) == []
+
+    def test_no_single_type_dominates(self) -> None:
+        candidates = {
+            "orphan": [{"note_id": f"orphan-{i}"} for i in range(10)],
+            "duplicate": [{"note_a_id": "d1", "note_b_id": "d2"}],
+        }
+        result = inspire_core.compose_candidates(candidates, limit=5)
+
+        assert len(result) == 5
+        types = [item["type"] for item in result]
+        assert "duplicate" in types
+        assert types != ["orphan"] * 5
+
+    def test_offset_changes_ordering(self) -> None:
+        candidates = {"orphan": [{"note_id": f"orphan-{i}"} for i in range(5)]}
+
+        result_a = inspire_core.compose_candidates(candidates, limit=5, offset=0)
+        result_b = inspire_core.compose_candidates(candidates, limit=5, offset=2)
+
+        ids_a = [item["data"]["note_id"] for item in result_a]
+        ids_b = [item["data"]["note_id"] for item in result_b]
+        assert ids_a != ids_b
+
+    def test_empty_candidates_returns_empty(self) -> None:
+        assert inspire_core.compose_candidates({}, limit=5) == []
+
+    def test_stops_when_all_types_exhausted(self) -> None:
+        candidates = {"orphan": [{"note_id": "only-one"}]}
+        result = inspire_core.compose_candidates(candidates, limit=10)
+
+        assert len(result) == 1
+
+
+class TestComputeKbFingerprint:
+    """compute_kb_fingerprint: stable, order-independent, change-sensitive."""
+
+    def test_stable_regardless_of_list_order(self) -> None:
+        notes = [
+            _note("a", content_length=100, link_count=1, backlink_count=0),
+            _note("b", content_length=200, link_count=0, backlink_count=2),
+        ]
+        articles = [{"id": "article-1"}, {"id": "article-2"}]
+
+        fp1 = inspire_core.compute_kb_fingerprint(notes, articles)
+        fp2 = inspire_core.compute_kb_fingerprint(list(reversed(notes)), list(reversed(articles)))
+
+        assert fp1 == fp2
+
+    def test_changes_when_content_length_changes(self) -> None:
+        notes_a = [_note("a", content_length=100)]
+        notes_b = [_note("a", content_length=101)]
+
+        assert inspire_core.compute_kb_fingerprint(
+            notes_a, []
+        ) != inspire_core.compute_kb_fingerprint(notes_b, [])
+
+    def test_changes_when_link_counts_change(self) -> None:
+        notes_a = [_note("a", link_count=0, backlink_count=0)]
+        notes_b = [_note("a", link_count=1, backlink_count=0)]
+
+        assert inspire_core.compute_kb_fingerprint(
+            notes_a, []
+        ) != inspire_core.compute_kb_fingerprint(notes_b, [])
+
+    def test_empty_input_is_stable(self) -> None:
+        assert inspire_core.compute_kb_fingerprint([], []) == inspire_core.compute_kb_fingerprint(
+            [], []
+        )
+
+
+class TestParseInspirationResponse:
+    """parse_inspiration_response: tolerant JSON parsing + validation."""
+
+    VALID_ITEM = (
+        '{"type": "orphan", "title": "Test", "description": "Test", '
+        '"related_notes": ["a"], "action_text": "Edit"}'
+    )
+
+    def test_valid_json_array(self) -> None:
+        result = inspire_core.parse_inspiration_response(f"[{self.VALID_ITEM}]")
+
+        assert len(result) == 1
+        assert result[0]["type"] == "orphan"
+
+    def test_markdown_fenced(self) -> None:
+        response = f"```json\n[{self.VALID_ITEM}]\n```"
+        result = inspire_core.parse_inspiration_response(response)
+
+        assert len(result) == 1
+
+    def test_json_wrapped_in_prose_on_both_sides(self) -> None:
+        response = f"Sure! Here you go:\n[{self.VALID_ITEM}]\nHope that helps!"
+        result = inspire_core.parse_inspiration_response(response)
+
+        assert len(result) == 1
+        assert result[0]["type"] == "orphan"
+
+    def test_brackets_inside_string_values_do_not_break_extraction(self) -> None:
+        item = (
+            '{"type": "orphan", "title": "Test [1]", '
+            '"description": "See [related] notes for context", '
+            '"related_notes": ["a"], "action_text": "Edit"}'
+        )
+        response = f"Preamble text\n[{item}]\nTrailing text"
+        result = inspire_core.parse_inspiration_response(response)
+
+        assert len(result) == 1
+        assert result[0]["title"] == "Test [1]"
+
+    def test_invalid_type_rejected(self) -> None:
+        item = (
+            '{"type": "invalid", "title": "Test", "description": "Test", '
+            '"related_notes": ["a"], "action_text": "Edit"}'
+        )
+        result = inspire_core.parse_inspiration_response(f"[{item}]")
+
+        assert result == []
+
+    def test_missing_required_fields_rejected(self) -> None:
+        result = inspire_core.parse_inspiration_response('[{"type": "orphan", "title": "Test"}]')
+
+        assert result == []
+
+    def test_non_list_related_notes_rejected(self) -> None:
+        item = (
+            '{"type": "orphan", "title": "Test", "description": "Test", '
+            '"related_notes": "not-a-list", "action_text": "Edit"}'
+        )
+        result = inspire_core.parse_inspiration_response(f"[{item}]")
+
+        assert result == []
+
+    def test_empty_input_returns_empty_list(self) -> None:
+        assert inspire_core.parse_inspiration_response("") == []
+
+    def test_single_object_wrapped_as_list(self) -> None:
+        result = inspire_core.parse_inspiration_response(self.VALID_ITEM)
+
+        assert len(result) == 1
+
+    def test_unparseable_garbage_returns_empty_list(self) -> None:
+        assert inspire_core.parse_inspiration_response("not json at all") == []
+
+
+class TestBuildInspirationPrompt:
+    """build_inspiration_prompt: includes candidate data and guardrails."""
+
+    def test_includes_candidate_titles_and_ids(self) -> None:
+        composed = [
+            {
+                "type": "orphan",
+                "data": {"note_id": "lonely-note", "title": "Lonely Note"},
+            }
+        ]
+        prompt = inspire_core.build_inspiration_prompt(composed)
+
+        assert "Lonely Note" in prompt
+        assert "lonely-note" in prompt
+
+    def test_forbids_lengthening_notes(self) -> None:
+        prompt = inspire_core.build_inspiration_prompt([])
+
+        assert "never suggest making a note longer" in prompt.lower()
+
+    def test_empty_composed_still_produces_prompt(self) -> None:
+        prompt = inspire_core.build_inspiration_prompt([])
+
+        assert "No opportunities found." in prompt
+
+
+class TestBuildFallbackSuggestions:
+    """build_fallback_suggestions: templated suggestions, no LLM required."""
+
+    REQUIRED_FIELDS = {"type", "title", "description", "related_notes", "action_text"}
+
+    def _composed_for_every_type(self) -> list[dict[str, Any]]:
+        data_by_type: dict[str, dict[str, Any]] = {
+            "orphan": {"note_id": "n1", "title": "Orphan Note"},
+            "duplicate": {
+                "note_a_id": "n1",
+                "note_a_title": "Note A",
+                "note_b_id": "n2",
+                "note_b_title": "Note B",
+                "similarity": 0.9,
+            },
+            "connection": {
+                "note_a_id": "n1",
+                "note_a_title": "Note A",
+                "note_b_id": "n2",
+                "note_b_title": "Note B",
+                "similarity": 0.75,
+            },
+            "hub": {
+                "note_ids": ["n1", "n2", "n3"],
+                "titles": ["Note A", "Note B", "Note C"],
+                "size": 3,
+            },
+            "promote": {"note_id": "n1", "title": "Popular Note", "backlink_count": 8},
+            "split": {"note_id": "n1", "title": "Long Note", "content_length": 2000},
+            "article": {
+                "tag": "leadership",
+                "note_count": 5,
+                "note_ids": ["n1", "n2"],
+                "titles": ["Note A", "Note B"],
+            },
+        }
+        return [
+            {"type": suggestion_type, "data": data_by_type[suggestion_type]}
+            for suggestion_type in inspire_core.SUGGESTION_TYPES
+        ]
+
+    def test_produces_suggestion_for_every_type(self) -> None:
+        composed = self._composed_for_every_type()
+        result = inspire_core.build_fallback_suggestions(
+            composed, limit=len(inspire_core.SUGGESTION_TYPES)
+        )
+
+        result_types = {item["type"] for item in result}
+        assert result_types == set(inspire_core.SUGGESTION_TYPES)
+
+    def test_every_suggestion_has_required_fields(self) -> None:
+        composed = self._composed_for_every_type()
+        result = inspire_core.build_fallback_suggestions(
+            composed, limit=len(inspire_core.SUGGESTION_TYPES)
+        )
+
+        for suggestion in result:
+            assert self.REQUIRED_FIELDS.issubset(suggestion.keys())
+
+    def test_respects_limit(self) -> None:
+        composed = self._composed_for_every_type()
+        result = inspire_core.build_fallback_suggestions(composed, limit=3)
+
+        assert len(result) == 3
+
+    def test_no_suggestion_asks_to_expand_or_lengthen(self) -> None:
+        """Regression guard for #259: fallback text must never ask for more content."""
+        composed = self._composed_for_every_type()
+        result = inspire_core.build_fallback_suggestions(
+            composed, limit=len(inspire_core.SUGGESTION_TYPES)
+        )
+
+        for suggestion in result:
+            description = suggestion["description"].lower()
+            assert "expand" not in description
+            assert "add more content" not in description
+
+
+class TestSanitizeSuggestions:
+    """sanitize_suggestions: the LLM is trusted for wording only."""
+
+    COMPOSED: list[dict[str, Any]] = [
+        {"type": "orphan", "data": {"note_id": "lonely-note", "title": "Lonely"}},
+        {
+            "type": "promote",
+            "data": {"note_id": "popular-note", "title": "Popular", "backlink_count": 8},
+        },
+        {
+            "type": "article",
+            "data": {
+                "tag": "sre",
+                "note_count": 6,
+                "note_ids": ["golden-signals", "error-budgets"],
+                "titles": ["Golden Signals", "Error Budgets"],
+            },
+        },
+    ]
+
+    def _suggestion(self, **overrides: Any) -> dict[str, Any]:
+        base = {
+            "type": "orphan",
+            "title": "A title",
+            "description": "A description",
+            "related_notes": ["lonely-note"],
+            "action_text": "Do It",
+        }
+        base.update(overrides)
+        return base
+
+    def test_keeps_valid_note_ids(self) -> None:
+        result = inspire_core.sanitize_suggestions([self._suggestion()], self.COMPOSED)
+
+        assert len(result) == 1
+        assert result[0]["related_notes"] == ["lonely-note"]
+
+    def test_drops_hallucinated_note_ids(self) -> None:
+        suggestion = self._suggestion(related_notes=["lonely-note", "does-not-exist"])
+        result = inspire_core.sanitize_suggestions([suggestion], self.COMPOSED)
+
+        assert result[0]["related_notes"] == ["lonely-note"]
+
+    def test_drops_suggestion_with_no_valid_ids(self) -> None:
+        """The LLM echoing a tag name where note IDs belong must not survive."""
+        suggestion = self._suggestion(type="article", related_notes=["sre"])
+        result = inspire_core.sanitize_suggestions([suggestion], self.COMPOSED)
+
+        assert result == []
+
+    def test_corrects_mislabelled_type(self) -> None:
+        """A promote finding tagged 'hub' by the LLM is retyped from the analysis."""
+        suggestion = self._suggestion(type="hub", related_notes=["popular-note"])
+        result = inspire_core.sanitize_suggestions([suggestion], self.COMPOSED)
+
+        assert result[0]["type"] == "promote"
+
+    def test_matches_multi_note_candidate(self) -> None:
+        suggestion = self._suggestion(
+            type="connection", related_notes=["golden-signals", "error-budgets"]
+        )
+        result = inspire_core.sanitize_suggestions([suggestion], self.COMPOSED)
+
+        assert result[0]["type"] == "article"
+        assert result[0]["related_notes"] == ["golden-signals", "error-budgets"]
+
+    def test_preserves_wording(self) -> None:
+        """Sanitizing must not touch the text the LLM was actually useful for."""
+        suggestion = self._suggestion(title="Nicely phrased", description="Well argued.")
+        result = inspire_core.sanitize_suggestions([suggestion], self.COMPOSED)
+
+        assert result[0]["title"] == "Nicely phrased"
+        assert result[0]["description"] == "Well argued."
+
+    def test_empty_composed_drops_everything(self) -> None:
+        result = inspire_core.sanitize_suggestions([self._suggestion()], [])
+
+        assert result == []
+
+
+class TestCandidateNoteIds:
+    """candidate_note_ids: extracting IDs from each candidate shape."""
+
+    def test_single_note_candidate(self) -> None:
+        assert inspire_core.candidate_note_ids({"note_id": "n1"}) == ["n1"]
+
+    def test_pair_candidate(self) -> None:
+        result = inspire_core.candidate_note_ids({"note_a_id": "n1", "note_b_id": "n2"})
+
+        assert set(result) == {"n1", "n2"}
+
+    def test_cluster_candidate(self) -> None:
+        result = inspire_core.candidate_note_ids({"note_ids": ["n1", "n2", "n3"]})
+
+        assert set(result) == {"n1", "n2", "n3"}
+
+    def test_candidate_without_ids(self) -> None:
+        assert inspire_core.candidate_note_ids({"tag": "sre"}) == []
+
+
+# ============================================================================
+# Endpoint integration tests: routers/inspire.py
+# ============================================================================
+
+
+class TestSuggestionsEndpoint:
+    """Integration tests for GET /api/inspire/suggestions."""
+
+    def test_empty_kb(self, client: TestClient) -> None:
+        _override_dependencies(
+            notes_service=FakeNotesService(), llm=FakeLLM(available=False), articles=[]
         )
 
         response = client.get("/api/inspire/suggestions")
 
         assert response.status_code == 200
         data = response.json()
-        assert isinstance(data["suggestions"], list)
-        # May or may not have suggestions depending on thresholds
+        assert data["suggestions"] == []
+        assert data["has_llm"] is False
 
-    def test_get_knowledge_gaps_empty(self, client: TestClient) -> None:
-        """Test getting gaps with no notes."""
+    def test_with_notes_and_working_llm(self, client: TestClient) -> None:
+        notes = [_note("orphan-1", title="Orphan One", content_length=200)]
+        llm_response = (
+            '[{"type": "orphan", "title": "Connect: Orphan One", '
+            '"description": "Add a link.", "related_notes": ["orphan-1"], '
+            '"action_text": "Connect Note"}]'
+        )
+        _override_dependencies(
+            notes_service=FakeNotesService(notes_with_stats=notes),
+            llm=FakeLLM(available=True, response=llm_response),
+            articles=[],
+        )
+
+        response = client.get("/api/inspire/suggestions")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["has_llm"] is True
+        assert len(data["suggestions"]) == 1
+        assert data["suggestions"][0]["type"] == "orphan"
+
+    def test_limit_honored(self, client: TestClient) -> None:
+        notes = [_note(f"orphan-{i}", content_length=100 + i) for i in range(10)]
+        _override_dependencies(
+            notes_service=FakeNotesService(notes_with_stats=notes),
+            llm=FakeLLM(available=False),
+            articles=[],
+        )
+
+        response = client.get("/api/inspire/suggestions?limit=2")
+
+        assert response.status_code == 200
+        assert len(response.json()["suggestions"]) <= 2
+
+    def test_refresh_returns_different_slice(self, client: TestClient) -> None:
+        notes = [_note(f"orphan-{i}", content_length=100 + i) for i in range(5)]
+        _override_dependencies(
+            notes_service=FakeNotesService(notes_with_stats=notes),
+            llm=FakeLLM(available=False),
+            articles=[],
+        )
+
+        first = client.get("/api/inspire/suggestions?limit=1")
+        second = client.get("/api/inspire/suggestions?limit=1&refresh=true")
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        first_ids = first.json()["suggestions"][0]["related_notes"]
+        second_ids = second.json()["suggestions"][0]["related_notes"]
+        assert first_ids != second_ids
+
+    def test_second_identical_call_is_cached(self, client: TestClient) -> None:
+        notes = [_note("orphan-1", content_length=100)]
+        _override_dependencies(
+            notes_service=FakeNotesService(notes_with_stats=notes),
+            llm=FakeLLM(available=False),
+            articles=[],
+        )
+
+        first = client.get("/api/inspire/suggestions?limit=1")
+        second = client.get("/api/inspire/suggestions?limit=1")
+
+        assert first.json()["cached"] is False
+        assert second.json()["cached"] is True
+
+    def test_llm_exception_falls_back_to_templated_suggestions(
+        self, client: TestClient
+    ) -> None:
+        notes = [_note("orphan-1", content_length=100)]
+        _override_dependencies(
+            notes_service=FakeNotesService(notes_with_stats=notes),
+            llm=FakeLLM(available=True, raise_error=True),
+            articles=[],
+        )
+
+        response = client.get("/api/inspire/suggestions")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["has_llm"] is False
+        assert len(data["suggestions"]) >= 1
+
+    def test_llm_garbage_response_falls_back_to_templated_suggestions(
+        self, client: TestClient
+    ) -> None:
+        notes = [_note("orphan-1", content_length=100)]
+        _override_dependencies(
+            notes_service=FakeNotesService(notes_with_stats=notes),
+            llm=FakeLLM(available=True, response="not valid json at all"),
+            articles=[],
+        )
+
+        response = client.get("/api/inspire/suggestions")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["has_llm"] is False
+        assert len(data["suggestions"]) >= 1
+
+
+class TestGapsEndpoint:
+    """Integration tests for GET /api/inspire/gaps."""
+
+    def test_returns_expected_keys(self, client: TestClient) -> None:
+        _override_dependencies(notes_service=FakeNotesService(), articles=[])
+
         response = client.get("/api/inspire/gaps")
 
         assert response.status_code == 200
         data = response.json()
-        assert data["gaps"] == []
+        assert "orphans" in data
+        assert "oversized" in data
+        assert "promotable" in data
+        assert "uncovered_topics" in data
         assert data["count"] == 0
 
-    def test_get_knowledge_gaps_with_short_note(
-        self, client: TestClient, admin_headers: dict[str, str]
-    ) -> None:
-        """Test getting gaps with a short note."""
-        # Create a short note
-        client.post(
-            "/api/notes",
-            json={"content": "Short", "title": "Short Note"},
-            headers=admin_headers,
-        )
+    def test_populated_kb(self, client: TestClient) -> None:
+        notes = [
+            _note("orphan-1", content_length=200, link_count=0, backlink_count=0),
+            _note("oversized-1", content_length=1500),
+            _note("popular-1", backlink_count=6),
+        ]
+        _override_dependencies(notes_service=FakeNotesService(notes_with_stats=notes), articles=[])
 
-        response = client.get("/api/inspire/gaps?min_content_length=100")
+        response = client.get("/api/inspire/gaps")
 
         assert response.status_code == 200
         data = response.json()
-        assert data["count"] >= 1
-        # First gap should be our short note
-        assert any(gap["title"] == "Short Note" for gap in data["gaps"])
+        assert any(o["note_id"] == "orphan-1" for o in data["orphans"])
+        assert any(o["note_id"] == "oversized-1" for o in data["oversized"])
+        assert any(o["note_id"] == "popular-1" for o in data["promotable"])
 
-    def test_get_knowledge_gaps_custom_thresholds(self, client: TestClient) -> None:
-        """Test getting gaps with custom thresholds."""
-        response = client.get("/api/inspire/gaps?min_content_length=1000&max_links=5&limit=5")
 
-        assert response.status_code == 200
-        data = response.json()
-        assert data["min_content_length"] == 1000
-        assert data["max_links"] == 5
+class TestConnectionsEndpoint:
+    """Integration tests for GET /api/inspire/connections."""
 
-    def test_get_connection_opportunities_empty(self, client: TestClient) -> None:
-        """Test getting connections with no notes."""
+    def test_returns_expected_keys(self, client: TestClient) -> None:
+        _override_dependencies(notes_service=FakeNotesService())
+
         response = client.get("/api/inspire/connections")
 
         assert response.status_code == 200
         data = response.json()
-        assert data["connections"] == []
+        assert "connections" in data
+        assert "duplicates" in data
+        assert "hubs" in data
         assert data["count"] == 0
 
-    def test_get_connection_opportunities_custom_threshold(
-        self, client: TestClient
-    ) -> None:
-        """Test getting connections with custom similarity threshold."""
-        response = client.get("/api/inspire/connections?similarity_threshold=0.9&limit=5")
+    def test_populated_kb(self, client: TestClient) -> None:
+        embedding = [1.0, 0.0, 0.0]
+        notes_with_embeddings = [
+            {"id": "note-a", "title": "5 Dysfunctions of a Team", "embedding": embedding},
+            {"id": "note-b", "title": "Five Dysfunctions of a Team", "embedding": embedding},
+        ]
+        _override_dependencies(
+            notes_service=FakeNotesService(notes_with_embeddings=notes_with_embeddings)
+        )
+
+        response = client.get("/api/inspire/connections")
 
         assert response.status_code == 200
         data = response.json()
-        assert data["similarity_threshold"] == 0.9
-
-    def test_suggestions_limit_parameter(self, client: TestClient) -> None:
-        """Test that limit parameter is respected."""
-        response = client.get("/api/inspire/suggestions?limit=2")
-
-        assert response.status_code == 200
-        data = response.json()
-        assert len(data["suggestions"]) <= 2
-
-    def test_gaps_limit_parameter(self, client: TestClient) -> None:
-        """Test that limit parameter is respected for gaps."""
-        response = client.get("/api/inspire/gaps?limit=3")
-
-        assert response.status_code == 200
-        data = response.json()
-        assert len(data["gaps"]) <= 3
-
-    def test_connections_limit_parameter(self, client: TestClient) -> None:
-        """Test that limit parameter is respected for connections."""
-        response = client.get("/api/inspire/connections?limit=3")
-
-        assert response.status_code == 200
-        data = response.json()
-        assert len(data["connections"]) <= 3
+        assert len(data["duplicates"]) == 1

--- a/frontend/src/app/knowledge-base/inspire/page.module.scss
+++ b/frontend/src/app/knowledge-base/inspire/page.module.scss
@@ -237,7 +237,12 @@
   display: flex;
   flex-direction: column;
 
-  &.gap {
+  // Two visual families rather than one per suggestion type: colour encodes
+  // whether the card is asking you to repair something or to build something,
+  // and the badge label carries the specific kind (#259).
+
+  // Repair: orphaned, duplicated, or oversized notes
+  &.fix {
     border-left: 4px solid $color-orphan-text;
 
     .typeBadge {
@@ -254,7 +259,8 @@
     }
   }
 
-  &.connection {
+  // Build: links, hubs, articles - additive work
+  &.build {
     border-left: 4px solid $color-hub-text;
 
     .typeBadge {
@@ -399,5 +405,14 @@
       font-size: $font-size-sm;
       color: $color-text-secondary;
     }
+  }
+
+  .helpFootnote {
+    margin: $spacing-4 0 0;
+    padding-top: $spacing-3;
+    border-top: 1px solid $neutral-200;
+    font-size: $font-size-sm;
+    font-style: italic;
+    color: $color-text-tertiary;
   }
 }

--- a/frontend/src/app/knowledge-base/inspire/page.tsx
+++ b/frontend/src/app/knowledge-base/inspire/page.tsx
@@ -1,16 +1,19 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
-import { NotePencil, LinkSimple, Sparkle } from "@phosphor-icons/react";
-import Link from "next/link";
+import { useState, useEffect, useCallback, useRef } from "react";
 import {
-  getSuggestions,
-  getKnowledgeGaps,
-  getConnectionOpportunities,
-  Suggestion,
-  GapNote,
-  ConnectionOpportunity,
-} from "@/lib/api/inspire";
+  ArrowsMerge,
+  ArrowUpRight,
+  Article,
+  LinkSimple,
+  Path,
+  PlugsConnected,
+  Scissors,
+  Sparkle,
+  TreeStructure,
+} from "@phosphor-icons/react";
+import Link from "next/link";
+import { getSuggestions, Suggestion, SuggestionType } from "@/lib/api/inspire";
 import { logger } from "@/lib/logger";
 import Breadcrumb from "@/components/Breadcrumb";
 import { LoadingState, ErrorState } from "@/components/PageState";
@@ -18,80 +21,108 @@ import styles from "./page.module.scss";
 
 type LoadingPhase = "initial" | "fast-data" | "ai-enhancing" | "complete";
 
+/** How each suggestion type is labelled and routed. */
+const TYPE_CONFIG: Record<
+  SuggestionType,
+  { label: string; family: "fix" | "build"; href: (s: Suggestion) => string }
+> = {
+  orphan: {
+    label: "Orphan",
+    family: "fix",
+    href: (s) => `/knowledge-base/notes/${s.related_notes[0]}/edit`,
+  },
+  duplicate: {
+    label: "Duplicate",
+    family: "fix",
+    href: (s) => `/knowledge-base/notes/${s.related_notes[0]}`,
+  },
+  split: {
+    label: "Too broad",
+    family: "fix",
+    href: (s) => `/knowledge-base/notes/${s.related_notes[0]}/edit`,
+  },
+  connection: {
+    label: "Connection",
+    family: "build",
+    href: (s) => `/knowledge-base/notes/${s.related_notes[0]}/edit`,
+  },
+  hub: {
+    label: "Hub",
+    family: "build",
+    // Prefill a hub note with wikilinks to every note in the cluster
+    href: (s) =>
+      `/knowledge-base/notes/new?content=${encodeURIComponent(
+        s.related_notes.map((id) => `- [[${id}]]`).join("\n")
+      )}`,
+  },
+  promote: {
+    label: "Promote note",
+    family: "build",
+    href: (s) => `/knowledge-base/notes/${s.related_notes[0]}`,
+  },
+  article: {
+    label: "Uncovered topic",
+    family: "build",
+    href: (s) => `/knowledge-base/notes/${s.related_notes[0]}`,
+  },
+};
+
+const TYPE_ICONS: Record<SuggestionType, React.ReactNode> = {
+  orphan: <PlugsConnected size={14} aria-hidden="true" />,
+  duplicate: <ArrowsMerge size={14} aria-hidden="true" />,
+  split: <Scissors size={14} aria-hidden="true" />,
+  connection: <LinkSimple size={14} aria-hidden="true" />,
+  hub: <TreeStructure size={14} aria-hidden="true" />,
+  promote: <ArrowUpRight size={14} aria-hidden="true" />,
+  article: <Article size={14} aria-hidden="true" />,
+};
+
+const SUGGESTION_LIMIT = 6;
+
 export default function InspirePage() {
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [loadingPhase, setLoadingPhase] = useState<LoadingPhase>("initial");
   const [error, setError] = useState<string | null>(null);
   const [hasLlm, setHasLlm] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
+  // Distinguishes "AI was asked and failed" from "AI was never asked"
+  const [llmFailed, setLlmFailed] = useState(false);
+  const hasLoaded = useRef(false);
 
-  // Convert raw data to suggestion format for quick display
-  const buildQuickSuggestions = useCallback(
-    (gaps: GapNote[], connections: ConnectionOpportunity[]): Suggestion[] => {
-      const quickSuggestions: Suggestion[] = [];
-
-      // Add gap suggestions
-      gaps.slice(0, 3).forEach((gap) => {
-        quickSuggestions.push({
-          type: "gap",
-          title: gap.title || gap.note_id,
-          description: `This note is ${gap.is_short ? "short" : ""}${gap.is_short && gap.has_few_links ? " and " : ""}${gap.has_few_links ? "has few connections" : ""}. Consider expanding it.`,
-          related_notes: [gap.note_id],
-          action_text: "Expand Note",
-        });
-      });
-
-      // Add connection suggestions
-      connections.slice(0, 3).forEach((conn) => {
-        quickSuggestions.push({
-          type: "connection",
-          title: `Link ${conn.note_a_title || conn.note_a_id} ↔ ${conn.note_b_title || conn.note_b_id}`,
-          description: `These notes are ${Math.round(conn.similarity * 100)}% similar but not linked.`,
-          related_notes: [conn.note_a_id, conn.note_b_id],
-          action_text: "View Note",
-        });
-      });
-
-      return quickSuggestions;
-    },
-    []
-  );
-
-  const fetchSuggestions = useCallback(async () => {
+  const fetchSuggestions = useCallback(async (refresh: boolean) => {
     setError(null);
+    setLlmFailed(false);
 
-    // Phase 1: Quickly fetch raw data (no LLM)
-    setLoadingPhase("fast-data");
     try {
-      const [gapsResponse, connectionsResponse] = await Promise.all([
-        getKnowledgeGaps(500, 1, 5),
-        getConnectionOpportunities(0.7, 5),
-      ]);
+      // Phase 1: templated wording, no LLM - paints immediately
+      setLoadingPhase("fast-data");
+      const fast = await getSuggestions(SUGGESTION_LIMIT, { refresh, skipLlm: true });
+      setSuggestions(fast.suggestions);
+      setHasLlm(false);
+      logger.info("Templated suggestions ready", { count: fast.suggestions.length });
 
-      // Show quick suggestions immediately
-      const quickSuggestions = buildQuickSuggestions(
-        gapsResponse.gaps,
-        connectionsResponse.connections
-      );
-      setSuggestions(quickSuggestions);
-      logger.info("Quick suggestions ready", { count: quickSuggestions.length });
-
-      // Phase 2: Fetch AI-enhanced suggestions
-      if (quickSuggestions.length > 0) {
+      // Phase 2: same findings, phrased by the LLM
+      if (fast.suggestions.length > 0) {
         setLoadingPhase("ai-enhancing");
         try {
-          const aiResponse = await getSuggestions(6);
-          if (aiResponse.suggestions.length > 0) {
-            setSuggestions(aiResponse.suggestions);
-            setHasLlm(aiResponse.has_llm);
-            logger.info("AI suggestions ready", {
-              count: aiResponse.suggestions.length,
-              hasLlm: aiResponse.has_llm,
-            });
+          const enhanced = await getSuggestions(SUGGESTION_LIMIT, { refresh });
+          if (enhanced.suggestions.length > 0) {
+            setSuggestions(enhanced.suggestions);
           }
+          // Always reflect reality - a stale "AI-powered" badge over templated
+          // output was the bug in #259
+          setHasLlm(enhanced.has_llm);
+          setLlmFailed(!enhanced.has_llm);
+          logger.info("Suggestions finalized", {
+            count: enhanced.suggestions.length,
+            hasLlm: enhanced.has_llm,
+            cached: enhanced.cached,
+          });
         } catch (aiErr) {
-          // AI failed but we still have quick suggestions, just log it
-          logger.warn("AI enhancement failed, keeping quick suggestions", aiErr);
+          // Keep the templated suggestions, but say so
+          setHasLlm(false);
+          setLlmFailed(true);
+          logger.warn("AI phrasing failed, keeping templated suggestions", aiErr);
         }
       }
 
@@ -102,15 +133,17 @@ export default function InspirePage() {
       setLoadingPhase("complete");
       logger.error("Failed to load suggestions", err);
     }
-  }, [buildQuickSuggestions]);
+  }, []);
 
   useEffect(() => {
-    fetchSuggestions();
+    if (hasLoaded.current) return;
+    hasLoaded.current = true;
+    fetchSuggestions(false);
   }, [fetchSuggestions]);
 
   const handleRefresh = async () => {
     setRefreshing(true);
-    await fetchSuggestions();
+    await fetchSuggestions(true);
     setRefreshing(false);
   };
 
@@ -159,18 +192,22 @@ export default function InspirePage() {
 
       <main className={styles.main}>
         {/* AI Status */}
-        <div className={styles.aiStatus}>
+        <div className={styles.aiStatus} role="status">
           {loadingPhase === "ai-enhancing" ? (
             <span className={styles.aiLoading}>
               <span className={styles.spinner}></span>
-              AI is enhancing suggestions...
+              AI is phrasing suggestions...
             </span>
           ) : hasLlm ? (
             <span className={styles.aiEnabled}>
               <Sparkle size={14} aria-hidden="true" /> AI-powered suggestions
             </span>
+          ) : llmFailed ? (
+            <span className={styles.aiDisabled}>
+              AI unavailable — showing the same findings in standard wording
+            </span>
           ) : loadingPhase === "complete" ? (
-            <span className={styles.aiDisabled}>Basic suggestions (AI unavailable)</span>
+            <span className={styles.aiDisabled}>Standard suggestions</span>
           ) : (
             <span className={styles.aiLoading}>Loading suggestions...</span>
           )}
@@ -182,7 +219,8 @@ export default function InspirePage() {
             <div className={styles.emptyIcon}>🎉</div>
             <h3 className={styles.emptyTitle}>Your knowledge base looks great!</h3>
             <p className={styles.emptyMessage}>
-              No suggestions right now. Keep adding notes and links to grow your knowledge graph.
+              No orphaned notes, duplicates, or uncovered topics right now. Keep adding notes and
+              links to grow your knowledge graph.
             </p>
             <Link href="/knowledge-base/notes/new" className={styles.createButton}>
               Create New Note
@@ -193,52 +231,53 @@ export default function InspirePage() {
         {/* Suggestions Grid */}
         {suggestions.length > 0 && (
           <div className={styles.suggestionsGrid}>
-            {suggestions.map((suggestion, index) => (
-              <div key={index} className={`${styles.suggestionCard} ${styles[suggestion.type]}`}>
-                <div className={styles.cardHeader}>
-                  <span className={styles.typeBadge}>
-                    {suggestion.type === "gap" ? "Gap" : "Connection"}
-                  </span>
-                </div>
+            {suggestions.map((suggestion, index) => {
+              const config = TYPE_CONFIG[suggestion.type];
+              // Defend against an unrecognized type from the LLM
+              if (!config) return null;
 
-                <h3 className={styles.cardTitle}>{suggestion.title}</h3>
-                <p className={styles.cardDescription}>{suggestion.description}</p>
-
-                <div className={styles.relatedNotes}>
-                  <span className={styles.relatedLabel}>Related:</span>
-                  <div className={styles.noteLinks}>
-                    {suggestion.related_notes.map((noteId) => (
-                      <Link
-                        key={noteId}
-                        href={`/knowledge-base/notes/${noteId}`}
-                        className={styles.noteLink}
-                      >
-                        {noteId}
-                      </Link>
-                    ))}
+              return (
+                <div
+                  key={`${suggestion.type}-${suggestion.related_notes.join("-")}-${index}`}
+                  className={`${styles.suggestionCard} ${styles[config.family]}`}
+                >
+                  <div className={styles.cardHeader}>
+                    <span className={styles.typeBadge}>
+                      {TYPE_ICONS[suggestion.type]}
+                      {config.label}
+                    </span>
                   </div>
-                </div>
 
-                <div className={styles.cardActions}>
-                  {suggestion.type === "gap" && suggestion.related_notes.length > 0 && (
-                    <Link
-                      href={`/knowledge-base/notes/${suggestion.related_notes[0]}/edit`}
-                      className={styles.actionButton}
-                    >
-                      {suggestion.action_text}
-                    </Link>
+                  <h3 className={styles.cardTitle}>{suggestion.title}</h3>
+                  <p className={styles.cardDescription}>{suggestion.description}</p>
+
+                  {suggestion.related_notes.length > 0 && (
+                    <div className={styles.relatedNotes}>
+                      <span className={styles.relatedLabel}>Related:</span>
+                      <div className={styles.noteLinks}>
+                        {suggestion.related_notes.map((noteId) => (
+                          <Link
+                            key={noteId}
+                            href={`/knowledge-base/notes/${noteId}`}
+                            className={styles.noteLink}
+                          >
+                            {noteId}
+                          </Link>
+                        ))}
+                      </div>
+                    </div>
                   )}
-                  {suggestion.type === "connection" && suggestion.related_notes.length > 0 && (
-                    <Link
-                      href={`/knowledge-base/notes/${suggestion.related_notes[0]}`}
-                      className={styles.actionButton}
-                    >
-                      {suggestion.action_text}
-                    </Link>
+
+                  {suggestion.related_notes.length > 0 && (
+                    <div className={styles.cardActions}>
+                      <Link href={config.href(suggestion)} className={styles.actionButton}>
+                        {suggestion.action_text}
+                      </Link>
+                    </div>
                   )}
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
 
@@ -248,23 +287,32 @@ export default function InspirePage() {
           <div className={styles.helpGrid}>
             <div className={styles.helpItem}>
               <span className={styles.helpIcon} aria-hidden="true">
-                <NotePencil size={20} />
+                <Path size={20} />
               </span>
               <div>
-                <strong>Gap suggestions</strong>
-                <p>Notes that are short or have few connections. Consider expanding them.</p>
+                <strong>Repairs</strong>
+                <p>
+                  Orphaned notes nothing links to, the same idea captured twice, or a note holding
+                  more than one idea.
+                </p>
               </div>
             </div>
             <div className={styles.helpItem}>
               <span className={styles.helpIcon} aria-hidden="true">
-                <LinkSimple size={20} />
+                <TreeStructure size={20} />
               </span>
               <div>
-                <strong>Connection suggestions</strong>
-                <p>Similar notes that aren&apos;t linked. Consider adding wikilinks.</p>
+                <strong>Things to build</strong>
+                <p>
+                  Wikilinks between related notes, hub notes that index a cluster, and article ideas
+                  from topics your notes already cover.
+                </p>
               </div>
             </div>
           </div>
+          <p className={styles.helpFootnote}>
+            Short notes are never flagged — an atomic note is supposed to be brief.
+          </p>
         </div>
       </main>
     </div>

--- a/frontend/src/lib/api/inspire.ts
+++ b/frontend/src/lib/api/inspire.ts
@@ -7,8 +7,23 @@ import { getAuthHeaders } from "@/lib/api/client";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
+/**
+ * Kinds of suggestion the knowledge base can produce.
+ *
+ * Note length is deliberately absent: a short atomic note is correct, not a
+ * defect, so suggestions describe structural problems instead (see #259).
+ */
+export type SuggestionType =
+  | "orphan" // no links in or out - unreachable in the graph
+  | "duplicate" // same idea captured twice - merge
+  | "connection" // related but unlinked - add a wikilink
+  | "hub" // cluster of related notes with no index
+  | "promote" // heavily referenced - could be a full article
+  | "split" // long enough to hold several ideas
+  | "article"; // many notes on a topic, no article covering it
+
 export interface Suggestion {
-  type: "gap" | "connection";
+  type: SuggestionType;
   title: string;
   description: string;
   related_notes: string[];
@@ -19,35 +34,64 @@ export interface InspireResponse {
   suggestions: Suggestion[];
   generated_at: number;
   has_llm: boolean;
+  cached: boolean;
 }
 
-export interface GapNote {
+export interface OrphanNote {
   note_id: string;
   title: string;
   content_length: number;
-  link_count: number;
+  tags: string[];
+}
+
+export interface OversizedNote {
+  note_id: string;
+  title: string;
+  content_length: number;
+}
+
+export interface PromotableNote {
+  note_id: string;
+  title: string;
   backlink_count: number;
-  is_short: boolean;
-  has_few_links: boolean;
+  content_length: number;
+}
+
+export interface UncoveredTopic {
+  tag: string;
+  note_count: number;
+  note_ids: string[];
+  titles: string[];
 }
 
 export interface GapsResponse {
-  gaps: GapNote[];
+  orphans: OrphanNote[];
+  oversized: OversizedNote[];
+  promotable: PromotableNote[];
+  uncovered_topics: UncoveredTopic[];
   count: number;
-  min_content_length: number;
-  max_links: number;
 }
 
-export interface ConnectionOpportunity {
+export interface NotePair {
   note_a_id: string;
   note_a_title: string;
   note_b_id: string;
   note_b_title: string;
   similarity: number;
+  title_overlap: number;
+  kind: "duplicate" | "connection";
+}
+
+export interface HubOpportunity {
+  note_ids: string[];
+  titles: string[];
+  size: number;
 }
 
 export interface ConnectionsResponse {
-  connections: ConnectionOpportunity[];
+  connections: NotePair[];
+  duplicates: NotePair[];
+  hubs: HubOpportunity[];
   count: number;
   similarity_threshold: number;
 }
@@ -59,11 +103,29 @@ function getHeaders(): HeadersInit {
   return getAuthHeaders();
 }
 
+interface SuggestionOptions {
+  /** Rotate to a different slice of the candidate pool */
+  refresh?: boolean;
+  /** Return templated wording immediately, without waiting on the LLM */
+  skipLlm?: boolean;
+}
+
 /**
- * Get AI-powered content suggestions
+ * Get content suggestions.
+ *
+ * With `skipLlm` the backend returns the same suggestions phrased from
+ * templates, which lets the page paint immediately and swap in the
+ * LLM-phrased versions when they arrive.
  */
-export async function getSuggestions(limit: number = 5): Promise<InspireResponse> {
-  const response = await fetch(`${API_URL}/api/inspire/suggestions?limit=${limit}`, {
+export async function getSuggestions(
+  limit: number = 5,
+  options: SuggestionOptions = {}
+): Promise<InspireResponse> {
+  const params = new URLSearchParams({ limit: String(limit) });
+  if (options.refresh) params.set("refresh", "true");
+  if (options.skipLlm) params.set("skip_llm", "true");
+
+  const response = await fetch(`${API_URL}/api/inspire/suggestions?${params.toString()}`, {
     headers: getHeaders(),
   });
 
@@ -73,23 +135,19 @@ export async function getSuggestions(limit: number = 5): Promise<InspireResponse
   }
 
   const data = await response.json();
-  logger.info("Suggestions retrieved", { count: data.suggestions.length, hasLlm: data.has_llm });
+  logger.info("Suggestions retrieved", {
+    count: data.suggestions.length,
+    hasLlm: data.has_llm,
+    cached: data.cached,
+  });
   return data;
 }
 
 /**
- * Get knowledge gaps (underdeveloped topics)
+ * Get structural gaps: orphaned, oversized, promotable notes and uncovered topics
  */
-export async function getKnowledgeGaps(
-  minContentLength: number = 500,
-  maxLinks: number = 1,
-  limit: number = 10
-): Promise<GapsResponse> {
-  const params = new URLSearchParams({
-    min_content_length: String(minContentLength),
-    max_links: String(maxLinks),
-    limit: String(limit),
-  });
+export async function getKnowledgeGaps(limit: number = 10): Promise<GapsResponse> {
+  const params = new URLSearchParams({ limit: String(limit) });
 
   const response = await fetch(`${API_URL}/api/inspire/gaps?${params.toString()}`, {
     headers: getHeaders(),
@@ -106,7 +164,7 @@ export async function getKnowledgeGaps(
 }
 
 /**
- * Get connection opportunities (unlinked similar notes)
+ * Get connection opportunities: unlinked similar notes, duplicates, and hub clusters
  */
 export async function getConnectionOpportunities(
   similarityThreshold: number = 0.7,


### PR DESCRIPTION
Fixes #259. Follow-up to #148.

## The core problem

Inspire flagged any note under 500 chars as an underdeveloped "gap". The note editor tells you the opposite while typing:

| Length | `NoteEditorForm.tsx:313-326` | `core/inspire.py:18` (before) |
|---|---|---|
| <300 | "Brief - good for atomic notes" | gap, expand |
| 300-500 | "✓ Good length for atomic note" | gap, expand |
| 500-1000 | "Getting long - single idea?" | fine |
| >1000 | "Consider splitting" | fine |

The editor's *ideal* band was Inspire's *deficient* band. With `is_short OR has_few_links` (length alone qualified) and a shortest-first sort, 44% of prod notes were permanently "a gap" and the most atomic notes always topped the page. Every card said "add more content" — the opposite of the atomicity the rest of the app teaches.

## Changes

**Gaps are structural, not length-based.** The short-note heuristic is deleted outright:

| Type | Signal |
|---|---|
| `orphan` | no links in or out — unreachable in the graph |
| `split` | >1000 chars, matching the editor's own threshold |
| `promote` | heavily backlinked — article material |
| `duplicate` | same idea captured twice — merge |
| `connection` | related but unlinked — add a wikilink |
| `hub` | connected component of mutually similar notes |
| `article` | tag cluster with no covering article |

**Duplicate detection needed more than embedding similarity.** Cosine alone cannot separate a real duplicate from deliberate siblings:

| Pair | Similarity | Verdict |
|---|---|---|
| "5 Dysfunctions of a Team" / "Five Dysfunctions of a Team" | 0.870 | duplicate |
| "Developer Productivity: People Factors" / "...: Process Factors" | 0.864 | siblings |

Normalized title overlap with number-word expansion separates them cleanly — **1.00 vs 0.60** against a 0.8 threshold. Validated against all 10 live production pairs: 10/10 correct.

**Articles and tags now participate**, which #148 asked for and the implementation never did. `get_all_articles()` and note tags were both already available and unused. Against real prod data this surfaces `one-on-ones`, `productivity`, and `sre` — 6 notes each, zero covering articles. Tag normalization also collapses the existing `Leadership`/`leadership` and `Performance`/`performance` splits.

**Composition round-robins across types**, so no single type can dominate as gaps previously did.

## LLM reliability

Five consecutive prod calls before this change:

```
1: has_llm=True   2.3s
2: has_llm=False  2.4s   <- fell back
3: has_llm=True   2.1s
4: has_llm=True   2.1s
5: has_llm=False  16.5s  <- primary hung, then fallback
```

Not a rate limit — `/api/inspire/*` has no limiter registered. Upstream provider failure, invisible because the exception was swallowed and `setHasLlm` only fired on success, leaving an "AI-powered" badge over templated output.

- suggestions cached against a KB fingerprint; Refresh rotates the candidate pool instead of re-running an O(n²) sweep and a fresh generation
- JSON extracted by quote-aware bracket matching, so prose around the array no longer looks identical to an outage
- 8s per-call timeout so a hung primary does not delay fallback by the full 30s
- **the LLM is trusted for wording only** — IDs and types are reconciled against the analysis. Testing caught it emitting `related_notes: ["sre"]` (a tag where note IDs belonged, which would have rendered a dead link) and typing `promote` findings as `hub`
- `has_llm` always reflects reality; the UI distinguishes "AI unavailable" from "AI not asked"

## Verification

- `make ci` green: ruff clean, mypy 50 files, **479 backend tests** (94 for inspire), ESLint clean, **70 frontend tests**
- duplicate classification validated against 10 live prod pairs — 10/10
- article-gap detection validated against real prod tags + article frontmatter
- page renders with no console errors and a genuine mix of card types
- regression guards in tests: no fallback text may contain "expand"/"add more content"; a short-but-well-linked note must not be flagged

## Notes for review

- `SPLIT_MIN_LENGTH = 1000` in `core/inspire.py` deliberately duplicates the editor's threshold in `NoteEditorForm.tsx`. They must stay in sync — commented in both.
- `tests/conftest.py`'s `MockOllamaClient.generate` gained a `timeout` kwarg to match the real interface.
- `routers/ai.py` has the same LLM weaknesses and is **not** touched here — filed separately as #260.

https://claude.ai/code/session_01HdJkUh2ZAsEJosxyuu1mFH