### PR TITLE
feat: passkey admin authentication (refs #229)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -457,6 +457,15 @@ In `backend/main.py`:
 - `GET /api/notes/{note_id}/backlinks` - Get inbound links
 - `GET /api/notes/graph/data` - Get full graph
 
+*Auth (passkeys, #229):*
+- `POST /api/auth/register/options|verify` - Enroll a passkey (admin auth required)
+- `POST /api/auth/login/options|verify` - Sign in, returns a 12h session token
+- `GET /api/auth/session` - Report auth state (200 whether or not signed in)
+- `GET|DELETE /api/auth/credentials` - List / revoke enrolled passkeys
+
+Admin endpoints accept a passkey session token **or** the static `ADMIN_TOKEN`;
+the token is retained for CI (deploy backups) and first-time enrollment.
+
 *AI Features:*
 - `POST /api/search` - Semantic search (articles + notes)
 - `POST /api/ask` - Q&A with context

--- a/backend/adapters/neo4j.py
+++ b/backend/adapters/neo4j.py
@@ -133,6 +133,15 @@ class Neo4jAdapter:
                 """
             )
 
+            # ===== ADMIN CREDENTIAL SCHEMA (#229) =====
+            # Unique constraint on AdminCredential.credential_id
+            session.run(
+                """
+                CREATE CONSTRAINT admin_credential_id_unique IF NOT EXISTS
+                FOR (c:AdminCredential) REQUIRE c.credential_id IS UNIQUE
+                """
+            )
+
             logger.info("Neo4j schema initialized (Notes + Articles + embeddings support)")
 
     def is_available(self) -> bool:
@@ -702,6 +711,219 @@ class Neo4jAdapter:
                 enabled=enabled,
             )
             return True
+
+    # ===== ADMIN CREDENTIALS (passkeys, #229) =====
+
+    def list_admin_credentials(self) -> list[dict[str, Any]]:
+        """List registered passkey credentials.
+
+        Returns:
+            Credential records, newest first (empty if Neo4j unavailable).
+            `public_key` is raw COSE bytes as stored.
+        """
+        if not self._available or not self.driver:
+            return []
+
+        with self.driver.session(database=self.database) as session:
+            result = session.run(
+                """
+                MATCH (c:AdminCredential)
+                RETURN c.credential_id AS credential_id,
+                       c.public_key AS public_key,
+                       c.sign_count AS sign_count,
+                       c.name AS name,
+                       c.created_at AS created_at,
+                       c.last_used_at AS last_used_at
+                ORDER BY c.created_at DESC
+                """
+            )
+            return [
+                {
+                    "credential_id": record["credential_id"],
+                    "public_key": bytes(record["public_key"]),
+                    "sign_count": int(record["sign_count"] or 0),
+                    "name": record["name"],
+                    "created_at": record["created_at"],
+                    "last_used_at": record["last_used_at"],
+                }
+                for record in result
+            ]
+
+    def get_admin_credential(self, credential_id: str) -> dict[str, Any] | None:
+        """Get a single passkey credential by its ID.
+
+        Args:
+            credential_id: base64url credential ID from the authenticator
+
+        Returns:
+            Credential record, or None if not found / Neo4j unavailable
+        """
+        for credential in self.list_admin_credentials():
+            if credential["credential_id"] == credential_id:
+                return credential
+        return None
+
+    def create_admin_credential(
+        self,
+        credential_id: str,
+        public_key: bytes,
+        sign_count: int,
+        name: str,
+    ) -> bool:
+        """Store a newly registered passkey.
+
+        Args:
+            credential_id: base64url credential ID from the authenticator
+            public_key: Raw COSE public key bytes
+            sign_count: Signature counter at registration
+            name: Human label for the device ("MacBook", "iPhone")
+
+        Returns:
+            True if stored, False if Neo4j unavailable
+        """
+        if not self._available or not self.driver:
+            return False
+
+        with self.driver.session(database=self.database) as session:
+            session.run(
+                """
+                MERGE (c:AdminCredential {credential_id: $credential_id})
+                SET c.public_key = $public_key,
+                    c.sign_count = $sign_count,
+                    c.name = $name,
+                    c.created_at = $created_at,
+                    c.last_used_at = null
+                """,
+                credential_id=credential_id,
+                public_key=public_key,
+                sign_count=sign_count,
+                name=name,
+                created_at=time.time(),
+            )
+            return True
+
+    def record_admin_credential_use(self, credential_id: str, sign_count: int) -> bool:
+        """Update a credential's signature counter after a successful login.
+
+        The counter is the authenticator's replay defense: it must never go
+        backwards. Callers verify that before calling this.
+
+        Args:
+            credential_id: base64url credential ID
+            sign_count: New counter value from the assertion
+
+        Returns:
+            True if updated, False if Neo4j unavailable
+        """
+        if not self._available or not self.driver:
+            return False
+
+        with self.driver.session(database=self.database) as session:
+            session.run(
+                """
+                MATCH (c:AdminCredential {credential_id: $credential_id})
+                SET c.sign_count = $sign_count, c.last_used_at = $last_used_at
+                """,
+                credential_id=credential_id,
+                sign_count=sign_count,
+                last_used_at=time.time(),
+            )
+            return True
+
+    def delete_admin_credential(self, credential_id: str) -> bool:
+        """Delete (revoke) a passkey credential.
+
+        Args:
+            credential_id: base64url credential ID
+
+        Returns:
+            True if a credential was deleted, False otherwise
+        """
+        if not self._available or not self.driver:
+            return False
+
+        with self.driver.session(database=self.database) as session:
+            result = session.run(
+                """
+                MATCH (c:AdminCredential {credential_id: $credential_id})
+                DELETE c
+                RETURN count(c) AS deleted
+                """,
+                credential_id=credential_id,
+            )
+            record = result.single()
+            return bool(record and record["deleted"] > 0)
+
+    def store_webauthn_challenge(self, challenge: str, purpose: str, ttl_seconds: float) -> bool:
+        """Store a pending WebAuthn challenge.
+
+        Challenges must be shared across processes: production runs four
+        uvicorn workers, so the worker that issues a challenge is usually
+        not the one that verifies the response.
+
+        Args:
+            challenge: base64url-encoded challenge bytes
+            purpose: "registration" or "authentication"
+            ttl_seconds: How long the challenge stays valid
+
+        Returns:
+            True if stored, False if Neo4j unavailable
+        """
+        if not self._available or not self.driver:
+            return False
+
+        now = time.time()
+        with self.driver.session(database=self.database) as session:
+            session.run(
+                """
+                CREATE (c:WebAuthnChallenge {
+                    challenge: $challenge,
+                    purpose: $purpose,
+                    expires_at: $expires_at
+                })
+                """,
+                challenge=challenge,
+                purpose=purpose,
+                expires_at=now + ttl_seconds,
+            )
+            # Opportunistic sweep so abandoned ceremonies do not accumulate
+            session.run(
+                "MATCH (c:WebAuthnChallenge) WHERE c.expires_at < $now DELETE c",
+                now=now,
+            )
+            return True
+
+    def consume_webauthn_challenge(self, challenge: str, purpose: str) -> bool:
+        """Atomically claim a pending challenge, if it exists and is unexpired.
+
+        Deleting on read makes challenges single-use, which is what stops a
+        captured assertion from being replayed.
+
+        Args:
+            challenge: base64url-encoded challenge bytes
+            purpose: "registration" or "authentication"
+
+        Returns:
+            True if the challenge was ours, unexpired, and is now consumed
+        """
+        if not self._available or not self.driver:
+            return False
+
+        with self.driver.session(database=self.database) as session:
+            result = session.run(
+                """
+                MATCH (c:WebAuthnChallenge {challenge: $challenge, purpose: $purpose})
+                WHERE c.expires_at >= $now
+                WITH c LIMIT 1
+                DELETE c
+                RETURN count(c) AS consumed
+                """,
+                challenge=challenge,
+                purpose=purpose,
+                now=time.time(),
+            )
+            record = result.single()
+            return bool(record and record["consumed"] > 0)
 
     def get_all_note_ids(self) -> set[str]:
         """Get all note IDs (for collision detection).

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,15 +1,28 @@
-"""Authentication middleware for Zettelkasten notes system."""
+"""Authentication middleware for Zettelkasten notes system.
+
+Two credentials share the `Authorization: Bearer` transport (#229):
+
+- **Passkey session tokens** - signed, 12-hour, minted by /api/auth/login/verify.
+  The primary path for humans, and the only one the frontend issues.
+- **The static admin token** - retained for machine callers (the deploy
+  workflow's pre/post-deploy backups) and to gate first-time passkey
+  enrollment. Long-lived and unrevokable, hence the #225 lockout below.
+
+Session tokens are checked first and are exempt from the lockout: they are
+unguessable by construction, so failed attempts carry no signal about them.
+"""
 
 import hmac
 import logging
 import threading
 import time
-from typing import Annotated
+from typing import Annotated, Any
 
 from fastapi import Depends, HTTPException, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from config import get_settings
+from core.sessions import derive_session_secret, looks_like_session_token, verify_session_token
 
 logger = logging.getLogger(__name__)
 settings = get_settings()
@@ -94,18 +107,50 @@ def _client_ip(request: Request) -> str:
     return request.client.host if request.client else "unknown"
 
 
+def _check_session_token(token: str) -> dict[str, Any] | None:
+    """Try to authenticate a bearer token as a passkey session.
+
+    Args:
+        token: The bearer token from the Authorization header
+
+    Returns:
+        Auth context if the token is a valid session, else None. None also
+        covers session-*shaped* tokens that failed verification - the caller
+        distinguishes those with looks_like_session_token.
+    """
+    secret = derive_session_secret(settings.admin_token, settings.session_secret)
+    if not secret:
+        return None
+
+    claims = verify_session_token(token, secret, time.time())
+    if claims is None:
+        return None
+
+    return {
+        "authenticated": True,
+        "kind": "passkey",
+        "credential_id": claims.credential_id,
+        "expires_at": claims.expires_at,
+    }
+
+
 def verify_admin(
     request: Request,
     credentials: HTTPAuthorizationCredentials | None = Depends(security),
 ) -> bool:
-    """Verify admin token from Authorization header.
+    """Verify admin credentials from the Authorization header.
 
-    Uses FastAPI's HTTPBearer security scheme for proper Swagger UI integration.
-    The token is stored in the environment (.env or 1Password).
+    Accepts either a passkey session token (#229) or the static admin token,
+    both over `Authorization: Bearer`. Uses FastAPI's HTTPBearer security
+    scheme for proper Swagger UI integration.
 
-    Repeated invalid tokens from one IP trigger a lockout (#225): after
-    MAX_FAILED_ATTEMPTS failures, that IP gets 429 for LOCKOUT_SECONDS -
-    even for requests that would otherwise carry the correct token.
+    Repeated invalid *static tokens* from one IP trigger a lockout (#225):
+    after MAX_FAILED_ATTEMPTS failures, that IP gets 429 for LOCKOUT_SECONDS
+    - even for requests that would otherwise carry the correct token. An
+    expired or malformed session token is reported as 401 and does not count
+    toward that budget: session tokens are HMAC-signed, so there is nothing
+    to brute-force, and counting them would let a stale browser tab lock the
+    admin out of logging back in.
 
     Args:
         request: Incoming request (for the client IP)
@@ -115,8 +160,8 @@ def verify_admin(
         True if authenticated
 
     Raises:
-        HTTPException: 401 if no auth header, 403 if invalid token,
-            429 if the client IP is locked out
+        HTTPException: 401 if no auth header or an expired session, 403 if
+            invalid token, 429 if the client IP is locked out
     """
     ip = _client_ip(request)
 
@@ -137,7 +182,20 @@ def verify_admin(
 
     token = credentials.credentials
 
-    # Get expected token from settings
+    # Passkey session first - the primary path for humans
+    if _check_session_token(token):
+        auth_tracker.record_success(ip)
+        logger.debug("Admin authenticated via passkey session")
+        return True
+
+    if looks_like_session_token(token):
+        logger.info("Rejected expired or invalid passkey session from %s", ip)
+        raise HTTPException(
+            status_code=401,
+            detail="Session expired. Sign in again with your passkey.",
+        )
+
+    # Fall back to the static token (CI/automation, passkey enrollment)
     expected_token = settings.admin_token
 
     if not expected_token:
@@ -162,6 +220,40 @@ def verify_admin(
     auth_tracker.record_success(ip)
     logger.debug("Admin authenticated successfully")
     return True
+
+
+def verify_admin_optional(
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
+) -> dict[str, Any]:
+    """Report auth state without rejecting unauthenticated callers.
+
+    Backs GET /api/auth/session, which answers "am I signed in?" - a question
+    whose negative answer is a 200, not a 401. Does not touch the lockout
+    tracker in either direction: this endpoint is a status read, so it must
+    neither consume attempts nor clear a running lockout.
+
+    Args:
+        credentials: HTTPAuthorizationCredentials from HTTPBearer (None if missing)
+
+    Returns:
+        Dict with 'authenticated', 'kind' ('passkey'/'token'/'none'), and for
+        passkey sessions 'credential_id' and 'expires_at'
+    """
+    unauthenticated: dict[str, Any] = {"authenticated": False, "kind": "none", "expires_at": None}
+
+    if not credentials:
+        return unauthenticated
+
+    token = credentials.credentials
+
+    session = _check_session_token(token)
+    if session:
+        return session
+
+    if settings.admin_token and hmac.compare_digest(token, settings.admin_token):
+        return {"authenticated": True, "kind": "token", "expires_at": None}
+
+    return unauthenticated
 
 
 # Type alias for dependency injection

--- a/backend/config.py
+++ b/backend/config.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import subprocess
+from urllib.parse import urlparse
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -97,6 +98,28 @@ class Settings(BaseSettings):
 
     # Zettelkasten authentication
     admin_token: str = ""  # Admin bearer token for creating persistent notes
+
+    # Passkey (WebAuthn) admin authentication (#229). Passkeys are the primary
+    # login for humans; admin_token remains valid for CI/automation callers
+    # (deploy backups) and gates first-time passkey enrollment.
+    session_secret: str = ""  # HMAC key for session tokens; derived from admin_token if unset
+    webauthn_rp_id: str = ""  # Relying Party ID; derived from the first CORS origin if unset
+    webauthn_rp_name: str = "Mongado"  # Shown by the OS passkey prompt
+
+    @property
+    def webauthn_rp_id_resolved(self) -> str:
+        """Relying Party ID: the frontend's registrable domain.
+
+        Defaults to the hostname of the first CORS origin, which is exactly
+        the frontend the passkey ceremony runs on ("localhost" in dev,
+        "mongado.com" in prod). Set WEBAUTHN_RP_ID to override.
+        """
+        if self.webauthn_rp_id:
+            return self.webauthn_rp_id
+        origins = self.cors_origins_list
+        if not origins:
+            return "localhost"
+        return urlparse(origins[0]).hostname or "localhost"
 
 
 class SecretManager:

--- a/backend/core/sessions.py
+++ b/backend/core/sessions.py
@@ -1,0 +1,187 @@
+"""Pure session-token logic for passkey auth (Functional Core).
+
+This module contains pure functions with no I/O or side effects. All
+functions are deterministic given their arguments -- the current time is
+passed in rather than read -- and fully unit-testable.
+
+Token format (#229):
+    <base64url(payload_json)>.<base64url(hmac_sha256(secret, payload_bytes))>
+
+A stateless signed token, not a stored session id. The backend runs several
+uvicorn workers with no shared session store, so a token that any worker can
+verify from the shared secret alone is the smallest thing that works. The
+cost is that individual sessions cannot be revoked before they expire --
+acceptable at a 12-hour TTL for a single-admin site. Revoking a *device* is
+done by deleting its credential, which stops new logins.
+
+Deliberately not JWT: no algorithm negotiation (the `alg: none` family of
+bugs is unreachable), no new dependency, and the payload is three fields.
+"""
+
+import base64
+import hmac
+import json
+from dataclasses import dataclass
+from hashlib import sha256
+from typing import Any
+
+DEFAULT_TTL_SECONDS = 12 * 60 * 60
+"""Session lifetime. Short enough that a stolen token expires the same day,
+long enough to write for an evening without re-tapping the passkey."""
+
+SESSION_KIND = "passkey"
+"""Marks tokens minted by a passkey assertion, distinguishing them from the
+static admin token that shares the same Authorization: Bearer transport."""
+
+
+@dataclass(frozen=True)
+class SessionClaims:
+    """Verified contents of a session token."""
+
+    credential_id: str
+    issued_at: int
+    expires_at: int
+
+
+def _b64url_encode(raw: bytes) -> str:
+    """Encode bytes as unpadded base64url."""
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _b64url_decode(value: str) -> bytes:
+    """Decode unpadded base64url. Raises ValueError on malformed input."""
+    padding = "=" * (-len(value) % 4)
+    try:
+        return base64.urlsafe_b64decode(value + padding)
+    except Exception as e:  # binascii.Error and friends
+        raise ValueError("malformed base64url segment") from e
+
+
+def _sign(payload: bytes, secret: str) -> str:
+    """Compute the base64url signature for a payload."""
+    digest = hmac.new(secret.encode("utf-8"), payload, sha256).digest()
+    return _b64url_encode(digest)
+
+
+def derive_session_secret(admin_token: str, configured_secret: str | None = None) -> str:
+    """Resolve the HMAC secret used to sign session tokens.
+
+    An explicit SESSION_SECRET always wins. Without one, derive a stable
+    secret from the admin token: every worker computes the same value, and
+    sessions survive restarts, with no new secret to provision. It is no
+    weaker than the admin token itself, which already grants full access.
+
+    Args:
+        admin_token: The static admin token from settings
+        configured_secret: Explicit SESSION_SECRET, or None/empty if unset
+
+    Returns:
+        The signing secret (empty if neither input is configured)
+    """
+    if configured_secret:
+        return configured_secret
+    if not admin_token:
+        return ""
+    return hmac.new(admin_token.encode("utf-8"), b"mongado-session-v1", sha256).hexdigest()
+
+
+def create_session_token(
+    secret: str,
+    credential_id: str,
+    now: float,
+    ttl_seconds: int = DEFAULT_TTL_SECONDS,
+) -> str:
+    """Mint a signed session token.
+
+    Args:
+        secret: HMAC signing secret (see derive_session_secret)
+        credential_id: The passkey credential that authenticated this session
+        now: Current unix timestamp
+        ttl_seconds: Lifetime in seconds
+
+    Returns:
+        The encoded token
+
+    Raises:
+        ValueError: If secret is empty
+    """
+    if not secret:
+        raise ValueError("cannot sign a session token without a secret")
+
+    payload: dict[str, Any] = {
+        "kind": SESSION_KIND,
+        "cred": credential_id,
+        "iat": int(now),
+        "exp": int(now) + ttl_seconds,
+    }
+    # sort_keys so the same claims always produce the same bytes
+    payload_bytes = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return f"{_b64url_encode(payload_bytes)}.{_sign(payload_bytes, secret)}"
+
+
+def looks_like_session_token(token: str) -> bool:
+    """Whether a bearer token is *shaped* like a session token.
+
+    Decidable without the signing secret, and deliberately so: it lets the
+    caller tell "your session expired" from "that is a wrong admin token",
+    so an expired session cannot burn attempts against the brute-force
+    lockout. Nothing is trusted on the strength of this - a shaped token
+    still has to pass verify_session_token.
+    """
+    if not token or token.count(".") != 1:
+        return False
+    encoded_payload = token.split(".")[0]
+    try:
+        payload = json.loads(_b64url_decode(encoded_payload))
+    except (ValueError, json.JSONDecodeError, UnicodeDecodeError):
+        return False
+    return isinstance(payload, dict) and payload.get("kind") == SESSION_KIND
+
+
+def verify_session_token(token: str, secret: str, now: float) -> SessionClaims | None:
+    """Verify a session token's signature and expiry.
+
+    Args:
+        token: The token from the Authorization header
+        secret: HMAC signing secret
+        now: Current unix timestamp
+
+    Returns:
+        SessionClaims if the token is authentic and unexpired, else None.
+        Returns None rather than raising so callers can fall through to the
+        static-token comparison without branching on exception type.
+    """
+    if not token or not secret or token.count(".") != 1:
+        return None
+
+    encoded_payload, signature = token.split(".")
+
+    try:
+        payload_bytes = _b64url_decode(encoded_payload)
+    except ValueError:
+        return None
+
+    if not hmac.compare_digest(_sign(payload_bytes, secret), signature):
+        return None
+
+    try:
+        payload = json.loads(payload_bytes)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
+
+    if not isinstance(payload, dict) or payload.get("kind") != SESSION_KIND:
+        return None
+
+    credential_id = payload.get("cred")
+    issued_at = payload.get("iat")
+    expires_at = payload.get("exp")
+    if not isinstance(credential_id, str) or not isinstance(issued_at, int):
+        return None
+    if not isinstance(expires_at, int) or int(now) >= expires_at:
+        return None
+
+    return SessionClaims(
+        credential_id=credential_id,
+        issued_at=issued_at,
+        expires_at=expires_at,
+    )

--- a/backend/main.py
+++ b/backend/main.py
@@ -39,6 +39,7 @@ from rate_limiter import RATE_LIMITS, limiter
 from routers.admin import create_admin_router
 from routers.ai import router as ai_router
 from routers.articles import router as articles_router
+from routers.auth import create_auth_router
 from routers.inspire import router as inspire_router
 from routers.notes import router as notes_router
 from routers.search import router as search_router
@@ -206,10 +207,16 @@ class CacheControlMiddleware(BaseHTTPMiddleware):
 
         # API responses - respect explicit cache headers, add defaults otherwise
         elif request.url.path.startswith("/api/") and "Cache-Control" not in response.headers:
+            # Auth state is never cacheable (#229). A cached /api/auth/session
+            # or /api/auth/credentials keeps reporting the pre-login or
+            # pre-enrollment answer for a minute after it stopped being true,
+            # and a shared cache must never hold a per-credential response.
+            if request.url.path.startswith("/api/auth/"):
+                response.headers["Cache-Control"] = "private, no-cache, no-store, must-revalidate"
             # Allow browser to cache list/read operations for 60 seconds;
             # serve stale while revalidating so refreshes never block on the
             # network for content that just changed underneath
-            if request.method == "GET":
+            elif request.method == "GET":
                 response.headers["Cache-Control"] = "public, max-age=60, stale-while-revalidate=300"
             else:
                 response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
@@ -298,6 +305,10 @@ app.include_router(templates_router)
 
 admin_router = create_admin_router(neo4j_adapter=neo4j_adapter)
 app.include_router(admin_router)
+
+# Passkey authentication (#229)
+auth_router = create_auth_router(neo4j_adapter=neo4j_adapter)
+app.include_router(auth_router)
 
 # Create uploads directory for user-uploaded images (temporary storage)
 UPLOAD_DIR = Path("uploads")

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -26,6 +26,18 @@ from models.ai import (
     SummaryResponse,
     WarmupResponse,
 )
+from models.auth import (
+    AuthenticationOptionsResponse,
+    AuthenticationVerifyRequest,
+    CredentialDeleteResponse,
+    CredentialInfo,
+    CredentialsListResponse,
+    RegistrationOptionsRequest,
+    RegistrationOptionsResponse,
+    RegistrationVerifyRequest,
+    SessionResponse,
+    SessionStatusResponse,
+)
 from models.note import (
     BacklinksResponse,
     LinkSuggestion,
@@ -75,6 +87,17 @@ __all__ = [
     "QuestionResponse",
     "SummaryResponse",
     "WarmupResponse",
+    # Auth models (passkeys)
+    "AuthenticationOptionsResponse",
+    "AuthenticationVerifyRequest",
+    "CredentialDeleteResponse",
+    "CredentialInfo",
+    "CredentialsListResponse",
+    "RegistrationOptionsRequest",
+    "RegistrationOptionsResponse",
+    "RegistrationVerifyRequest",
+    "SessionResponse",
+    "SessionStatusResponse",
     # Note models
     "BacklinksResponse",
     "LinkSuggestion",

--- a/backend/models/auth.py
+++ b/backend/models/auth.py
@@ -1,0 +1,79 @@
+"""Pydantic models for passkey (WebAuthn) admin authentication (#229)."""
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class RegistrationOptionsRequest(BaseModel):
+    """Request to begin passkey enrollment."""
+
+    name: str = Field(
+        "Passkey",
+        max_length=64,
+        description="Human label for the device being enrolled (e.g. 'MacBook')",
+    )
+
+
+class RegistrationOptionsResponse(BaseModel):
+    """WebAuthn creation options, passed straight to navigator.credentials.create()."""
+
+    options: dict[str, Any] = Field(..., description="PublicKeyCredentialCreationOptions as JSON")
+
+
+class RegistrationVerifyRequest(BaseModel):
+    """Completed registration ceremony from the browser."""
+
+    credential: dict[str, Any] = Field(..., description="Credential returned by the authenticator")
+    name: str = Field("Passkey", max_length=64, description="Human label for the device")
+
+
+class AuthenticationOptionsResponse(BaseModel):
+    """WebAuthn request options, passed to navigator.credentials.get()."""
+
+    options: dict[str, Any] = Field(..., description="PublicKeyCredentialRequestOptions as JSON")
+
+
+class AuthenticationVerifyRequest(BaseModel):
+    """Completed authentication ceremony from the browser."""
+
+    credential: dict[str, Any] = Field(..., description="Assertion returned by the authenticator")
+
+
+class SessionResponse(BaseModel):
+    """An issued admin session."""
+
+    token: str = Field(..., description="Bearer token for subsequent admin requests")
+    expires_at: int = Field(..., description="Unix timestamp when the session expires")
+    credential_name: str = Field(..., description="Name of the passkey that authenticated")
+
+
+class SessionStatusResponse(BaseModel):
+    """Whether the caller's current credentials are valid."""
+
+    authenticated: bool = Field(..., description="Whether the request carried valid admin auth")
+    kind: str = Field(..., description="'passkey', 'token', or 'none'")
+    expires_at: int | None = Field(None, description="Session expiry, for passkey sessions only")
+
+
+class CredentialInfo(BaseModel):
+    """A registered passkey, as shown in the admin UI."""
+
+    credential_id: str = Field(..., description="base64url credential ID")
+    name: str = Field(..., description="Human label for the device")
+    created_at: float = Field(..., description="Unix timestamp of enrollment")
+    last_used_at: float | None = Field(None, description="Unix timestamp of last successful login")
+
+
+class CredentialsListResponse(BaseModel):
+    """All registered passkeys."""
+
+    credentials: list[CredentialInfo] = Field(..., description="Registered passkeys, newest first")
+    count: int = Field(..., description="Number of registered passkeys")
+
+
+class CredentialDeleteResponse(BaseModel):
+    """Result of revoking a passkey."""
+
+    success: bool = Field(..., description="Whether the credential was deleted")
+    message: str = Field(..., description="Human-readable outcome")

--- a/backend/rate_limiter.py
+++ b/backend/rate_limiter.py
@@ -3,11 +3,16 @@
 Uses slowapi for rate limiting with Redis backend (if available) or in-memory fallback.
 """
 
+import os
+
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
-# Create rate limiter using remote IP as key
-limiter = Limiter(key_func=get_remote_address)
+# Create rate limiter using remote IP as key. Disabled under TESTING so a test
+# file's many calls to one endpoint do not trip the limit (every request in a
+# TestClient shares the key "testclient"); routers/notes.py already did this
+# for its own limiter.
+limiter = Limiter(key_func=get_remote_address, enabled=os.getenv("TESTING") != "1")
 
 # Rate limit presets for different endpoint types
 RATE_LIMITS = {

--- a/backend/requirements-base.txt
+++ b/backend/requirements-base.txt
@@ -10,6 +10,7 @@ ollama==0.6.0  # Ollama Python client for AI features
 httpx==0.28.1  # HTTP client for hosted LLM APIs (Groq/Gemini)
 neo4j==6.0.2  # Neo4j driver for graph database (notes)
 slowapi==0.1.9  # Rate limiting for FastAPI
+webauthn==3.0.0  # Passkey (WebAuthn) admin authentication (#229)
 rapidfuzz==3.10.1  # Fuzzy string matching for search
 psutil==7.0.0  # Server resource usage endpoint (/api/admin/health/resources)
 python-dateutil==2.9.0.post0  # Date parsing in articles router (was a phantom dep via boto3)

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,0 +1,332 @@
+"""Passkey (WebAuthn) admin authentication endpoints (#229).
+
+Replaces the static admin token as the login mechanism for humans. The token
+itself is not retired: CI/automation callers (deploy-time backups) still use
+it, and it gates first-time passkey enrollment.
+
+Ceremony flow:
+    1. POST /api/auth/register/options    -> creation options + stored challenge
+    2. POST /api/auth/register/verify     -> credential persisted to Neo4j
+    3. POST /api/auth/login/options       -> request options + stored challenge
+    4. POST /api/auth/login/verify        -> signed session token
+
+Challenges live in Neo4j rather than memory because production runs four
+uvicorn workers; the worker that issues a challenge is usually not the one
+that verifies the response.
+"""
+
+import json
+import logging
+import time
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from webauthn import (
+    generate_authentication_options,
+    generate_registration_options,
+    options_to_json,
+    verify_authentication_response,
+    verify_registration_response,
+)
+from webauthn.helpers import base64url_to_bytes, bytes_to_base64url, parse_client_data_json
+from webauthn.helpers.exceptions import InvalidAuthenticationResponse, InvalidRegistrationResponse
+from webauthn.helpers.structs import (
+    AuthenticatorSelectionCriteria,
+    PublicKeyCredentialDescriptor,
+    ResidentKeyRequirement,
+    UserVerificationRequirement,
+)
+
+from auth import AdminUser, verify_admin_optional
+from config import Settings, get_settings
+from core.sessions import (
+    DEFAULT_TTL_SECONDS,
+    create_session_token,
+    derive_session_secret,
+)
+from models import (
+    AuthenticationOptionsResponse,
+    AuthenticationVerifyRequest,
+    CredentialDeleteResponse,
+    CredentialInfo,
+    CredentialsListResponse,
+    RegistrationOptionsRequest,
+    RegistrationOptionsResponse,
+    RegistrationVerifyRequest,
+    SessionResponse,
+    SessionStatusResponse,
+)
+from rate_limiter import RATE_LIMITS, limiter
+
+logger = logging.getLogger(__name__)
+
+CHALLENGE_TTL_SECONDS = 5 * 60
+"""How long a ceremony may sit unfinished. Matches the 60s authenticator
+timeout with generous slack for the OS prompt and a fumbled Touch ID."""
+
+ADMIN_USER_NAME = "admin"
+"""Single-admin site: every passkey belongs to the same notional user, so
+the user handle is constant and the login ceremony can be usernameless."""
+
+
+def create_auth_router(neo4j_adapter: Any) -> APIRouter:
+    """Create the passkey auth router with dependencies injected.
+
+    Args:
+        neo4j_adapter: Neo4j adapter for credential and challenge storage
+
+    Returns:
+        Configured APIRouter with auth endpoints
+    """
+    # Created per call rather than at module level: a shared router object
+    # would have every factory call register duplicate paths onto it, and the
+    # first registration (with whichever adapter it captured) would win.
+    router = APIRouter(prefix="/api/auth", tags=["auth"])
+
+    def _require_neo4j() -> None:
+        """Passkeys need persistent storage; fail loudly rather than half-work."""
+        if not neo4j_adapter.is_available():
+            raise HTTPException(
+                status_code=503,
+                detail="Passkey authentication unavailable: database not reachable.",
+            )
+
+    def _stored_credentials() -> list[dict[str, Any]]:
+        return list(neo4j_adapter.list_admin_credentials())
+
+    def _session_secret(settings: Settings) -> str:
+        secret = derive_session_secret(settings.admin_token, settings.session_secret)
+        if not secret:
+            raise HTTPException(
+                status_code=500,
+                detail="Server configuration error: no session signing secret available.",
+            )
+        return secret
+
+    def _challenge_from_credential(credential: dict[str, Any]) -> str:
+        """Extract the echoed challenge from a ceremony response.
+
+        The authenticator returns the challenge we issued inside
+        clientDataJSON. Reading it here lets us look the challenge up in the
+        store; consuming it proves we issued it and that it is unused, and
+        py_webauthn then re-verifies the match as part of its own checks.
+        """
+        try:
+            client_data_b64 = credential["response"]["clientDataJSON"]
+            client_data = parse_client_data_json(base64url_to_bytes(client_data_b64))
+            return bytes_to_base64url(client_data.challenge)
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as e:
+            logger.warning("Malformed credential payload: %s", e)
+            raise HTTPException(status_code=400, detail="Malformed credential payload.") from e
+
+    @router.post("/register/options", response_model=RegistrationOptionsResponse)
+    @limiter.limit(RATE_LIMITS["admin"])
+    async def registration_options(
+        request: Request,
+        body: RegistrationOptionsRequest,
+        _admin: AdminUser,
+        settings: Annotated[Settings, Depends(get_settings)],
+    ) -> RegistrationOptionsResponse:
+        """Begin passkey enrollment.
+
+        Requires existing admin auth: the static token for the first passkey,
+        a live passkey session for every one after. There is deliberately no
+        unauthenticated enrollment path.
+        """
+        _require_neo4j()
+
+        existing = _stored_credentials()
+        options = generate_registration_options(
+            rp_id=settings.webauthn_rp_id_resolved,
+            rp_name=settings.webauthn_rp_name,
+            user_name=ADMIN_USER_NAME,
+            user_display_name=ADMIN_USER_NAME,
+            user_id=ADMIN_USER_NAME.encode("utf-8"),
+            # Stop the same authenticator from enrolling twice
+            exclude_credentials=[
+                PublicKeyCredentialDescriptor(id=base64url_to_bytes(c["credential_id"]))
+                for c in existing
+            ],
+            authenticator_selection=AuthenticatorSelectionCriteria(
+                resident_key=ResidentKeyRequirement.PREFERRED,
+                user_verification=UserVerificationRequirement.PREFERRED,
+            ),
+        )
+
+        neo4j_adapter.store_webauthn_challenge(
+            bytes_to_base64url(options.challenge), "registration", CHALLENGE_TTL_SECONDS
+        )
+        logger.info("Issued passkey registration challenge for '%s'", body.name)
+        return RegistrationOptionsResponse(options=json.loads(options_to_json(options)))
+
+    @router.post("/register/verify", response_model=CredentialsListResponse)
+    @limiter.limit(RATE_LIMITS["admin"])
+    async def registration_verify(
+        request: Request,
+        body: RegistrationVerifyRequest,
+        _admin: AdminUser,
+        settings: Annotated[Settings, Depends(get_settings)],
+    ) -> CredentialsListResponse:
+        """Complete passkey enrollment and persist the credential."""
+        _require_neo4j()
+
+        challenge = _challenge_from_credential(body.credential)
+        if not neo4j_adapter.consume_webauthn_challenge(challenge, "registration"):
+            raise HTTPException(
+                status_code=400, detail="Registration challenge expired or already used."
+            )
+
+        try:
+            verified = verify_registration_response(
+                credential=body.credential,
+                expected_challenge=base64url_to_bytes(challenge),
+                expected_rp_id=settings.webauthn_rp_id_resolved,
+                expected_origin=settings.cors_origins_list,
+            )
+        except InvalidRegistrationResponse as e:
+            logger.warning("Passkey registration rejected: %s", e)
+            raise HTTPException(status_code=400, detail=f"Registration failed: {e}") from e
+
+        neo4j_adapter.create_admin_credential(
+            credential_id=bytes_to_base64url(verified.credential_id),
+            public_key=verified.credential_public_key,
+            sign_count=verified.sign_count,
+            name=body.name,
+        )
+        logger.info("Registered passkey '%s'", body.name)
+        return _credentials_response()
+
+    @router.post("/login/options", response_model=AuthenticationOptionsResponse)
+    @limiter.limit(RATE_LIMITS["admin"])
+    async def authentication_options(
+        request: Request,
+        settings: Annotated[Settings, Depends(get_settings)],
+    ) -> AuthenticationOptionsResponse:
+        """Begin passkey login. Unauthenticated by necessity."""
+        _require_neo4j()
+
+        credentials = _stored_credentials()
+        if not credentials:
+            raise HTTPException(
+                status_code=409,
+                detail="No passkeys registered. Enroll one from the admin page first.",
+            )
+
+        options = generate_authentication_options(
+            rp_id=settings.webauthn_rp_id_resolved,
+            allow_credentials=[
+                PublicKeyCredentialDescriptor(id=base64url_to_bytes(c["credential_id"]))
+                for c in credentials
+            ],
+            user_verification=UserVerificationRequirement.PREFERRED,
+        )
+
+        neo4j_adapter.store_webauthn_challenge(
+            bytes_to_base64url(options.challenge), "authentication", CHALLENGE_TTL_SECONDS
+        )
+        return AuthenticationOptionsResponse(options=json.loads(options_to_json(options)))
+
+    @router.post("/login/verify", response_model=SessionResponse)
+    @limiter.limit(RATE_LIMITS["admin"])
+    async def authentication_verify(
+        request: Request,
+        body: AuthenticationVerifyRequest,
+        settings: Annotated[Settings, Depends(get_settings)],
+    ) -> SessionResponse:
+        """Complete passkey login and issue a session token."""
+        _require_neo4j()
+
+        challenge = _challenge_from_credential(body.credential)
+        if not neo4j_adapter.consume_webauthn_challenge(challenge, "authentication"):
+            raise HTTPException(status_code=400, detail="Login challenge expired or already used.")
+
+        credential_id = body.credential.get("id")
+        if not isinstance(credential_id, str):
+            raise HTTPException(status_code=400, detail="Malformed credential payload.")
+
+        stored = neo4j_adapter.get_admin_credential(credential_id)
+        if not stored:
+            logger.warning("Login attempt with unknown credential %s", credential_id[:12])
+            raise HTTPException(status_code=403, detail="Unknown passkey.")
+
+        try:
+            verified = verify_authentication_response(
+                credential=body.credential,
+                expected_challenge=base64url_to_bytes(challenge),
+                expected_rp_id=settings.webauthn_rp_id_resolved,
+                expected_origin=settings.cors_origins_list,
+                credential_public_key=stored["public_key"],
+                credential_current_sign_count=stored["sign_count"],
+            )
+        except InvalidAuthenticationResponse as e:
+            logger.warning("Passkey login rejected: %s", e)
+            raise HTTPException(status_code=403, detail=f"Login failed: {e}") from e
+
+        neo4j_adapter.record_admin_credential_use(credential_id, verified.new_sign_count)
+
+        now = time.time()
+        token = create_session_token(
+            secret=_session_secret(settings),
+            credential_id=credential_id,
+            now=now,
+            ttl_seconds=DEFAULT_TTL_SECONDS,
+        )
+        logger.info("Passkey login succeeded for '%s'", stored["name"])
+        return SessionResponse(
+            token=token,
+            expires_at=int(now) + DEFAULT_TTL_SECONDS,
+            credential_name=stored["name"],
+        )
+
+    @router.get("/session", response_model=SessionStatusResponse)
+    async def session_status(
+        auth: Annotated[dict[str, Any], Depends(verify_admin_optional)],
+    ) -> SessionStatusResponse:
+        """Report whether the caller's credentials are currently valid.
+
+        Replaces the frontend's old "create a note then delete it" probe.
+        Never 401s - the answer to "am I logged in?" is a 200 either way.
+        """
+        return SessionStatusResponse(
+            authenticated=auth["authenticated"],
+            kind=auth["kind"],
+            expires_at=auth.get("expires_at"),
+        )
+
+    def _credentials_response() -> CredentialsListResponse:
+        credentials = [
+            CredentialInfo(
+                credential_id=c["credential_id"],
+                name=c["name"] or "Passkey",
+                created_at=c["created_at"] or 0.0,
+                last_used_at=c["last_used_at"],
+            )
+            for c in _stored_credentials()
+        ]
+        return CredentialsListResponse(credentials=credentials, count=len(credentials))
+
+    @router.get("/credentials", response_model=CredentialsListResponse)
+    async def list_credentials(_admin: AdminUser) -> CredentialsListResponse:
+        """List registered passkeys."""
+        _require_neo4j()
+        return _credentials_response()
+
+    # Plain path param, not `:path` - credential IDs are base64url, which has
+    # no "/", so nothing needs to span segments
+    @router.delete("/credentials/{credential_id}", response_model=CredentialDeleteResponse)
+    async def delete_credential(credential_id: str, _admin: AdminUser) -> CredentialDeleteResponse:
+        """Revoke a passkey.
+
+        Deleting the last one is allowed: the static admin token remains a
+        working way back in, so this cannot lock the admin out.
+        """
+        _require_neo4j()
+
+        deleted = neo4j_adapter.delete_admin_credential(credential_id)
+        if not deleted:
+            raise HTTPException(status_code=404, detail="Passkey not found.")
+
+        logger.info("Revoked passkey %s", credential_id[:12])
+        return CredentialDeleteResponse(success=True, message="Passkey revoked.")
+
+    return router

--- a/backend/tests/unit/test_auth_api.py
+++ b/backend/tests/unit/test_auth_api.py
@@ -1,0 +1,460 @@
+"""Tests for passkey authentication endpoints (#229).
+
+The WebAuthn ceremonies themselves need a real authenticator, so they are
+exercised in the browser with a virtual authenticator rather than here.
+These tests cover everything around them: which endpoints require auth,
+challenge issuance and single-use consumption, credential management, and
+the interaction between session tokens and the #225 brute-force lockout.
+"""
+
+import os
+import time
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+os.environ["TESTING"] = "1"
+
+from auth import MAX_FAILED_ATTEMPTS
+from config import get_settings
+from core.sessions import create_session_token, derive_session_secret
+from main import app as real_app
+from routers.auth import create_auth_router
+
+TEST_ADMIN_TOKEN = "test-admin-token-for-ci"
+
+
+def _admin_token() -> str:
+    return get_settings().admin_token or TEST_ADMIN_TOKEN
+
+
+@pytest.fixture
+def admin_headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {_admin_token()}"}
+
+
+@pytest.fixture
+def session_headers() -> dict[str, str]:
+    """Headers carrying a valid passkey session token."""
+    settings = get_settings()
+    secret = derive_session_secret(_admin_token(), settings.session_secret)
+    token = create_session_token(secret, "test-credential", time.time())
+    return {"Authorization": f"Bearer {token}"}
+
+
+class FakeNeo4jAdapter:
+    """In-memory stand-in for the Neo4j adapter.
+
+    CI has no Neo4j, and these endpoints are pure orchestration over the
+    adapter's interface, so a fake keeps the tests honest without a server.
+    """
+
+    def __init__(self, available: bool = True) -> None:
+        self._available = available
+        self.credentials: list[dict[str, Any]] = []
+        self.challenges: list[tuple[str, str, float]] = []
+
+    def is_available(self) -> bool:
+        return self._available
+
+    def list_admin_credentials(self) -> list[dict[str, Any]]:
+        return list(self.credentials)
+
+    def get_admin_credential(self, credential_id: str) -> dict[str, Any] | None:
+        return next(
+            (c for c in self.credentials if c["credential_id"] == credential_id),
+            None,
+        )
+
+    def create_admin_credential(
+        self, credential_id: str, public_key: bytes, sign_count: int, name: str
+    ) -> bool:
+        self.credentials.append(
+            {
+                "credential_id": credential_id,
+                "public_key": public_key,
+                "sign_count": sign_count,
+                "name": name,
+                "created_at": time.time(),
+                "last_used_at": None,
+            }
+        )
+        return True
+
+    def record_admin_credential_use(self, credential_id: str, sign_count: int) -> bool:
+        credential = self.get_admin_credential(credential_id)
+        if not credential:
+            return False
+        credential["sign_count"] = sign_count
+        credential["last_used_at"] = time.time()
+        return True
+
+    def delete_admin_credential(self, credential_id: str) -> bool:
+        before = len(self.credentials)
+        self.credentials = [c for c in self.credentials if c["credential_id"] != credential_id]
+        return len(self.credentials) < before
+
+    def store_webauthn_challenge(self, challenge: str, purpose: str, ttl_seconds: float) -> bool:
+        self.challenges.append((challenge, purpose, time.time() + ttl_seconds))
+        return True
+
+    def consume_webauthn_challenge(self, challenge: str, purpose: str) -> bool:
+        now = time.time()
+        for entry in self.challenges:
+            if entry[0] == challenge and entry[1] == purpose and entry[2] >= now:
+                self.challenges.remove(entry)
+                return True
+        return False
+
+
+def _client(adapter: FakeNeo4jAdapter) -> TestClient:
+    """Mount the auth router alone, over the given adapter."""
+    app = FastAPI()
+    app.include_router(create_auth_router(neo4j_adapter=adapter))
+    return TestClient(app)
+
+
+@pytest.fixture
+def adapter() -> FakeNeo4jAdapter:
+    return FakeNeo4jAdapter()
+
+
+@pytest.fixture
+def client(adapter: FakeNeo4jAdapter) -> TestClient:
+    return _client(adapter)
+
+
+class TestRegistrationOptions:
+    """POST /api/auth/register/options."""
+
+    def test_requires_auth(self, client: TestClient) -> None:
+        """Enrollment is never open - there is no unauthenticated path in."""
+        response = client.post("/api/auth/register/options", json={"name": "Laptop"})
+        assert response.status_code == 401
+
+    def test_rejects_invalid_token(self, client: TestClient) -> None:
+        response = client.post(
+            "/api/auth/register/options",
+            json={"name": "Laptop"},
+            headers={"Authorization": "Bearer wrong-token"},
+        )
+        assert response.status_code == 403
+
+    def test_returns_creation_options(
+        self, client: TestClient, admin_headers: dict[str, str]
+    ) -> None:
+        response = client.post(
+            "/api/auth/register/options", json={"name": "Laptop"}, headers=admin_headers
+        )
+        assert response.status_code == 200
+        options = response.json()["options"]
+        assert options["challenge"]
+        assert options["rp"]["name"] == "Mongado"
+        assert options["user"]["name"] == "admin"
+
+    def test_stores_challenge(
+        self,
+        client: TestClient,
+        adapter: FakeNeo4jAdapter,
+        admin_headers: dict[str, str],
+    ) -> None:
+        client.post("/api/auth/register/options", json={"name": "Laptop"}, headers=admin_headers)
+        assert len(adapter.challenges) == 1
+        assert adapter.challenges[0][1] == "registration"
+
+    def test_session_token_can_enroll_another_passkey(
+        self, client: TestClient, session_headers: dict[str, str]
+    ) -> None:
+        """A signed-in admin adds a second device without the static token."""
+        response = client.post(
+            "/api/auth/register/options", json={"name": "Phone"}, headers=session_headers
+        )
+        assert response.status_code == 200
+
+    def test_excludes_existing_credentials(
+        self,
+        client: TestClient,
+        adapter: FakeNeo4jAdapter,
+        admin_headers: dict[str, str],
+    ) -> None:
+        """An already-enrolled authenticator must not enroll twice."""
+        adapter.create_admin_credential("dGVzdC1jcmVk", b"key", 0, "Existing")
+        response = client.post(
+            "/api/auth/register/options", json={"name": "Laptop"}, headers=admin_headers
+        )
+        assert len(response.json()["options"]["excludeCredentials"]) == 1
+
+
+class TestRegistrationVerify:
+    """POST /api/auth/register/verify."""
+
+    def test_requires_auth(self, client: TestClient) -> None:
+        response = client.post(
+            "/api/auth/register/verify", json={"credential": {}, "name": "Laptop"}
+        )
+        assert response.status_code == 401
+
+    def test_rejects_malformed_credential(
+        self, client: TestClient, admin_headers: dict[str, str]
+    ) -> None:
+        response = client.post(
+            "/api/auth/register/verify",
+            json={"credential": {"nonsense": True}, "name": "Laptop"},
+            headers=admin_headers,
+        )
+        assert response.status_code == 400
+        assert "Malformed" in response.json()["detail"]
+
+
+class TestAuthenticationOptions:
+    """POST /api/auth/login/options."""
+
+    def test_conflict_when_no_passkeys(self, client: TestClient) -> None:
+        """Nothing to authenticate against yet - say so instead of 500ing."""
+        response = client.post("/api/auth/login/options")
+        assert response.status_code == 409
+
+    def test_returns_request_options(self, client: TestClient, adapter: FakeNeo4jAdapter) -> None:
+        adapter.create_admin_credential("dGVzdC1jcmVk", b"key", 0, "Laptop")
+        response = client.post("/api/auth/login/options")
+        assert response.status_code == 200
+        options = response.json()["options"]
+        assert options["challenge"]
+        assert len(options["allowCredentials"]) == 1
+
+    def test_needs_no_auth(self, client: TestClient, adapter: FakeNeo4jAdapter) -> None:
+        """Login cannot require being logged in."""
+        adapter.create_admin_credential("dGVzdC1jcmVk", b"key", 0, "Laptop")
+        assert client.post("/api/auth/login/options").status_code == 200
+
+    def test_stores_challenge(self, client: TestClient, adapter: FakeNeo4jAdapter) -> None:
+        adapter.create_admin_credential("dGVzdC1jcmVk", b"key", 0, "Laptop")
+        client.post("/api/auth/login/options")
+        assert adapter.challenges[0][1] == "authentication"
+
+
+class TestChallengeLifecycle:
+    """Challenges are single-use and scoped to their ceremony."""
+
+    def test_consume_removes_challenge(self, adapter: FakeNeo4jAdapter) -> None:
+        adapter.store_webauthn_challenge("abc", "registration", 60)
+        assert adapter.consume_webauthn_challenge("abc", "registration") is True
+        assert adapter.consume_webauthn_challenge("abc", "registration") is False
+
+    def test_purpose_is_scoped(self, adapter: FakeNeo4jAdapter) -> None:
+        """A registration challenge must not authorize a login."""
+        adapter.store_webauthn_challenge("abc", "registration", 60)
+        assert adapter.consume_webauthn_challenge("abc", "authentication") is False
+
+    def test_expired_challenge_rejected(self, adapter: FakeNeo4jAdapter) -> None:
+        adapter.store_webauthn_challenge("abc", "registration", -1)
+        assert adapter.consume_webauthn_challenge("abc", "registration") is False
+
+    def test_login_rejects_unknown_challenge(
+        self, client: TestClient, adapter: FakeNeo4jAdapter
+    ) -> None:
+        """A well-formed response whose challenge we never issued is refused."""
+        adapter.create_admin_credential("dGVzdC1jcmVk", b"key", 0, "Laptop")
+        # clientDataJSON for a challenge the server never stored
+        import base64
+        import json as json_lib
+
+        client_data = base64.urlsafe_b64encode(
+            json_lib.dumps(
+                {"type": "webauthn.get", "challenge": "bm90LW91cnM", "origin": "http://x"}
+            ).encode()
+        ).decode()
+        response = client.post(
+            "/api/auth/login/verify",
+            json={
+                "credential": {"id": "dGVzdC1jcmVk", "response": {"clientDataJSON": client_data}}
+            },
+        )
+        assert response.status_code == 400
+        assert "expired or already used" in response.json()["detail"]
+
+
+class TestCredentialManagement:
+    """GET/DELETE /api/auth/credentials."""
+
+    def test_list_requires_auth(self, client: TestClient) -> None:
+        assert client.get("/api/auth/credentials").status_code == 401
+
+    def test_list_returns_credentials(
+        self,
+        client: TestClient,
+        adapter: FakeNeo4jAdapter,
+        admin_headers: dict[str, str],
+    ) -> None:
+        adapter.create_admin_credential("dGVzdC1jcmVk", b"key", 0, "Laptop")
+        response = client.get("/api/auth/credentials", headers=admin_headers)
+        assert response.status_code == 200
+        body = response.json()
+        assert body["count"] == 1
+        assert body["credentials"][0]["name"] == "Laptop"
+
+    def test_list_never_leaks_public_key(
+        self,
+        client: TestClient,
+        adapter: FakeNeo4jAdapter,
+        admin_headers: dict[str, str],
+    ) -> None:
+        adapter.create_admin_credential("dGVzdC1jcmVk", b"secret-key-bytes", 0, "Laptop")
+        body = client.get("/api/auth/credentials", headers=admin_headers).text
+        assert "public_key" not in body
+
+    def test_delete_requires_auth(self, client: TestClient) -> None:
+        assert client.delete("/api/auth/credentials/dGVzdC1jcmVk").status_code == 401
+
+    def test_delete_removes_credential(
+        self,
+        client: TestClient,
+        adapter: FakeNeo4jAdapter,
+        admin_headers: dict[str, str],
+    ) -> None:
+        adapter.create_admin_credential("dGVzdC1jcmVk", b"key", 0, "Laptop")
+        response = client.delete("/api/auth/credentials/dGVzdC1jcmVk", headers=admin_headers)
+        assert response.status_code == 200
+        assert adapter.credentials == []
+
+    def test_delete_unknown_returns_404(
+        self, client: TestClient, admin_headers: dict[str, str]
+    ) -> None:
+        response = client.delete("/api/auth/credentials/missing", headers=admin_headers)
+        assert response.status_code == 404
+
+    def test_delete_last_credential_allowed(
+        self,
+        client: TestClient,
+        adapter: FakeNeo4jAdapter,
+        admin_headers: dict[str, str],
+    ) -> None:
+        """The static token is still a way back in, so this cannot lock anyone out."""
+        adapter.create_admin_credential("dGVzdC1jcmVk", b"key", 0, "Only")
+        assert (
+            client.delete("/api/auth/credentials/dGVzdC1jcmVk", headers=admin_headers).status_code
+            == 200
+        )
+
+
+class TestNeo4jUnavailable:
+    """Passkeys need storage; the failure must be explicit."""
+
+    def test_register_options_returns_503(self, admin_headers: dict[str, str]) -> None:
+        client = _client(FakeNeo4jAdapter(available=False))
+        response = client.post(
+            "/api/auth/register/options", json={"name": "Laptop"}, headers=admin_headers
+        )
+        assert response.status_code == 503
+
+    def test_login_options_returns_503(self) -> None:
+        client = _client(FakeNeo4jAdapter(available=False))
+        assert client.post("/api/auth/login/options").status_code == 503
+
+
+class TestSessionStatus:
+    """GET /api/auth/session - the 'am I signed in?' probe."""
+
+    def test_unauthenticated_is_200_not_401(self, client: TestClient) -> None:
+        response = client.get("/api/auth/session")
+        assert response.status_code == 200
+        assert response.json() == {"authenticated": False, "kind": "none", "expires_at": None}
+
+    def test_static_token_reported_as_token(
+        self, client: TestClient, admin_headers: dict[str, str]
+    ) -> None:
+        body = client.get("/api/auth/session", headers=admin_headers).json()
+        assert body["authenticated"] is True
+        assert body["kind"] == "token"
+
+    def test_session_token_reported_as_passkey(
+        self, client: TestClient, session_headers: dict[str, str]
+    ) -> None:
+        body = client.get("/api/auth/session", headers=session_headers).json()
+        assert body["authenticated"] is True
+        assert body["kind"] == "passkey"
+        assert body["expires_at"] > time.time()
+
+    def test_expired_session_reported_unauthenticated(self, client: TestClient) -> None:
+        secret = derive_session_secret(_admin_token(), get_settings().session_secret)
+        expired = create_session_token(secret, "cred", time.time() - 100_000)
+        body = client.get(
+            "/api/auth/session", headers={"Authorization": f"Bearer {expired}"}
+        ).json()
+        assert body["authenticated"] is False
+
+
+class TestAuthResponsesAreNotCacheable:
+    """Auth state must never be served from a cache.
+
+    Regression for a bug found in browser testing: the API's blanket
+    `max-age=60` on GETs meant that after enrolling a passkey, the admin page
+    kept rendering the cached pre-enrollment (empty) credential list, and
+    /api/auth/session kept reporting the pre-login answer, for a full minute.
+    """
+
+    def test_session_endpoint_is_no_store(self) -> None:
+        client = TestClient(real_app)
+        response = client.get("/api/auth/session")
+        assert "no-store" in response.headers["Cache-Control"]
+
+    def test_credentials_endpoint_is_no_store(self, admin_headers: dict[str, str]) -> None:
+        client = TestClient(real_app)
+        response = client.get("/api/auth/credentials", headers=admin_headers)
+        assert "no-store" in response.headers["Cache-Control"]
+
+    def test_auth_responses_are_private(self, admin_headers: dict[str, str]) -> None:
+        """A shared cache must not hold one caller's credential list."""
+        client = TestClient(real_app)
+        response = client.get("/api/auth/credentials", headers=admin_headers)
+        assert "private" in response.headers["Cache-Control"]
+
+    def test_other_get_endpoints_still_cache(self) -> None:
+        """The fix must not disable caching for the rest of the API."""
+        client = TestClient(real_app)
+        response = client.get("/api/notes?limit=1")
+        assert "max-age=60" in response.headers["Cache-Control"]
+
+
+class TestSessionTokenAcceptedByAdminEndpoints:
+    """Session tokens must work everywhere the static token did."""
+
+    def test_session_token_authorizes_admin_endpoint(self, session_headers: dict[str, str]) -> None:
+        client = TestClient(real_app)
+        response = client.get("/api/admin/backups", headers=session_headers)
+        assert response.status_code == 200
+
+    def test_expired_session_gets_401_not_403(self) -> None:
+        """401 tells the frontend to re-authenticate; 403 means a bad token."""
+        client = TestClient(real_app)
+        secret = derive_session_secret(_admin_token(), get_settings().session_secret)
+        expired = create_session_token(secret, "cred", time.time() - 100_000)
+        response = client.get("/api/admin/backups", headers={"Authorization": f"Bearer {expired}"})
+        assert response.status_code == 401
+        assert "Session expired" in response.json()["detail"]
+
+    def test_expired_sessions_do_not_trigger_lockout(self) -> None:
+        """A stale browser tab must not lock the admin out of signing back in."""
+        client = TestClient(real_app)
+        secret = derive_session_secret(_admin_token(), get_settings().session_secret)
+        expired = create_session_token(secret, "cred", time.time() - 100_000)
+        headers = {"Authorization": f"Bearer {expired}"}
+
+        for _ in range(MAX_FAILED_ATTEMPTS + 2):
+            assert client.get("/api/admin/backups", headers=headers).status_code == 401
+
+        # Not locked out: a valid token still works
+        response = client.get(
+            "/api/admin/backups", headers={"Authorization": f"Bearer {_admin_token()}"}
+        )
+        assert response.status_code == 200
+
+    def test_forged_session_signature_rejected(self) -> None:
+        """A session token signed with the wrong secret is not session-shaped auth."""
+        client = TestClient(real_app)
+        forged = create_session_token("attacker-secret", "cred", time.time())
+        response = client.get("/api/admin/backups", headers={"Authorization": f"Bearer {forged}"})
+        # Shaped like a session but unverifiable -> 401, never authorized
+        assert response.status_code == 401

--- a/backend/tests/unit/test_core_sessions.py
+++ b/backend/tests/unit/test_core_sessions.py
@@ -1,0 +1,142 @@
+"""Tests for session-token logic (pure functions, #229)."""
+
+import base64
+import json
+
+from core.sessions import (
+    DEFAULT_TTL_SECONDS,
+    create_session_token,
+    derive_session_secret,
+    looks_like_session_token,
+    verify_session_token,
+)
+
+SECRET = "test-signing-secret"
+NOW = 1_700_000_000.0
+
+
+class TestDeriveSessionSecret:
+    """Resolving the signing secret."""
+
+    def test_explicit_secret_wins(self) -> None:
+        assert derive_session_secret("admin-token", "explicit") == "explicit"
+
+    def test_derived_from_admin_token(self) -> None:
+        derived = derive_session_secret("admin-token")
+        assert derived
+        assert derived != "admin-token"
+
+    def test_derivation_is_stable(self) -> None:
+        """Every worker must derive the same secret, or sessions break at random."""
+        assert derive_session_secret("admin-token") == derive_session_secret("admin-token")
+
+    def test_different_tokens_derive_different_secrets(self) -> None:
+        assert derive_session_secret("token-a") != derive_session_secret("token-b")
+
+    def test_no_inputs_yields_no_secret(self) -> None:
+        assert derive_session_secret("", "") == ""
+
+
+class TestRoundTrip:
+    """Minting and verifying."""
+
+    def test_valid_token_verifies(self) -> None:
+        token = create_session_token(SECRET, "cred-1", NOW)
+        claims = verify_session_token(token, SECRET, NOW + 60)
+        assert claims is not None
+        assert claims.credential_id == "cred-1"
+        assert claims.expires_at == int(NOW) + DEFAULT_TTL_SECONDS
+
+    def test_custom_ttl_honored(self) -> None:
+        token = create_session_token(SECRET, "cred-1", NOW, ttl_seconds=30)
+        assert verify_session_token(token, SECRET, NOW + 10) is not None
+        assert verify_session_token(token, SECRET, NOW + 31) is None
+
+    def test_expired_token_rejected(self) -> None:
+        token = create_session_token(SECRET, "cred-1", NOW)
+        assert verify_session_token(token, SECRET, NOW + DEFAULT_TTL_SECONDS + 1) is None
+
+    def test_expiry_boundary_is_exclusive(self) -> None:
+        """A token is dead *at* its expiry, not one second after."""
+        token = create_session_token(SECRET, "cred-1", NOW, ttl_seconds=10)
+        assert verify_session_token(token, SECRET, NOW + 10) is None
+
+    def test_wrong_secret_rejected(self) -> None:
+        token = create_session_token(SECRET, "cred-1", NOW)
+        assert verify_session_token(token, "other-secret", NOW) is None
+
+    def test_empty_secret_cannot_sign(self) -> None:
+        try:
+            create_session_token("", "cred-1", NOW)
+        except ValueError:
+            return
+        raise AssertionError("signing with an empty secret must raise")
+
+    def test_empty_secret_verifies_nothing(self) -> None:
+        token = create_session_token(SECRET, "cred-1", NOW)
+        assert verify_session_token(token, "", NOW) is None
+
+
+class TestTampering:
+    """A token whose payload was edited must not verify."""
+
+    def test_modified_payload_rejected(self) -> None:
+        token = create_session_token(SECRET, "cred-1", NOW)
+        encoded_payload, signature = token.split(".")
+        payload = json.loads(base64.urlsafe_b64decode(encoded_payload + "=="))
+        payload["exp"] += 10_000
+        forged = (
+            base64.urlsafe_b64encode(
+                json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+            )
+            .decode()
+            .rstrip("=")
+        )
+        assert verify_session_token(f"{forged}.{signature}", SECRET, NOW) is None
+
+    def test_swapped_signature_rejected(self) -> None:
+        a = create_session_token(SECRET, "cred-a", NOW)
+        b = create_session_token(SECRET, "cred-b", NOW)
+        forged = f"{a.split('.')[0]}.{b.split('.')[1]}"
+        assert verify_session_token(forged, SECRET, NOW) is None
+
+    def test_malformed_tokens_rejected(self) -> None:
+        for bad in ["", "nodot", "a.b.c", "!!!.###", ".", "a."]:
+            assert verify_session_token(bad, SECRET, NOW) is None
+
+    def test_non_session_payload_rejected(self) -> None:
+        """A correctly-signed blob that is not a session must not authenticate."""
+        payload = json.dumps({"kind": "other", "cred": "x", "iat": 1, "exp": 9_999_999_999})
+        encoded = base64.urlsafe_b64encode(payload.encode()).decode().rstrip("=")
+        # Sign it properly, so only the `kind` check can reject it
+        import hmac
+        from hashlib import sha256
+
+        sig = (
+            base64.urlsafe_b64encode(
+                hmac.new(SECRET.encode(), base64.urlsafe_b64decode(encoded + "=="), sha256).digest()
+            )
+            .decode()
+            .rstrip("=")
+        )
+        assert verify_session_token(f"{encoded}.{sig}", SECRET, NOW) is None
+
+
+class TestLooksLikeSessionToken:
+    """Shape detection, which decides 401-expired vs 403-wrong-token."""
+
+    def test_real_token_looks_like_one(self) -> None:
+        assert looks_like_session_token(create_session_token(SECRET, "cred-1", NOW)) is True
+
+    def test_expired_token_still_looks_like_one(self) -> None:
+        """The whole point: an expired session must be recognizable as a session."""
+        token = create_session_token(SECRET, "cred-1", NOW - 100_000)
+        assert verify_session_token(token, SECRET, NOW) is None
+        assert looks_like_session_token(token) is True
+
+    def test_static_token_does_not(self) -> None:
+        assert looks_like_session_token("some-static-admin-token") is False
+
+    def test_garbage_does_not(self) -> None:
+        for bad in ["", "a.b.c", "!!!.@@@", "nodot"]:
+            assert looks_like_session_token(bad) is False

--- a/docs/API.md
+++ b/docs/API.md
@@ -25,7 +25,10 @@ Mongado API comes with built-in interactive documentation powered by FastAPI:
 
 ### Authentication
 
-For admin-only endpoints (creating persistent notes, etc.):
+Admin endpoints accept either a **passkey session token** or the **static
+admin token**, both as `Authorization: Bearer <value>`. In the browser, sign
+in at `/login` with a passkey; see `docs/knowledge-base/NOTES.md` for setup.
+For Swagger and scripts, use the static admin token:
 
 1. Click the **Authorize** button (🔓) at the top right
 2. Enter your admin token in the "Value" field (without "Bearer " prefix)

--- a/docs/knowledge-base/NOTES.md
+++ b/docs/knowledge-base/NOTES.md
@@ -48,80 +48,71 @@ The system:
 
 ### Admin User
 
-- Authenticate via 1Password secret (passkey/API token)
-- Create persistent notes (saved to Neo4j database)
-- Full CRUD operations on all notes
+Admin auth gates note creation, editing, and deletion. Two credentials are
+accepted, both sent as `Authorization: Bearer <value>`:
 
-### Authentication Flow
+| Credential | Who uses it | Lifetime | Revocable |
+|---|---|---|---|
+| **Passkey session** (#229) | You, in the browser | 12 hours, server-enforced | per device |
+| **Static admin token** (`ADMIN_TOKEN`) | CI/automation, first-time enrollment | none | no (rotate the env var) |
 
-**Backend (passkey approach):**
+Passkeys are the normal way in. The static token is kept because the deploy
+workflow calls `/api/admin/backup` and cannot present a passkey, and because
+something has to authorize enrolling the *first* passkey.
 
-```python
-# backend/auth.py
-from fastapi import HTTPException, Header
+### Passkey Setup
 
-def verify_admin(authorization: str = Header(None)) -> bool:
-    """Verify admin passkey from Authorization header.
+1. Sign in at `/login` with the admin token (use "Use an admin token instead")
+2. Go to `/admin`, name the device, and press **Add passkey**
+3. Approve the OS prompt (Touch ID, Windows Hello, security key)
 
-    Expects: "Bearer your-secret-passkey"
-    """
-    if not authorization or not authorization.startswith("Bearer "):
-        raise HTTPException(status_code=401, detail="Authorization required")
+From then on, `/login` offers **Sign in with passkey**. Enroll additional
+devices from `/admin` while signed in; revoke any of them there individually.
+Revoking the last passkey is allowed - the admin token still works, so this
+cannot lock you out.
 
-    passkey = authorization.replace("Bearer ", "")
+### How It Works
 
-    if passkey != settings.admin_passkey:
-        raise HTTPException(status_code=403, detail="Invalid passkey")
+**Ceremonies** (`backend/routers/auth.py`, using `py_webauthn`):
 
-    return True
-
-# Usage in endpoints
-@app.post("/api/notes")
-async def create_note(
-    note: NoteCreate,
-    is_admin: bool = Depends(verify_admin)
-):
-    """Create persistent note (requires admin auth)."""
-    # Create persistent note in database
+```
+POST /api/auth/register/options   -> creation options + stored challenge
+POST /api/auth/register/verify    -> credential persisted to Neo4j
+POST /api/auth/login/options      -> request options + stored challenge
+POST /api/auth/login/verify       -> signed session token
+GET  /api/auth/session            -> "am I signed in?" (200 either way)
+GET/DELETE /api/auth/credentials  -> list / revoke enrolled devices
 ```
 
-**Frontend (localStorage approach):**
+**Sessions** (`backend/core/sessions.py`) are stateless HMAC-signed tokens,
+not stored session ids - production runs four uvicorn workers with no shared
+session store. The signing key comes from `SESSION_SECRET`, or is derived
+deterministically from `ADMIN_TOKEN` when that is unset.
 
-```typescript
-// frontend/src/lib/auth.ts
-export const login = (passkey: string) => {
-  localStorage.setItem('adminPasskey', passkey);
-};
+**Challenges** are stored in Neo4j and consumed on use, for the same
+multi-worker reason: the worker that issues a challenge is usually not the
+one that verifies the response.
 
-export const getAuthHeaders = () => {
-  const passkey = localStorage.getItem('adminPasskey');
-  if (!passkey) return {};
+**Credentials** live as `(:AdminCredential)` nodes holding the credential id,
+COSE public key, signature counter, and device name.
 
-  return {
-    'Authorization': `Bearer ${passkey}`
-  };
-};
+**Brute-force lockout** (#225) still applies to static-token guesses. Expired
+passkey sessions return 401 and are deliberately exempt, so a stale browser
+tab cannot lock you out of signing back in.
 
-// Usage in API calls
-const response = await fetch('/api/notes', {
-  method: 'POST',
-  headers: {
-    ...getAuthHeaders(),
-    'Content-Type': 'application/json'
-  },
-  body: JSON.stringify(note)
-});
-```
-
-**Environment Setup:**
+### Configuration
 
 ```bash
-# .env
-ADMIN_PASSKEY=your-secret-passkey-here
-
-# Or use 1Password CLI
-ADMIN_PASSKEY=$(op read "op://vault/mongado-admin/passkey")
+# backend/.env
+ADMIN_TOKEN=your-admin-token          # required (enrollment + automation)
+SESSION_SECRET=                       # optional; derived from ADMIN_TOKEN if empty
+WEBAUTHN_RP_ID=                       # optional; defaults to the first CORS origin's host
+WEBAUTHN_RP_NAME=Mongado              # shown in the OS passkey prompt
 ```
+
+The Relying Party ID must match the domain the browser is on: `localhost` in
+development, `mongado.com` in production. The default derives it from
+`CORS_ORIGINS`, so it is usually correct without being set.
 
 ## Data Storage
 

--- a/frontend/src/__tests__/passkeyAuth.test.ts
+++ b/frontend/src/__tests__/passkeyAuth.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for passkey auth plumbing (#229)
+ *
+ * The ceremonies themselves need a real authenticator and are verified in the
+ * browser. What is testable here is the part that silently corrupts data when
+ * wrong: base64url <-> ArrayBuffer conversion of the WebAuthn options, and the
+ * session-expiry bookkeeping in the API client.
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { isPasskeySupported } from "@/lib/api/passkey";
+import { setAdminToken, clearAdminToken, isAuthenticated, getAuthHeaders } from "@/lib/api/client";
+
+describe("isPasskeySupported", () => {
+  const originalPublicKeyCredential = window.PublicKeyCredential;
+
+  afterEach(() => {
+    window.PublicKeyCredential = originalPublicKeyCredential;
+  });
+
+  it("is false when the browser has no PublicKeyCredential", () => {
+    // @ts-expect-error - simulating an old browser
+    delete window.PublicKeyCredential;
+    expect(isPasskeySupported()).toBe(false);
+  });
+
+  it("is true when PublicKeyCredential and credentials.create exist", () => {
+    // @ts-expect-error - minimal stand-in for the real global
+    window.PublicKeyCredential = function () {};
+    Object.defineProperty(navigator, "credentials", {
+      value: { create: vi.fn(), get: vi.fn() },
+      configurable: true,
+    });
+    expect(isPasskeySupported()).toBe(true);
+  });
+});
+
+describe("session storage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("treats a passkey session as valid before its expiry", () => {
+    const inOneHour = Math.floor(Date.now() / 1000) + 3600;
+    setAdminToken("session-token", inOneHour);
+    expect(isAuthenticated()).toBe(true);
+  });
+
+  it("treats a passkey session as invalid at its expiry", () => {
+    const anHourAgo = Math.floor(Date.now() / 1000) - 3600;
+    setAdminToken("session-token", anHourAgo);
+    expect(isAuthenticated()).toBe(false);
+  });
+
+  it("clears the stored token once the session has expired", () => {
+    setAdminToken("session-token", Math.floor(Date.now() / 1000) - 1);
+    isAuthenticated();
+    expect(localStorage.getItem("admin_token")).toBeNull();
+    expect(localStorage.getItem("admin_session_expires")).toBeNull();
+  });
+
+  it("falls back to the client-side TTL for static tokens", () => {
+    setAdminToken("static-admin-token");
+    expect(localStorage.getItem("admin_session_expires")).toBeNull();
+    expect(isAuthenticated()).toBe(true);
+  });
+
+  it("expires a static token older than the 7-day TTL", () => {
+    setAdminToken("static-admin-token");
+    const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
+    localStorage.setItem("admin_token_timestamp", eightDaysAgo.toString());
+    expect(isAuthenticated()).toBe(false);
+  });
+
+  it("drops a stale session expiry when a static token replaces a session", () => {
+    setAdminToken("session-token", Math.floor(Date.now() / 1000) + 3600);
+    setAdminToken("static-admin-token");
+    expect(localStorage.getItem("admin_session_expires")).toBeNull();
+  });
+
+  it("sends the stored token as a bearer credential", () => {
+    setAdminToken("session-token", Math.floor(Date.now() / 1000) + 3600);
+    const headers = getAuthHeaders() as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer session-token");
+  });
+
+  it("sends no Authorization header when signed out", () => {
+    clearAdminToken();
+    const headers = getAuthHeaders() as Record<string, string>;
+    expect(headers["Authorization"]).toBeUndefined();
+  });
+
+  it("clears every auth key on logout", () => {
+    setAdminToken("session-token", Math.floor(Date.now() / 1000) + 3600);
+    clearAdminToken();
+    expect(localStorage.getItem("admin_token")).toBeNull();
+    expect(localStorage.getItem("admin_token_timestamp")).toBeNull();
+    expect(localStorage.getItem("admin_session_expires")).toBeNull();
+  });
+});

--- a/frontend/src/app/admin/page.module.scss
+++ b/frontend/src/app/admin/page.module.scss
@@ -137,6 +137,95 @@
   @include button-sm;
 }
 
+// ===== PASSKEYS =====
+.cardDescription {
+  @include text-secondary;
+  margin: 0 0 $spacing-4 0;
+  color: $color-text-secondary;
+}
+
+.passkeyList {
+  list-style: none;
+  margin: 0 0 $spacing-5 0;
+  padding: 0;
+}
+
+.passkeyRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $spacing-4;
+  padding: $spacing-3 0;
+  border-bottom: $border-width-thin solid $color-border-subtle;
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.passkeyInfo {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-1;
+  min-width: 0;
+}
+
+.passkeyName {
+  font-weight: $font-weight-medium;
+  color: $color-text-primary;
+}
+
+.passkeyMeta {
+  font-family: $font-family-mono;
+  font-size: $font-size-sm;
+  color: $color-text-tertiary;
+}
+
+.revokeButton {
+  @include button-secondary;
+  @include button-sm;
+  flex-shrink: 0;
+}
+
+.passkeyEnroll {
+  display: flex;
+  gap: $spacing-3;
+  flex-wrap: wrap;
+}
+
+.passkeyInput {
+  flex: 1 1 12rem;
+  padding: $spacing-2 $spacing-3;
+  border: $border-default;
+  border-radius: $border-radius-button;
+  font-family: $font-family-primary;
+  background-color: $color-bg-canvas;
+
+  &:focus {
+    outline: none;
+    border-color: $color-input-border-focus;
+    box-shadow: $shadow-focus-primary;
+  }
+
+  &:disabled {
+    background-color: $color-bg-secondary;
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
 .status {
   @include text-secondary;
   margin: 0;

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -128,9 +128,7 @@ export default function AdminPage() {
     setPasskeyMessage(null);
     try {
       await deletePasskey(credential.credential_id);
-      setPasskeys((current) =>
-        current.filter((c) => c.credential_id !== credential.credential_id)
-      );
+      setPasskeys((current) => current.filter((c) => c.credential_id !== credential.credential_id));
       setPasskeyMessage(`Revoked "${credential.name}".`);
     } catch (err) {
       adminLogger.error("Passkey revocation failed:", err);
@@ -232,8 +230,8 @@ export default function AdminPage() {
           <div className={styles.card}>
             <h2 className={styles.cardTitle}>Passkeys</h2>
             <p className={styles.cardDescription}>
-              Sign in with Touch ID, Windows Hello, or a security key instead of the admin
-              token. Each device is enrolled and revoked independently.
+              Sign in with Touch ID, Windows Hello, or a security key instead of the admin token.
+              Each device is enrolled and revoked independently.
             </p>
 
             {passkeyError && <p className={styles.error}>{passkeyError}</p>}

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -12,6 +12,13 @@ import {
   type FeatureFlag,
   type DatabaseHealth,
 } from "@/lib/api/admin";
+import {
+  deletePasskey,
+  isPasskeySupported,
+  listPasskeys,
+  registerPasskey,
+  type PasskeyCredential,
+} from "@/lib/api/passkey";
 import { applyFeatureFlag } from "@/hooks/useFeatureFlags";
 import { logger } from "@/lib/logger";
 import styles from "./page.module.scss";
@@ -23,6 +30,11 @@ function formatTimestamp(iso: string | null): string {
   const date = new Date(iso);
   if (isNaN(date.getTime())) return iso;
   return date.toLocaleString();
+}
+
+function formatUnixTimestamp(seconds: number | null): string {
+  if (!seconds) return "never";
+  return new Date(seconds * 1000).toLocaleString();
 }
 
 export default function AdminPage() {
@@ -37,6 +49,22 @@ export default function AdminPage() {
   const [healthError, setHealthError] = useState<string | null>(null);
   const [backingUp, setBackingUp] = useState(false);
   const [backupMessage, setBackupMessage] = useState<string | null>(null);
+
+  const [passkeys, setPasskeys] = useState<PasskeyCredential[]>([]);
+  const [passkeyError, setPasskeyError] = useState<string | null>(null);
+  const [passkeyMessage, setPasskeyMessage] = useState<string | null>(null);
+  const [passkeyName, setPasskeyName] = useState("");
+  const [enrolling, setEnrolling] = useState(false);
+  const [passkeySupported, setPasskeySupported] = useState(false);
+
+  const loadPasskeys = useCallback(() => {
+    listPasskeys()
+      .then(setPasskeys)
+      .catch((err) => {
+        adminLogger.error("Failed to load passkeys:", err);
+        setPasskeyError("Failed to load passkeys.");
+      });
+  }, []);
 
   const loadHealth = useCallback(() => {
     getDatabaseHealth()
@@ -62,7 +90,53 @@ export default function AdminPage() {
       .finally(() => setLoading(false));
 
     loadHealth();
-  }, [router, loadHealth]);
+    setPasskeySupported(isPasskeySupported());
+    loadPasskeys();
+  }, [router, loadHealth, loadPasskeys]);
+
+  const handleEnrollPasskey = async () => {
+    setEnrolling(true);
+    setPasskeyError(null);
+    setPasskeyMessage(null);
+
+    const name = passkeyName.trim() || "Passkey";
+    try {
+      setPasskeys(await registerPasskey(name));
+      setPasskeyName("");
+      setPasskeyMessage(`Enrolled "${name}".`);
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "NotAllowedError") {
+        setPasskeyError("Enrollment was cancelled.");
+      } else if (err instanceof DOMException && err.name === "InvalidStateError") {
+        // The browser refuses to double-enroll an excluded authenticator
+        setPasskeyError("This device already has a passkey registered.");
+      } else {
+        adminLogger.error("Passkey enrollment failed:", err);
+        setPasskeyError(err instanceof Error ? err.message : "Enrollment failed.");
+      }
+    } finally {
+      setEnrolling(false);
+    }
+  };
+
+  const handleRevokePasskey = async (credential: PasskeyCredential) => {
+    if (!window.confirm(`Revoke "${credential.name}"? That device will no longer sign in.`)) {
+      return;
+    }
+
+    setPasskeyError(null);
+    setPasskeyMessage(null);
+    try {
+      await deletePasskey(credential.credential_id);
+      setPasskeys((current) =>
+        current.filter((c) => c.credential_id !== credential.credential_id)
+      );
+      setPasskeyMessage(`Revoked "${credential.name}".`);
+    } catch (err) {
+      adminLogger.error("Passkey revocation failed:", err);
+      setPasskeyError("Failed to revoke passkey.");
+    }
+  };
 
   const handleToggle = async (flag: FeatureFlag) => {
     const newValue = !flag.enabled;
@@ -153,6 +227,70 @@ export default function AdminPage() {
                 </button>
               </div>
             ))}
+          </div>
+
+          <div className={styles.card}>
+            <h2 className={styles.cardTitle}>Passkeys</h2>
+            <p className={styles.cardDescription}>
+              Sign in with Touch ID, Windows Hello, or a security key instead of the admin
+              token. Each device is enrolled and revoked independently.
+            </p>
+
+            {passkeyError && <p className={styles.error}>{passkeyError}</p>}
+            {passkeyMessage && <p className={styles.success}>{passkeyMessage}</p>}
+
+            {passkeys.length === 0 ? (
+              <p className={styles.status}>No passkeys enrolled yet.</p>
+            ) : (
+              <ul className={styles.passkeyList}>
+                {passkeys.map((credential) => (
+                  <li key={credential.credential_id} className={styles.passkeyRow}>
+                    <div className={styles.passkeyInfo}>
+                      <span className={styles.passkeyName}>{credential.name}</span>
+                      <span className={styles.passkeyMeta}>
+                        Added {formatUnixTimestamp(credential.created_at)} · Last used{" "}
+                        {formatUnixTimestamp(credential.last_used_at)}
+                      </span>
+                    </div>
+                    <button
+                      type="button"
+                      className={styles.revokeButton}
+                      onClick={() => handleRevokePasskey(credential)}
+                    >
+                      Revoke
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            {passkeySupported ? (
+              <div className={styles.passkeyEnroll}>
+                <label htmlFor="passkey-name" className={styles.srOnly}>
+                  Device name
+                </label>
+                <input
+                  id="passkey-name"
+                  type="text"
+                  className={styles.passkeyInput}
+                  placeholder="Device name (e.g. MacBook)"
+                  maxLength={64}
+                  value={passkeyName}
+                  onChange={(e) => setPasskeyName(e.target.value)}
+                  disabled={enrolling}
+                />
+                <button
+                  type="button"
+                  className={styles.backupButton}
+                  disabled={enrolling}
+                  onClick={handleEnrollPasskey}
+                >
+                  {enrolling ? "Waiting for device..." : "Add passkey"}
+                </button>
+              </div>
+            ) : (
+              <p className={styles.status}>This browser does not support passkeys.</p>
+            )}
           </div>
 
           <div className={styles.card}>

--- a/frontend/src/app/login/page.module.scss
+++ b/frontend/src/app/login/page.module.scss
@@ -110,9 +110,40 @@
   }
 }
 
+// ===== PASSKEY =====
+.passkeySection {
+  @include stack($spacing-2);
+  margin-bottom: $spacing-4;
+
+  .hint {
+    @include text-secondary;
+    color: $color-text-tertiary;
+    text-align: center;
+  }
+}
+
+.linkButton {
+  display: block;
+  width: 100%;
+  margin-top: $spacing-4;
+  padding: 0;
+  background: none;
+  border: none;
+  font-family: $font-family-primary;
+  font-size: $font-size-sm;
+  color: $color-link-default;
+  cursor: pointer;
+  @include transition-colors;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
 // ===== FORM =====
 .form {
   @include stack($spacing-6);
+  margin-top: $spacing-4;
 }
 
 .inputGroup {

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -109,9 +109,7 @@ export default function LoginPage() {
                 >
                   {isLoading ? "Waiting for passkey..." : "Sign in with passkey"}
                 </button>
-                <p className={styles.hint}>
-                  Uses Touch ID, Windows Hello, or your security key.
-                </p>
+                <p className={styles.hint}>Uses Touch ID, Windows Hello, or your security key.</p>
               </div>
             )}
 

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,70 +1,81 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { setAdminToken } from "@/lib/api/client";
+import { isPasskeySupported, loginWithPasskey } from "@/lib/api/passkey";
 import { hasDraft } from "@/lib/draft";
+import { logger } from "@/lib/logger";
 import TopNavigation from "@/components/TopNavigation";
 import styles from "./page.module.scss";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
+const loginLogger = logger.withContext("Login");
+
 export default function LoginPage() {
   const [token, setToken] = useState("");
   const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const [passkeyAvailable, setPasskeyAvailable] = useState(false);
+  const [showTokenForm, setShowTokenForm] = useState(false);
   const router = useRouter();
 
-  const handleLogin = async (e: React.FormEvent) => {
+  // Checked after mount: navigator is not available during SSR
+  useEffect(() => {
+    setPasskeyAvailable(isPasskeySupported());
+  }, []);
+
+  const goToDestination = () => {
+    if (hasDraft()) {
+      router.push("/knowledge-base/notes/new");
+    } else {
+      router.push("/knowledge-base/notes");
+    }
+  };
+
+  const handlePasskeyLogin = async () => {
+    setError("");
+    setIsLoading(true);
+
+    try {
+      await loginWithPasskey();
+      goToDestination();
+    } catch (err) {
+      // A cancelled OS prompt throws NotAllowedError - not worth an error box
+      if (err instanceof DOMException && err.name === "NotAllowedError") {
+        setError("Passkey prompt was dismissed.");
+      } else {
+        loginLogger.error("Passkey login failed:", err);
+        setError(err instanceof Error ? err.message : "Passkey login failed.");
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleTokenLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
     setIsLoading(true);
 
     try {
-      // Store the token first so the API client can use it
-      setAdminToken(token);
-
-      // Test the token by making an authenticated request to create a note
-      // This endpoint requires auth, so it will validate our token
-      const response = await fetch(`${API_URL}/api/notes`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify({
-          content: "# Test Auth\n\nTemporary note to validate authentication",
-          title: "Auth Test",
-        }),
+      // Validate against the session endpoint, which exists to answer exactly
+      // this question - no throwaway note round-trip needed.
+      const response = await fetch(`${API_URL}/api/auth/session`, {
+        headers: { Authorization: `Bearer ${token}` },
       });
+      const status = await response.json();
 
-      if (response.ok) {
-        // Token is valid, delete the test note
-        const testNote = await response.json();
-
-        await fetch(`${API_URL}/api/notes/${testNote.id}`, {
-          method: "DELETE",
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        });
-
-        // Redirect to draft if one exists, otherwise to notes list
-        if (hasDraft()) {
-          router.push("/knowledge-base/notes/new");
-        } else {
-          router.push("/knowledge-base/notes");
-        }
+      if (status.authenticated) {
+        setAdminToken(token);
+        goToDestination();
       } else {
-        const data = await response.json().catch(() => ({ detail: "Invalid token" }));
-        setError(data.detail || "Invalid token");
-        // Clear the stored token on failure
-        setAdminToken("");
+        setError("Invalid token");
       }
     } catch (err) {
+      loginLogger.error("Token login failed:", err);
       setError("Failed to connect to server");
-      // Clear the stored token on failure
-      setAdminToken("");
     } finally {
       setIsLoading(false);
     }
@@ -81,49 +92,77 @@ export default function LoginPage() {
               ← Back
             </button>
             <h1 className={styles.title}>Admin Login</h1>
-            <p className={styles.subtitle}>Enter your admin token to create persistent notes</p>
+            <p className={styles.subtitle}>Sign in to create and edit persistent notes</p>
           </div>
         </header>
 
         {/* Form */}
         <main className={styles.main}>
           <div className={styles.formCard}>
-            <form className={styles.form} onSubmit={handleLogin}>
-              <div className={styles.inputGroup}>
-                <label htmlFor="token" className={styles.label}>
-                  Admin Token
-                </label>
-                <input
-                  id="token"
-                  name="token"
-                  type="password"
-                  autoComplete="current-password"
-                  required
-                  className={styles.input}
-                  placeholder="Admin token"
-                  value={token}
-                  onChange={(e) => setToken(e.target.value)}
+            {passkeyAvailable && (
+              <div className={styles.passkeySection}>
+                <button
+                  type="button"
+                  onClick={handlePasskeyLogin}
                   disabled={isLoading}
-                />
+                  className={styles.submitButton}
+                >
+                  {isLoading ? "Waiting for passkey..." : "Sign in with passkey"}
+                </button>
+                <p className={styles.hint}>
+                  Uses Touch ID, Windows Hello, or your security key.
+                </p>
               </div>
+            )}
 
-              {error && (
-                <div className={styles.errorBox}>
-                  <svg className={styles.errorIcon} viewBox="0 0 20 20" fill="currentColor">
-                    <path
-                      fillRule="evenodd"
-                      d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
-                      clipRule="evenodd"
-                    />
-                  </svg>
-                  <p className={styles.errorMessage}>{error}</p>
-                </div>
-              )}
+            {error && (
+              <div className={styles.errorBox}>
+                <svg className={styles.errorIcon} viewBox="0 0 20 20" fill="currentColor">
+                  <path
+                    fillRule="evenodd"
+                    d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+                <p className={styles.errorMessage}>{error}</p>
+              </div>
+            )}
 
-              <button type="submit" disabled={isLoading} className={styles.submitButton}>
-                {isLoading ? "Verifying..." : "Sign in"}
+            {passkeyAvailable && !showTokenForm && (
+              <button
+                type="button"
+                className={styles.linkButton}
+                onClick={() => setShowTokenForm(true)}
+              >
+                Use an admin token instead
               </button>
-            </form>
+            )}
+
+            {(!passkeyAvailable || showTokenForm) && (
+              <form className={styles.form} onSubmit={handleTokenLogin}>
+                <div className={styles.inputGroup}>
+                  <label htmlFor="token" className={styles.label}>
+                    Admin Token
+                  </label>
+                  <input
+                    id="token"
+                    name="token"
+                    type="password"
+                    autoComplete="current-password"
+                    required
+                    className={styles.input}
+                    placeholder="Admin token"
+                    value={token}
+                    onChange={(e) => setToken(e.target.value)}
+                    disabled={isLoading}
+                  />
+                </div>
+
+                <button type="submit" disabled={isLoading} className={styles.submitButton}>
+                  {isLoading ? "Verifying..." : "Sign in with token"}
+                </button>
+              </form>
+            )}
           </div>
         </main>
       </div>

--- a/frontend/src/components/AuthStatusBanner.tsx
+++ b/frontend/src/components/AuthStatusBanner.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { clearAdminToken } from "@/lib/api/client";
+import { clearAdminToken, isAuthenticated as hasValidSession } from "@/lib/api/client";
 import styles from "./AuthStatusBanner.module.scss";
 
 interface AuthStatusBannerProps {
@@ -20,8 +20,9 @@ export default function AuthStatusBanner({ mode = "auto" }: AuthStatusBannerProp
 
   const checkAuth = () => {
     try {
-      const adminToken = localStorage.getItem("admin_token");
-      setIsAuthenticated(!!adminToken);
+      // Presence of a token is not enough - a passkey session expires after
+      // 12 hours, and this banner must not claim you are still signed in
+      setIsAuthenticated(hasValidSession());
     } catch (err) {
       setIsAuthenticated(false);
     } finally {
@@ -114,8 +115,7 @@ export function AuthStatusIndicator() {
   useEffect(() => {
     const checkAuth = async () => {
       try {
-        const adminToken = localStorage.getItem("admin_token");
-        setIsAuthenticated(!!adminToken);
+        setIsAuthenticated(hasValidSession());
       } catch (err) {
         setIsAuthenticated(false);
       } finally {

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -4,8 +4,13 @@
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
-// Session TTL: 7 days (in milliseconds)
+// Fallback TTL for static admin tokens, which carry no expiry of their own.
+// Passkey sessions (#229) instead store the backend's authoritative expiry.
 const SESSION_TTL = 7 * 24 * 60 * 60 * 1000;
+
+// Unix ms at which a passkey session expires, as told to us by the backend.
+// Only a hint for the UI: the server enforces the real expiry on every call.
+const SESSION_EXPIRES_KEY = "admin_session_expires";
 
 /**
  * Get authorization headers if admin token is set
@@ -101,11 +106,22 @@ export function isAuthenticated(): boolean {
   if (typeof window === "undefined") return false;
 
   const token = localStorage.getItem("admin_token");
-  const loginTime = localStorage.getItem("admin_token_timestamp");
-
   if (!token) {
     return false;
   }
+
+  // Passkey session: trust the backend's own expiry (#229)
+  const sessionExpires = localStorage.getItem(SESSION_EXPIRES_KEY);
+  if (sessionExpires) {
+    if (Date.now() >= parseInt(sessionExpires, 10)) {
+      clearAdminToken();
+      return false;
+    }
+    return true;
+  }
+
+  // Static admin token: fall back to the client-side TTL
+  const loginTime = localStorage.getItem("admin_token_timestamp");
 
   // Migration: If token exists but no timestamp, set timestamp now
   // This handles sessions created before TTL feature was added
@@ -126,12 +142,22 @@ export function isAuthenticated(): boolean {
 }
 
 /**
- * Set the admin token (login)
+ * Set the admin token (login).
+ *
+ * @param token - Passkey session token, or the static admin token
+ * @param expiresAtSeconds - Server-issued expiry (unix seconds) for passkey
+ *   sessions. Omit for the static token, which has no server-side expiry.
  */
-export function setAdminToken(token: string): void {
-  if (typeof window !== "undefined") {
-    localStorage.setItem("admin_token", token);
-    localStorage.setItem("admin_token_timestamp", Date.now().toString());
+export function setAdminToken(token: string, expiresAtSeconds?: number): void {
+  if (typeof window === "undefined") return;
+
+  localStorage.setItem("admin_token", token);
+  localStorage.setItem("admin_token_timestamp", Date.now().toString());
+
+  if (expiresAtSeconds) {
+    localStorage.setItem(SESSION_EXPIRES_KEY, (expiresAtSeconds * 1000).toString());
+  } else {
+    localStorage.removeItem(SESSION_EXPIRES_KEY);
   }
 }
 
@@ -142,5 +168,6 @@ export function clearAdminToken(): void {
   if (typeof window !== "undefined") {
     localStorage.removeItem("admin_token");
     localStorage.removeItem("admin_token_timestamp");
+    localStorage.removeItem(SESSION_EXPIRES_KEY);
   }
 }

--- a/frontend/src/lib/api/passkey.ts
+++ b/frontend/src/lib/api/passkey.ts
@@ -87,9 +87,7 @@ function decodeCreationOptions(
   return decoded as unknown as PublicKeyCredentialCreationOptions;
 }
 
-function decodeRequestOptions(
-  options: Record<string, unknown>
-): PublicKeyCredentialRequestOptions {
+function decodeRequestOptions(options: Record<string, unknown>): PublicKeyCredentialRequestOptions {
   const decoded = { ...options } as Record<string, unknown>;
   decoded.challenge = base64urlToBuffer(options.challenge as string);
 

--- a/frontend/src/lib/api/passkey.ts
+++ b/frontend/src/lib/api/passkey.ts
@@ -1,0 +1,216 @@
+/**
+ * Passkey (WebAuthn) authentication (#229).
+ *
+ * The browser's credential APIs speak ArrayBuffer; the backend speaks
+ * base64url JSON. This module is the translation layer plus the four
+ * ceremony calls, so the pages stay free of buffer juggling.
+ */
+
+import { apiDelete, apiGet, apiPost, setAdminToken } from "./client";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+export interface PasskeyCredential {
+  credential_id: string;
+  name: string;
+  created_at: number;
+  last_used_at: number | null;
+}
+
+interface CredentialsListResponse {
+  credentials: PasskeyCredential[];
+  count: number;
+}
+
+export interface SessionStatus {
+  authenticated: boolean;
+  kind: "passkey" | "token" | "none";
+  expires_at: number | null;
+}
+
+interface SessionResponse {
+  token: string;
+  expires_at: number;
+  credential_name: string;
+}
+
+/** Whether this browser can do passkeys at all. */
+export function isPasskeySupported(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.PublicKeyCredential !== "undefined" &&
+    typeof navigator.credentials?.create === "function"
+  );
+}
+
+function base64urlToBuffer(value: string): ArrayBuffer {
+  const padded = value.replace(/-/g, "+").replace(/_/g, "/");
+  const binary = atob(padded + "=".repeat((4 - (padded.length % 4)) % 4));
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+function bufferToBase64url(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+/**
+ * Decode the base64url fields the backend sends into the buffers the
+ * browser requires. Only the fields WebAuthn defines as BufferSource are
+ * converted; everything else passes through untouched.
+ */
+function decodeCreationOptions(
+  options: Record<string, unknown>
+): PublicKeyCredentialCreationOptions {
+  const decoded = { ...options } as Record<string, unknown>;
+  decoded.challenge = base64urlToBuffer(options.challenge as string);
+
+  const user = options.user as Record<string, unknown>;
+  decoded.user = { ...user, id: base64urlToBuffer(user.id as string) };
+
+  const exclude = options.excludeCredentials as Array<Record<string, unknown>> | undefined;
+  if (exclude) {
+    decoded.excludeCredentials = exclude.map((credential) => ({
+      ...credential,
+      id: base64urlToBuffer(credential.id as string),
+    }));
+  }
+
+  return decoded as unknown as PublicKeyCredentialCreationOptions;
+}
+
+function decodeRequestOptions(
+  options: Record<string, unknown>
+): PublicKeyCredentialRequestOptions {
+  const decoded = { ...options } as Record<string, unknown>;
+  decoded.challenge = base64urlToBuffer(options.challenge as string);
+
+  const allow = options.allowCredentials as Array<Record<string, unknown>> | undefined;
+  if (allow) {
+    decoded.allowCredentials = allow.map((credential) => ({
+      ...credential,
+      id: base64urlToBuffer(credential.id as string),
+    }));
+  }
+
+  return decoded as unknown as PublicKeyCredentialRequestOptions;
+}
+
+/** Re-encode an authenticator's response into the JSON shape py_webauthn parses. */
+function encodeRegistrationCredential(credential: PublicKeyCredential): Record<string, unknown> {
+  const response = credential.response as AuthenticatorAttestationResponse;
+  return {
+    id: credential.id,
+    rawId: bufferToBase64url(credential.rawId),
+    type: credential.type,
+    response: {
+      clientDataJSON: bufferToBase64url(response.clientDataJSON),
+      attestationObject: bufferToBase64url(response.attestationObject),
+    },
+    clientExtensionResults: credential.getClientExtensionResults(),
+  };
+}
+
+function encodeAuthenticationCredential(credential: PublicKeyCredential): Record<string, unknown> {
+  const response = credential.response as AuthenticatorAssertionResponse;
+  return {
+    id: credential.id,
+    rawId: bufferToBase64url(credential.rawId),
+    type: credential.type,
+    response: {
+      clientDataJSON: bufferToBase64url(response.clientDataJSON),
+      authenticatorData: bufferToBase64url(response.authenticatorData),
+      signature: bufferToBase64url(response.signature),
+      userHandle: response.userHandle ? bufferToBase64url(response.userHandle) : null,
+    },
+    clientExtensionResults: credential.getClientExtensionResults(),
+  };
+}
+
+/**
+ * Enroll a new passkey. Requires an already-authenticated session (the
+ * static admin token for the first one, a passkey session after that).
+ */
+export async function registerPasskey(name: string): Promise<PasskeyCredential[]> {
+  const { options } = await apiPost<{ options: Record<string, unknown> }>(
+    "/api/auth/register/options",
+    { name }
+  );
+
+  const credential = (await navigator.credentials.create({
+    publicKey: decodeCreationOptions(options),
+  })) as PublicKeyCredential | null;
+
+  if (!credential) {
+    throw new Error("Passkey creation was cancelled.");
+  }
+
+  const result = await apiPost<CredentialsListResponse>("/api/auth/register/verify", {
+    credential: encodeRegistrationCredential(credential),
+    name,
+  });
+  return result.credentials;
+}
+
+/**
+ * Sign in with a passkey and store the resulting session.
+ *
+ * Deliberately not routed through apiPost: these two calls must not carry a
+ * stale Authorization header, and their errors need to reach the UI with the
+ * backend's own wording (e.g. "No passkeys registered").
+ */
+export async function loginWithPasskey(): Promise<{ expiresAt: number; credentialName: string }> {
+  const optionsResponse = await fetch(`${API_BASE_URL}/api/auth/login/options`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+  });
+  if (!optionsResponse.ok) {
+    const body = await optionsResponse.json().catch(() => ({ detail: "Login unavailable" }));
+    throw new Error(body.detail || "Could not start passkey login.");
+  }
+  const { options } = await optionsResponse.json();
+
+  const credential = (await navigator.credentials.get({
+    publicKey: decodeRequestOptions(options),
+  })) as PublicKeyCredential | null;
+
+  if (!credential) {
+    throw new Error("Passkey login was cancelled.");
+  }
+
+  const verifyResponse = await fetch(`${API_BASE_URL}/api/auth/login/verify`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ credential: encodeAuthenticationCredential(credential) }),
+  });
+  if (!verifyResponse.ok) {
+    const body = await verifyResponse.json().catch(() => ({ detail: "Login failed" }));
+    throw new Error(body.detail || "Passkey login failed.");
+  }
+
+  const session: SessionResponse = await verifyResponse.json();
+  setAdminToken(session.token, session.expires_at);
+  return { expiresAt: session.expires_at, credentialName: session.credential_name };
+}
+
+/** Ask the backend whether the stored credentials are still good. */
+export async function getSessionStatus(): Promise<SessionStatus> {
+  return apiGet<SessionStatus>("/api/auth/session");
+}
+
+export async function listPasskeys(): Promise<PasskeyCredential[]> {
+  const response = await apiGet<CredentialsListResponse>("/api/auth/credentials");
+  return response.credentials;
+}
+
+export async function deletePasskey(credentialId: string): Promise<void> {
+  await apiDelete(`/api/auth/credentials/${encodeURIComponent(credentialId)}`);
+}

--- a/frontend/tests/e2e/passkey-auth.spec.ts
+++ b/frontend/tests/e2e/passkey-auth.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * End-to-end passkey enrollment and login (#229).
+ *
+ * Uses Chrome's WebAuthn virtual authenticator over CDP, so the full ceremony
+ * runs for real - challenge, attestation, assertion, signature verification -
+ * without a physical device. Chromium only; the CDP domain does not exist in
+ * Firefox or WebKit.
+ *
+ * Enrollment needs the static admin token, which is what gates the first
+ * passkey. Set E2E_ADMIN_TOKEN to run this; it skips without it.
+ *
+ * The test enrolls a device named DEVICE_NAME and revokes it at the end. It
+ * also revokes any leftover of that name up front, because a stale row from
+ * an interrupted run would otherwise satisfy the "enrolled" assertion without
+ * anything actually having been enrolled - and the login step would then fail
+ * against a credential this run's authenticator does not hold.
+ */
+
+const ADMIN_TOKEN = process.env.E2E_ADMIN_TOKEN;
+const DEVICE_NAME = "E2E Device";
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+test.describe("Passkey authentication", () => {
+  test.skip(({ browserName }) => browserName !== "chromium", "Needs Chrome DevTools Protocol");
+  test.skip(!ADMIN_TOKEN, "Set E2E_ADMIN_TOKEN to run passkey tests");
+
+  /** Attach a virtual authenticator to this page's browser context. */
+  async function addVirtualAuthenticator(page: Page): Promise<void> {
+    const client = await page.context().newCDPSession(page);
+    await client.send("WebAuthn.enable");
+    await client.send("WebAuthn.addVirtualAuthenticator", {
+      options: {
+        protocol: "ctap2",
+        transport: "internal",
+        hasResidentKey: true,
+        hasUserVerification: true,
+        isUserVerified: true,
+        automaticPresenceSimulation: true,
+      },
+    });
+  }
+
+  /** Remove any credential left behind by an earlier run. */
+  async function revokeLeftovers(page: Page): Promise<void> {
+    await page.request
+      .get(`${API_URL}/api/auth/credentials`, {
+        headers: { Authorization: `Bearer ${ADMIN_TOKEN}` },
+      })
+      .then(async (response) => {
+        if (!response.ok()) return;
+        const { credentials } = await response.json();
+        for (const credential of credentials) {
+          if (credential.name === DEVICE_NAME) {
+            await page.request.delete(
+              `${API_URL}/api/auth/credentials/${encodeURIComponent(credential.credential_id)}`,
+              { headers: { Authorization: `Bearer ${ADMIN_TOKEN}` } }
+            );
+          }
+        }
+      });
+  }
+
+  /** Sign in with the static admin token, which passkey enrollment requires. */
+  async function signInWithToken(page: Page): Promise<void> {
+    await page.goto("/login");
+    await page.getByRole("button", { name: /use an admin token instead/i }).click();
+    await page.getByPlaceholder("Admin token").fill(ADMIN_TOKEN!);
+    await page.getByRole("button", { name: /sign in with token/i }).click();
+    await expect(page).toHaveURL(/\/knowledge-base\/notes/);
+  }
+
+  test("enrolls a passkey, then signs in with it", async ({ page }) => {
+    await addVirtualAuthenticator(page);
+    await revokeLeftovers(page);
+    await signInWithToken(page);
+
+    // Enroll from the admin page
+    await page.goto("/admin");
+    const enrolledRow = page.getByText(DEVICE_NAME, { exact: true });
+    await expect(enrolledRow).toBeHidden();
+
+    await page.getByPlaceholder(/device name/i).fill(DEVICE_NAME);
+    await page.getByRole("button", { name: /add passkey/i }).click();
+    await expect(enrolledRow).toBeVisible({ timeout: 15000 });
+
+    // Sign out, then sign back in using only the passkey
+    await page.evaluate(() => localStorage.clear());
+    await page.goto("/login");
+    await page.getByRole("button", { name: /sign in with passkey/i }).click();
+    await expect(page).toHaveURL(/\/knowledge-base\/notes/, { timeout: 15000 });
+
+    // The stored credential must be a session token carrying a server expiry,
+    // not the static admin token
+    const session = await page.evaluate(() => ({
+      token: localStorage.getItem("admin_token"),
+      expires: localStorage.getItem("admin_session_expires"),
+    }));
+    expect(session.token).not.toBe(process.env.E2E_ADMIN_TOKEN);
+    expect(session.expires).toBeTruthy();
+    expect(Number(session.expires)).toBeGreaterThan(Date.now());
+
+    // Revoking removes it from the list
+    await page.goto("/admin");
+    page.once("dialog", (dialog) => dialog.accept());
+    await page.getByRole("button", { name: /revoke/i }).first().click();
+    await expect(enrolledRow).toBeHidden({ timeout: 10000 });
+  });
+});


### PR DESCRIPTION
Adds WebAuthn passkeys as the primary admin login, with short-lived signed sessions. The static `ADMIN_TOKEN` is deliberately kept: the deploy workflow's backup calls cannot present a passkey, and something has to authorize enrolling the first one.

## Backend
- `core/sessions.py` — pure HMAC-signed session tokens, 12h server-enforced expiry. Stateless because prod runs 4 uvicorn workers with no shared session store; signing key is `SESSION_SECRET` or derived from `ADMIN_TOKEN`, so no new prod secret is needed.
- `routers/auth.py` — register/login ceremonies, session status, credential list/revoke. Challenges live in Neo4j and are consumed on use (multi-worker).
- `auth.py` — `verify_admin` accepts a session token or the static token. Expired sessions 401 and are exempt from the #225 lockout, so a stale tab can't lock the admin out.

## Frontend
- Passkey button on `/login` with the token form kept as fallback; enroll/list/revoke per device on `/admin`.
- The old "create a note then delete it" login probe is replaced by `GET /api/auth/session`.

## Defects fixed along the way
1. Auth responses were cacheable (blanket `max-age=60` on API GETs) — auth paths are now `private, no-store`, with regression tests.
2. The auth router creates its `APIRouter` per factory call (a module-level router would bind the first adapter and ignore later ones; same latent issue exists in `routers/admin.py`, out of scope here).
3. The shared rate limiter now respects `TESTING`, matching `routers/notes.py`.

## Verification
- 543 backend tests (57 new), 81 frontend (11 new); ruff + mypy clean.
- Playwright E2E (`passkey-auth.spec.ts`) drives the full ceremony against Chrome's virtual authenticator: enroll → sign out → passkey login → server-expiry session token → revoke. Run from the host with `E2E_ADMIN_TOKEN` set (the frontend image is Alpine/musl; Playwright's Chromium can't run in it).

## Left open (follow-up, not this PR)
- Phase 3 of #229: move deploy backup calls to SSH, then narrow `ADMIN_TOKEN` to enrollment-only.
- Bootstrap: first passkey is enrolled by signing in once with the admin token (documented in `docs/knowledge-base/NOTES.md`).

Refs #229