### PR TITLE
fix: provision independent SESSION_SECRET and pin WEBAUTHN_RP_ID in prod (#268)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,6 +77,8 @@ jobs:
           NEO4J_PASSWORD: ${{ secrets.NEO4J_PASSWORD }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
+          WEBAUTHN_RP_ID: ${{ secrets.WEBAUTHN_RP_ID }}
         run: |
           # Pass secrets to remote server via SSH command arguments
           ssh $DO_USER@$DO_HOST "bash -s" \
@@ -86,7 +88,9 @@ jobs:
             "$NEXT_PUBLIC_API_URL" \
             "$NEO4J_PASSWORD" \
             "$GROQ_API_KEY" \
-            "$GEMINI_API_KEY" << 'EOF'
+            "$GEMINI_API_KEY" \
+            "$SESSION_SECRET" \
+            "$WEBAUTHN_RP_ID" << 'EOF'
             set -e
 
             # Receive arguments
@@ -97,6 +101,8 @@ jobs:
             NEO4J_PASSWORD="$5"
             GROQ_API_KEY="$6"
             GEMINI_API_KEY="$7"
+            SESSION_SECRET="$8"
+            WEBAUTHN_RP_ID="$9"
 
             echo "📦 Deploying Mongado to production..."
 
@@ -121,6 +127,12 @@ jobs:
             echo "CORS_ORIGINS=$CORS_ORIGINS" >> backend/.env
             echo "OP_MONGADO_SERVICE_ACCOUNT_TOKEN=$OP_SERVICE_ACCOUNT_TOKEN" >> backend/.env
             echo "ADMIN_TOKEN=$ADMIN_PASSKEY" >> backend/.env
+            # Passkey auth (#268): sign sessions with a secret independent of
+            # ADMIN_TOKEN so a token leak cannot also forge sessions. Pin the
+            # WebAuthn RP ID (mongado.com) so it can't drift with the
+            # CORS_ORIGINS ordering and strand enrolled passkeys.
+            echo "SESSION_SECRET=$SESSION_SECRET" >> backend/.env
+            echo "WEBAUTHN_RP_ID=$WEBAUTHN_RP_ID" >> backend/.env
             # Hosted LLM API keys (#190): Groq = generation primary,
             # Gemini = generation fallback + embeddings
             echo "GROQ_API_KEY=$GROQ_API_KEY" >> backend/.env

--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -35,8 +35,15 @@ LOG_FORMAT=json  # Use JSON format for log aggregation
 OLLAMA_BASE_URL=http://localhost:11434
 OLLAMA_MODEL=mistral
 
-# Session Configuration
-SESSION_SECRET_KEY=your-session-secret-key-here  # Generate with: openssl rand -hex 32
+# Passkey / Session Configuration (#229, #268)
+# HMAC key for signing passkey session tokens. Set an independent value so a
+# leaked ADMIN_TOKEN cannot also forge sessions. If unset, it is derived from
+# ADMIN_TOKEN. Generate with: openssl rand -hex 32
+SESSION_SECRET=your-session-secret-here
+# WebAuthn Relying Party ID: the registrable domain passkeys are bound to.
+# Pin it so it can't drift with the CORS_ORIGINS ordering. If unset, it is
+# derived from the hostname of the first CORS origin.
+WEBAUTHN_RP_ID=mongado.com
 
 # Rate Limiting
 RATE_LIMIT_ENABLED=true


### PR DESCRIPTION
Follow-up hardening to #229 / PR #266. Both values are provisioned through the deploy workflow because it rewrites `backend/.env` from scratch on every run — a hand-edit on the droplet would be clobbered on the next deploy.

## Changes
- **`SESSION_SECRET`** — sourced from a new GitHub Actions secret and written to `backend/.env`, so passkey session tokens are signed with a key independent of `ADMIN_TOKEN`. Without it, `core/sessions.derive_session_secret()` falls back to a value derived from `ADMIN_TOKEN`, meaning a token leak also lets an attacker forge sessions.
- **`WEBAUTHN_RP_ID`** — sourced from a GitHub Actions secret (set to `mongado.com`) and pinned in `backend/.env`, so the RP ID can't drift with the ordering of `CORS_ORIGINS` (`webauthn_rp_id_resolved` otherwise uses the first origin's hostname), which would strand already-enrolled passkeys. If the secret is ever empty, the code still safely derives `mongado.com` from the first CORS origin.
- Corrects `.env.production.example`, which documented a nonexistent `SESSION_SECRET_KEY`, and adds `WEBAUTHN_RP_ID`.

Secrets `SESSION_SECRET` and `WEBAUTHN_RP_ID` are already set in repo secrets.

## Expected effect on deploy
The new `SESSION_SECRET` invalidates the currently-active passkey session (signed with the old `ADMIN_TOKEN`-derived key) — a one-time **re-login** with the passkey. The passkey itself stays valid because `WEBAUTHN_RP_ID=mongado.com` matches what it's bound to (apex enrollment).

Refs #268

https://claude.ai/code/session_01MgwQCvsNhqPZJsbJTjeqwW