### PR TITLE
fix: harden AI endpoints against silent LLM failure (fixes #260)

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -66,7 +66,11 @@ class Settings(BaseSettings):
     gemini_base_url: str = "https://generativelanguage.googleapis.com/v1beta/openai"
     gemini_model: str = "gemini-flash-latest"  # Free tier: 1,500 req/day
     gemini_embed_model: str = "gemini-embedding-001"  # Embeddings via OpenAI-compat endpoint
-    llm_api_timeout: float = 30.0  # Per-provider request timeout (seconds)
+    # Per-provider request timeout (seconds). Applies per provider, so the
+    # fallback chain can cost this twice before failing - keep it sized for an
+    # interactive request, not a worst-case generation. Callers that need a
+    # tighter bound pass timeout= explicitly (see routers/inspire.py).
+    llm_api_timeout: float = 12.0
     llm_api_max_tokens: int = 1024  # Default response cap for API generation
 
     # Which backend generates embeddings: "ollama" (default, dev) or "api"

--- a/backend/core/ai.py
+++ b/backend/core/ai.py
@@ -346,6 +346,58 @@ Example: [{{"note_id": "psychological-safety", "confidence": 0.85, "reason": "Bo
 JSON:"""
 
 
+def extract_json_payload(text: str, opener: str = "[") -> str | None:
+    """Extract the first balanced JSON array or object from surrounding text.
+
+    Pure function: No I/O, no side effects, deterministic.
+
+    Small models routinely wrap their output in prose ("Sure! Here is the
+    JSON: [...] Hope that helps!"). Bracket matching recovers the payload
+    where a plain json.loads fails. Quote- and escape-aware, so brackets
+    inside string values do not throw off the depth count.
+
+    Args:
+        text: Raw text that may contain a JSON payload
+        opener: "[" for arrays, "{" for objects
+
+    Returns:
+        The JSON substring, or None if no balanced payload is found
+    """
+    closer = "]" if opener == "[" else "}"
+
+    start = text.find(opener)
+    if start == -1:
+        return None
+
+    depth = 0
+    in_string = False
+    escaped = False
+
+    for index in range(start, len(text)):
+        char = text[index]
+
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char == '"':
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+
+        if char == opener:
+            depth += 1
+        elif char == closer:
+            depth -= 1
+            if depth == 0:
+                return text[start : index + 1]
+
+    return None
+
+
 def parse_json_response(
     raw_response: str, expected_type: str = "array"
 ) -> list[dict[str, Any]] | dict[str, Any] | None:
@@ -397,7 +449,23 @@ def parse_json_response(
                 return None
 
     except json.JSONDecodeError:
-        # Fallback: Try line-by-line parsing (some models output newline-delimited JSON)
+        # Fallback 1: the payload is embedded in prose ("Here is the JSON: [...]")
+        opener = "[" if expected_type == "array" else "{"
+        extracted = extract_json_payload(response, opener=opener)
+        if extracted is not None:
+            try:
+                data = json.loads(extracted)
+                if expected_type == "array":
+                    if isinstance(data, dict):
+                        return [data]
+                    if isinstance(data, list):
+                        return data
+                elif isinstance(data, dict):
+                    return data
+            except json.JSONDecodeError:
+                pass
+
+        # Fallback 2: newline-delimited JSON objects (some models emit these)
         if expected_type == "array":
             parsed_objects = []
             for line in response.split("\n"):

--- a/backend/core/inspire.py
+++ b/backend/core/inspire.py
@@ -17,7 +17,7 @@ import logging
 import re
 from typing import Any
 
-from core.ai import cosine_similarity
+from core.ai import cosine_similarity, extract_json_payload
 
 logger = logging.getLogger(__name__)
 
@@ -643,47 +643,6 @@ JSON:"""
 # --- parsing ----------------------------------------------------------------
 
 
-def _extract_json_array(text: str) -> str | None:
-    """Extract the first balanced top-level JSON array from text. Pure.
-
-    Small models routinely wrap the array in prose or fences ("Here is the
-    JSON: [...]  Hope this helps!"). Bracket matching recovers the payload
-    where a plain json.loads would fail. Quote- and escape-aware so brackets
-    inside string values don't throw off the depth count.
-    """
-    start = text.find("[")
-    if start == -1:
-        return None
-
-    depth = 0
-    in_string = False
-    escaped = False
-
-    for index in range(start, len(text)):
-        char = text[index]
-
-        if escaped:
-            escaped = False
-            continue
-        if char == "\\":
-            escaped = True
-            continue
-        if char == '"':
-            in_string = not in_string
-            continue
-        if in_string:
-            continue
-
-        if char == "[":
-            depth += 1
-        elif char == "]":
-            depth -= 1
-            if depth == 0:
-                return text[start : index + 1]
-
-    return None
-
-
 def parse_inspiration_response(raw_response: str) -> list[dict[str, Any]]:
     """Parse LLM response into structured suggestions.
 
@@ -714,7 +673,7 @@ def parse_inspiration_response(raw_response: str) -> list[dict[str, Any]]:
         data = json.loads(response)
     except json.JSONDecodeError:
         # Model wrapped the array in prose - recover it
-        extracted = _extract_json_array(response)
+        extracted = extract_json_payload(response, opener="[")
         if extracted is None:
             logger.warning("No JSON array found in inspiration response")
             logger.debug("Raw response (first 500 chars): %s", raw_response[:500])

--- a/backend/models/note.py
+++ b/backend/models/note.py
@@ -132,6 +132,10 @@ class TagSuggestionsResponse(BaseModel):
 
     suggestions: list[TagSuggestion]
     count: int
+    # True when the AI could not be reached or its output was unusable, as
+    # opposed to it running fine and finding nothing worth suggesting. Without
+    # this the two are indistinguishable to the client (#260).
+    degraded: bool = False
 
 
 class LinkSuggestion(BaseModel):
@@ -150,3 +154,5 @@ class LinkSuggestionsResponse(BaseModel):
     count: int
     cached: bool = False  # True if returned from pre-computed cache
     cached_at: float | None = None  # Unix timestamp when cached
+    # See TagSuggestionsResponse.degraded (#260)
+    degraded: bool = False

--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -259,8 +259,8 @@ def suggest_tags(
 
     # If Ollama unavailable, return empty suggestions
     if not ollama.is_available():
-        logger.warning("Ollama not available for tag suggestions")
-        return TagSuggestionsResponse(suggestions=[], count=0)
+        logger.warning("LLM not available for tag suggestions")
+        return TagSuggestionsResponse(suggestions=[], count=0, degraded=True)
 
     # Get all existing tags from all notes for context
     all_notes = notes_service.list_notes()
@@ -282,12 +282,14 @@ def suggest_tags(
         response = ollama.generate(prompt, role="structured", num_ctx=4096)
         if not response:
             logger.error("Empty response from LLM for tag suggestions")
-            return TagSuggestionsResponse(suggestions=[], count=0)
+            return TagSuggestionsResponse(suggestions=[], count=0, degraded=True)
 
         # Parse JSON response using pure function
         suggestions_data = ai_core.parse_json_response(response, expected_type="array")
-        if not suggestions_data or not isinstance(suggestions_data, list):
-            return TagSuggestionsResponse(suggestions=[], count=0)
+        # None means the parse failed; [] means the model ran and found nothing
+        if suggestions_data is None or not isinstance(suggestions_data, list):
+            logger.warning("Unparseable tag suggestion response for note %s", note_id)
+            return TagSuggestionsResponse(suggestions=[], count=0, degraded=True)
 
         # Convert to TagSuggestion models
         suggestions = [
@@ -306,7 +308,7 @@ def suggest_tags(
 
     except Exception as e:
         logger.error("Error generating tag suggestions: %s", e)
-        return TagSuggestionsResponse(suggestions=[], count=0)
+        return TagSuggestionsResponse(suggestions=[], count=0, degraded=True)
 
 
 @router.post("/notes/{note_id}/suggest-links", response_model=LinkSuggestionsResponse)
@@ -358,8 +360,8 @@ def suggest_links(
 
     # No cache or refresh requested - generate new suggestions
     if not ollama.is_available():
-        logger.warning("Ollama not available for link suggestions")
-        return LinkSuggestionsResponse(suggestions=[], count=0)
+        logger.warning("LLM not available for link suggestions")
+        return LinkSuggestionsResponse(suggestions=[], count=0, degraded=True)
 
     # Force regeneration
     if refresh:
@@ -411,12 +413,14 @@ def suggest_links(
         response = ollama.generate(prompt, role="structured", num_ctx=8192)
         if not response:
             logger.error("Empty response from LLM for link suggestions")
-            return LinkSuggestionsResponse(suggestions=[], count=0)
+            return LinkSuggestionsResponse(suggestions=[], count=0, degraded=True)
 
         # Parse JSON response using pure function
         suggestions_data = ai_core.parse_json_response(response, expected_type="array")
-        if not suggestions_data or not isinstance(suggestions_data, list):
-            return LinkSuggestionsResponse(suggestions=[], count=0)
+        # None means the parse failed; [] means the model ran and found nothing
+        if suggestions_data is None or not isinstance(suggestions_data, list):
+            logger.warning("Unparseable link suggestion response for note %s", note_id)
+            return LinkSuggestionsResponse(suggestions=[], count=0, degraded=True)
 
         # Convert to LinkSuggestion models and add titles
         suggestions = []
@@ -444,7 +448,7 @@ def suggest_links(
 
     except Exception as e:
         logger.error("Error generating link suggestions: %s", e)
-        return LinkSuggestionsResponse(suggestions=[], count=0)
+        return LinkSuggestionsResponse(suggestions=[], count=0, degraded=True)
 
 
 @router.get("/notes/{note_id}/suggest-stream")
@@ -538,7 +542,9 @@ def suggest_stream(
 
         except Exception as e:
             logger.error("Error generating tag suggestions during stream: %s", e)
-            # Continue to links even if tags fail
+            # Tell the client this phase degraded, then continue to links (#260).
+            # Silently dropping the phase is indistinguishable from "no tags fit".
+            yield format_sse({"type": "degraded", "phase": "tags"})
 
         # === PHASE 2: Generate Links ===
         yield format_sse({"type": "progress", "phase": "links"})
@@ -595,6 +601,7 @@ def suggest_stream(
 
             except Exception as e:
                 logger.error("Error generating link suggestions during stream: %s", e)
+                yield format_sse({"type": "degraded", "phase": "links"})
 
         # === COMPLETE ===
         yield format_sse({"type": "complete"})

--- a/backend/tests/unit/test_ai_api.py
+++ b/backend/tests/unit/test_ai_api.py
@@ -8,8 +8,15 @@ Tests marked with @pytest.mark.slow hit real Ollama and can take 30-120+ seconds
 on CPU-only systems. Run with `pytest -m "not slow"` to skip them.
 """
 
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import Any
+
 import pytest
 from fastapi.testclient import TestClient
+
+from dependencies import get_llm, get_notes
+from main import app
 
 # Mark for slow tests that hit real Ollama
 slow = pytest.mark.slow
@@ -140,6 +147,100 @@ class TestSuggestTags:
         """Suggest tags returns 404 for non-existent note."""
         response = client.post("/api/notes/nonexistent-note-id-12345/suggest-tags")
         assert response.status_code == 404
+
+
+class TestDegradedSignalling:
+    """The `degraded` flag must separate "AI failed" from "nothing to suggest" (#260).
+
+    Both cases return an empty suggestions list, so without this flag the
+    client cannot tell a broken LLM from a note that genuinely needs no tags.
+    """
+
+    NOTE = {
+        "id": "test-note",
+        "title": "A Note",
+        "content": "Some content about reliability.",
+        "tags": ["sre"],
+        "links": [],
+    }
+
+    class _NotesService:
+        def __init__(self, note: dict[str, Any]) -> None:
+            self._note = note
+
+        def get_note(self, note_id: str) -> dict[str, Any] | None:
+            return self._note if note_id == self._note["id"] else None
+
+        def list_notes(self) -> list[dict[str, Any]]:
+            return [self._note]
+
+    class _LLM:
+        """Stands in for the routed client, with a scriptable generate()."""
+
+        def __init__(self, available: bool = True, response: str | None = None) -> None:
+            self._available = available
+            self._response = response
+
+        def is_available(self) -> bool:
+            return self._available
+
+        def generate(self, prompt: str, **kwargs: Any) -> str | None:
+            return self._response
+
+    @contextmanager
+    def _client(self, llm: Any) -> Generator[TestClient]:
+        app.dependency_overrides[get_llm] = lambda: llm
+        app.dependency_overrides[get_notes] = lambda: self._NotesService(self.NOTE)
+        try:
+            with TestClient(app) as test_client:
+                yield test_client
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_degraded_when_llm_unavailable(self) -> None:
+        with self._client(self._LLM(available=False)) as client:
+            data = client.post("/api/notes/test-note/suggest-tags").json()
+
+        assert data["suggestions"] == []
+        assert data["degraded"] is True
+
+    def test_degraded_when_llm_returns_nothing(self) -> None:
+        with self._client(self._LLM(response=None)) as client:
+            data = client.post("/api/notes/test-note/suggest-tags").json()
+
+        assert data["degraded"] is True
+
+    def test_degraded_when_output_unparseable(self) -> None:
+        with self._client(self._LLM(response="I'm afraid I can't do that.")) as client:
+            data = client.post("/api/notes/test-note/suggest-tags").json()
+
+        assert data["degraded"] is True
+
+    def test_not_degraded_when_llm_returns_empty_array(self) -> None:
+        """A working LLM that finds no tags is NOT degraded - the key distinction."""
+        with self._client(self._LLM(response="[]")) as client:
+            data = client.post("/api/notes/test-note/suggest-tags").json()
+
+        assert data["suggestions"] == []
+        assert data["degraded"] is False
+
+    def test_not_degraded_on_success(self) -> None:
+        response = '[{"tag": "reliability", "confidence": 0.9, "reason": "core topic"}]'
+        with self._client(self._LLM(response=response)) as client:
+            data = client.post("/api/notes/test-note/suggest-tags").json()
+
+        assert data["count"] == 1
+        assert data["degraded"] is False
+
+    def test_prose_wrapped_output_is_not_degraded(self) -> None:
+        """The #260 parser fix, verified through the endpoint."""
+        response = 'Sure!\n[{"tag": "reliability", "confidence": 0.9, "reason": "core"}]\nDone.'
+        with self._client(self._LLM(response=response)) as client:
+            data = client.post("/api/notes/test-note/suggest-tags").json()
+
+        assert data["count"] == 1
+        assert data["suggestions"][0]["tag"] == "reliability"
+        assert data["degraded"] is False
 
 
 class TestSuggestLinks:

--- a/backend/tests/unit/test_core_ai.py
+++ b/backend/tests/unit/test_core_ai.py
@@ -209,6 +209,76 @@ class TestParseJSONResponse:
         result = ai.parse_json_response("", expected_type="array")
         assert result is None
 
+    def test_recovers_array_wrapped_in_prose(self):
+        """Models often narrate around the payload (#260).
+
+        The line-by-line fallback only matched lines starting with '{', so a
+        single-line array inside prose was lost entirely.
+        """
+        response = 'Sure! Here is the JSON:\n[{"tag": "sre", "confidence": 0.9}]\nHope that helps!'
+        result = ai.parse_json_response(response, expected_type="array")
+
+        assert result is not None
+        assert isinstance(result, list)
+        assert result[0]["tag"] == "sre"
+
+    def test_recovers_fenced_array_wrapped_in_prose(self):
+        """Prose plus fences: neither stripping nor line-splitting alone suffices."""
+        response = 'Here you go:\n```json\n[{"tag": "sre"}]\n```\nLet me know!'
+        result = ai.parse_json_response(response, expected_type="array")
+
+        assert result is not None
+        assert isinstance(result, list)
+        assert result[0]["tag"] == "sre"
+
+    def test_recovers_object_wrapped_in_prose(self):
+        """Object mode gets the same treatment as array mode."""
+        response = 'Here is the result: {"summary": "A summary."} Anything else?'
+        result = ai.parse_json_response(response, expected_type="object")
+
+        assert result is not None
+        assert isinstance(result, dict)
+        assert result["summary"] == "A summary."
+
+    def test_genuine_garbage_still_returns_none(self):
+        """Hardening must not turn unparseable output into a false positive."""
+        assert ai.parse_json_response("I could not do that.", expected_type="array") is None
+
+
+class TestExtractJSONPayload:
+    """Tests for bracket-matched payload extraction."""
+
+    def test_extracts_array_from_prose(self):
+        result = ai.extract_json_payload('Here: [{"a": 1}] done', opener="[")
+        assert result == '[{"a": 1}]'
+
+    def test_extracts_object_from_prose(self):
+        result = ai.extract_json_payload('Here: {"a": 1} done', opener="{")
+        assert result == '{"a": 1}'
+
+    def test_handles_nested_structures(self):
+        result = ai.extract_json_payload('x [{"a": [1, 2], "b": {"c": 3}}] y', opener="[")
+        assert result == '[{"a": [1, 2], "b": {"c": 3}}]'
+
+    def test_ignores_brackets_inside_strings(self):
+        """Wikilink syntax in a reason field must not unbalance the scan.
+
+        This codebase's own note IDs appear as [[note-id]], so payloads
+        containing them are the normal case, not an edge case.
+        """
+        result = ai.extract_json_payload('[{"reason": "see [[note-id]] here"}]', opener="[")
+        assert result == '[{"reason": "see [[note-id]] here"}]'
+
+    def test_ignores_escaped_quotes(self):
+        result = ai.extract_json_payload(r'[{"reason": "a \"quoted\" word"}]', opener="[")
+        assert result == r'[{"reason": "a \"quoted\" word"}]'
+
+    def test_returns_none_when_absent(self):
+        assert ai.extract_json_payload("no payload here", opener="[") is None
+
+    def test_returns_none_when_unbalanced(self):
+        assert ai.extract_json_payload('[{"a": 1}', opener="[") is None
+
 
 class TestPromptBuilders:
     """Tests for specialized prompt builders."""


### PR DESCRIPTION
Fixes #260. Applies the #259 reliability work to `routers/ai.py`.

## First: two corrections to the issue

I wrote #260 by inference from the #259 work rather than by reading `routers/ai.py`. Auditing it first showed I had overstated the problem twice:

- **"No caching"** — wrong. Summaries are cached in Neo4j (`ai_summary` / `ai_summary_at`, both articles and notes), and `suggest-links` caches to `ai_link_suggestions`.
- **"No output sanitization"** — wrong. `suggest-links` already validates model-supplied note IDs against `note_map`, in both the sync and streaming paths.

`/api/ask` was also fine: it raises 503/500 rather than degrading quietly. Left alone.

The real gaps were narrower than the issue claimed. I have corrected #260 to match.

## The actual bug

`parse_json_response` could not recover a JSON array wrapped in prose. The line-by-line fallback only matched lines starting with `{`, so a single-line array inside narration was lost entirely:

```
clean array          OK
markdown fenced      OK
newline-delimited    OK
PROSE-WRAPPED array  FAIL   <-
prose + fenced       FAIL   <-
```

That is the same failure mode #259 found, and it is the common shape for `llama-3.1-8b-instant`. It affected `suggest-tags`, `suggest-links`, and both streaming phases — and it is **indistinguishable from a provider outage** in the logs.

## Changes

**One shared extractor.** The bracket-matching logic moves out of `core/inspire.py` into `core/ai.extract_json_payload` and both call it. Quote- and escape-aware, which matters here specifically because reason fields routinely contain `[[note-id]]` wikilinks — there is a test for exactly that.

All eight cases now pass, and genuine garbage still correctly returns `None` rather than becoming a false positive.

**Honest degradation.** "The AI failed" and "the AI found nothing" both returned an empty list with no way to tell them apart. Tag and link responses now carry `degraded`, and the SSE stream emits a `degraded` event per phase instead of silently dropping it.

**A real bug that test surfaced:** `if not suggestions_data` treated a valid empty array as a parse failure — so a model that correctly decided no tags applied was reported as broken. Only `None` counts as failure now. This is the exact conflation the flag exists to remove, and I would not have found it without writing the "not degraded when empty" case.

**Timeout.** Default per-provider timeout 30s → 12s. It applies *per provider*, so the fallback chain could stall an interactive request for 60s. Rather than thread a `timeout` argument through six signatures across three client classes, the default itself is the right lever — every `generate()` caller here is user-facing. Callers needing a tighter bound still pass `timeout=` explicitly, as `routers/inspire.py` does at 8s.

## Verification

`make ci` green: ruff clean, mypy 50 files, **496 backend tests** (up from 479), ESLint clean, 70 frontend tests.

New coverage: 7 cases for `extract_json_payload` (nesting, wikilinks in strings, escaped quotes, unbalanced input), 4 for prose-wrapped parsing in both array and object mode, and 6 endpoint tests pinning the degraded/not-degraded distinction.

## Not included

`suggest-tags` still has no caching, unlike links and summaries. That is a genuine gap but a larger change (it needs a storage field and an invalidation story), and it is a performance concern rather than a correctness one. Worth its own issue if you want it.

https://claude.ai/code/session_01HdJkUh2ZAsEJosxyuu1mFH