### PR TITLE
fix: back up over SSH instead of token-authed API; base64 deploy secrets (#267 pt 1)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,41 +21,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Create pre-deployment backup
-        env:
-          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
-        run: |
-          echo "📦 Creating pre-deployment backup..."
-
-          # Attempt backup via API (may fail on first deployment)
-          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://api.mongado.com/api/admin/backup \
-            -H "Authorization: Bearer $ADMIN_TOKEN" \
-            --max-time 300 2>&1 || echo -e "\n000")
-
-          HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
-          BODY=$(echo "$RESPONSE" | sed '$d')
-
-          if [ "$HTTP_CODE" = "200" ]; then
-            echo "✅ Pre-deployment backup created successfully"
-            # Only parse JSON if it's valid
-            if echo "$BODY" | jq -e . >/dev/null 2>&1; then
-              echo "$BODY" | jq '.'
-              BACKUP_FILE=$(echo "$BODY" | jq -r '.backup_file // "unknown"')
-              echo "backup_file=$BACKUP_FILE" >> $GITHUB_OUTPUT
-              echo "Backup file: $BACKUP_FILE"
-            else
-              echo "⚠️ Response is not valid JSON:"
-              echo "$BODY"
-            fi
-          else
-            echo "⚠️ Pre-deployment backup failed (HTTP $HTTP_CODE)"
-            echo "This is expected on first deployment or if API is unreachable"
-            echo "Response: $BODY"
-            echo "Continuing with deployment..."
-          fi
-        id: pre_backup
-        continue-on-error: true
-
       - name: Set up SSH
         uses: webfactory/ssh-agent@v0.9.0
         with:
@@ -65,6 +30,21 @@ jobs:
         run: |
           mkdir -p ~/.ssh
           ssh-keyscan -H ${{ secrets.DO_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Create pre-deployment backup
+        env:
+          DO_HOST: ${{ secrets.DO_HOST }}
+          DO_USER: ${{ secrets.DO_USER }}
+        # Runs the zero-downtime JSON export inside the currently-running backend
+        # container over SSH (#267), so no admin token is needed - CI authenticates
+        # to the droplet with its SSH key. On the first deploy of this change the
+        # running container predates scripts/backup_export.py, so this is expected
+        # to no-op; continue-on-error keeps that from blocking the deploy.
+        run: |
+          echo "📦 Creating pre-deployment backup..."
+          ssh "$DO_USER@$DO_HOST" \
+            "cd /opt/mongado && docker compose -f docker-compose.prod.yml exec -T backend python -m scripts.backup_export"
+        continue-on-error: true
 
       - name: Deploy to DigitalOcean
         env:
@@ -80,29 +60,35 @@ jobs:
           SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
           WEBAUTHN_RP_ID: ${{ secrets.WEBAUTHN_RP_ID }}
         run: |
-          # Pass secrets to remote server via SSH command arguments
+          # Pass secrets to the droplet as SSH command arguments, base64-encoded.
+          # ssh joins the args into one string that the remote LOGIN shell (zsh)
+          # re-parses before `bash -s` runs, so a raw value containing a glob char
+          # (* ? [ ] { }) makes zsh abort with "no matches found" (#267; hit live
+          # in #268). base64's alphabet has no glob chars, so the encoded args
+          # survive that re-parse; the heredoc decodes them under bash. This also
+          # keeps the plaintext secrets out of the remote process list.
           ssh $DO_USER@$DO_HOST "bash -s" \
-            "$CORS_ORIGINS" \
-            "$OP_SERVICE_ACCOUNT_TOKEN" \
-            "$ADMIN_PASSKEY" \
-            "$NEXT_PUBLIC_API_URL" \
-            "$NEO4J_PASSWORD" \
-            "$GROQ_API_KEY" \
-            "$GEMINI_API_KEY" \
-            "$SESSION_SECRET" \
-            "$WEBAUTHN_RP_ID" << 'EOF'
+            "$(printf %s "$CORS_ORIGINS" | base64 -w0)" \
+            "$(printf %s "$OP_SERVICE_ACCOUNT_TOKEN" | base64 -w0)" \
+            "$(printf %s "$ADMIN_PASSKEY" | base64 -w0)" \
+            "$(printf %s "$NEXT_PUBLIC_API_URL" | base64 -w0)" \
+            "$(printf %s "$NEO4J_PASSWORD" | base64 -w0)" \
+            "$(printf %s "$GROQ_API_KEY" | base64 -w0)" \
+            "$(printf %s "$GEMINI_API_KEY" | base64 -w0)" \
+            "$(printf %s "$SESSION_SECRET" | base64 -w0)" \
+            "$(printf %s "$WEBAUTHN_RP_ID" | base64 -w0)" << 'EOF'
             set -e
 
-            # Receive arguments
-            CORS_ORIGINS="$1"
-            OP_SERVICE_ACCOUNT_TOKEN="$2"
-            ADMIN_PASSKEY="$3"
-            NEXT_PUBLIC_API_URL="$4"
-            NEO4J_PASSWORD="$5"
-            GROQ_API_KEY="$6"
-            GEMINI_API_KEY="$7"
-            SESSION_SECRET="$8"
-            WEBAUTHN_RP_ID="$9"
+            # Receive arguments (base64-decoded; see the encoding note above)
+            CORS_ORIGINS="$(printf %s "$1" | base64 -d)"
+            OP_SERVICE_ACCOUNT_TOKEN="$(printf %s "$2" | base64 -d)"
+            ADMIN_PASSKEY="$(printf %s "$3" | base64 -d)"
+            NEXT_PUBLIC_API_URL="$(printf %s "$4" | base64 -d)"
+            NEO4J_PASSWORD="$(printf %s "$5" | base64 -d)"
+            GROQ_API_KEY="$(printf %s "$6" | base64 -d)"
+            GEMINI_API_KEY="$(printf %s "$7" | base64 -d)"
+            SESSION_SECRET="$(printf %s "$8" | base64 -d)"
+            WEBAUTHN_RP_ID="$(printf %s "$9" | base64 -d)"
 
             echo "📦 Deploying Mongado to production..."
 
@@ -229,8 +215,6 @@ jobs:
           EOF
 
       - name: Check database health
-        env:
-          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
         run: |
           echo "🏥 Checking database health (single attempt - Cloudflare may block)..."
 
@@ -257,27 +241,16 @@ jobs:
 
       - name: Create post-deployment backup
         env:
-          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+          DO_HOST: ${{ secrets.DO_HOST }}
+          DO_USER: ${{ secrets.DO_USER }}
+        # Snapshot the freshly-deployed state via the new backend container over
+        # SSH (#267). No admin token, and no Cloudflare in the path (the old curl
+        # to the public API was frequently blocked). Nightly cron backups still
+        # run independently at 2 AM.
         run: |
-          echo "💾 Creating post-deployment backup (single attempt - Cloudflare may block)..."
-
-          # Single attempt with short timeout - backup API requires Docker access anyway
-          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://api.mongado.com/api/admin/backup \
-            -H "Authorization: Bearer $ADMIN_TOKEN" \
-            --max-time 10 2>&1 || echo -e "\n000")
-
-          HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
-          BODY=$(echo "$RESPONSE" | sed '$d')
-
-          if [ "$HTTP_CODE" = "200" ]; then
-            echo "✅ Post-deployment backup created successfully"
-            if echo "$BODY" | jq -e . >/dev/null 2>&1; then
-              echo "$BODY" | jq '.'
-            fi
-          else
-            echo "⚠️ Post-deployment backup skipped (HTTP $HTTP_CODE)"
-            echo "Note: Backups run automatically at 2 AM via cron, or manually via SSH"
-          fi
+          echo "💾 Creating post-deployment backup..."
+          ssh "$DO_USER@$DO_HOST" \
+            "cd /opt/mongado && docker compose -f docker-compose.prod.yml exec -T backend python -m scripts.backup_export"
         continue-on-error: true
 
       - name: Deployment notification

--- a/backend/scripts/backup_export.py
+++ b/backend/scripts/backup_export.py
@@ -1,0 +1,88 @@
+"""On-demand logical backup of the Neo4j database (#267).
+
+Writes the same zero-downtime JSON export that ``POST /api/admin/backup``
+produces, but as a CLI so the deploy workflow can create pre/post-deploy
+snapshots over SSH instead of an authenticated HTTP call. This removes the
+deploy's dependency on ``ADMIN_TOKEN`` -- CI authenticates to the droplet with
+its SSH key, and the backup no longer needs an admin credential at all.
+
+Run inside the backend container:
+    docker compose exec -T backend python -m scripts.backup_export
+
+Exit status:
+    0  backup written (path printed on the last line)
+    1  Neo4j unavailable or the export/write failed
+"""
+
+import json
+import logging
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from adapters.neo4j import get_neo4j_adapter
+
+logger = logging.getLogger(__name__)
+
+
+def _backup_dir() -> Path:
+    """Resolve the backup directory.
+
+    Honours ``BACKUP_DIR`` (set in docker-compose.prod.yml to
+    ``/var/mongado-backups``) so the CLI, the nightly cron, and the API endpoint
+    all write to the same place; falls back to the endpoint's convention when it
+    is unset.
+    """
+    env_dir = os.getenv("BACKUP_DIR")
+    if env_dir:
+        return Path(env_dir)
+    if "prod" in os.getenv("COMPOSE_FILE", "docker-compose.yml"):
+        return Path("/var/mongado-backups")
+    return Path("/app").parent / "backups"
+
+
+def create_backup() -> Path:
+    """Export the database to a timestamped JSON file and return its path.
+
+    Raises:
+        RuntimeError: If Neo4j is unavailable.
+    """
+    adapter = get_neo4j_adapter()
+    if not adapter.is_available():
+        raise RuntimeError("Neo4j not available - cannot create backup")
+
+    export_data = adapter.export_database()
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    backup_path = _backup_dir() / f"neo4j_backup_{timestamp}"
+    backup_path.mkdir(parents=True, exist_ok=True)
+    backup_file = backup_path / "backup.json"
+    with open(backup_file, "w") as f:
+        json.dump(export_data, f, indent=2)
+
+    metadata = export_data.get("metadata", {})
+    logger.info(
+        "Backup created: %s (%d notes, %d relationships, %d bytes)",
+        backup_path.name,
+        metadata.get("note_count", 0),
+        metadata.get("relationship_count", 0),
+        backup_file.stat().st_size,
+    )
+    return backup_file
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    try:
+        backup_file = create_backup()
+    except Exception as e:  # noqa: BLE001 - CLI boundary: report and exit non-zero
+        logger.error("Backup failed: %s", e)
+        return 1
+    # Last line is the path so the caller can capture it
+    print(backup_file)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/unit/test_backup_export.py
+++ b/backend/tests/unit/test_backup_export.py
@@ -1,0 +1,83 @@
+"""Unit tests for the on-demand backup CLI (scripts/backup_export.py, #267).
+
+The CLI replaces the deploy workflow's authenticated `POST /api/admin/backup`
+call, so these cover the directory resolution, the export-to-file path, and the
+exit codes the workflow relies on.
+"""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+os.environ["TESTING"] = "1"
+
+from scripts import backup_export
+
+
+class TestBackupDir:
+    def test_honours_backup_dir_env(self, monkeypatch) -> None:
+        monkeypatch.setenv("BACKUP_DIR", "/custom/backups")
+        assert backup_export._backup_dir() == Path("/custom/backups")
+
+    def test_prod_compose_defaults_to_var_mongado_backups(self, monkeypatch) -> None:
+        monkeypatch.delenv("BACKUP_DIR", raising=False)
+        monkeypatch.setenv("COMPOSE_FILE", "docker-compose.prod.yml")
+        assert backup_export._backup_dir() == Path("/var/mongado-backups")
+
+    def test_dev_default(self, monkeypatch) -> None:
+        monkeypatch.delenv("BACKUP_DIR", raising=False)
+        monkeypatch.delenv("COMPOSE_FILE", raising=False)
+        assert backup_export._backup_dir() == Path("/app").parent / "backups"
+
+
+class TestCreateBackup:
+    def _fake_adapter(self) -> MagicMock:
+        adapter = MagicMock()
+        adapter.is_available.return_value = True
+        adapter.export_database.return_value = {
+            "notes": [{"id": "curious-elephant"}],
+            "relationships": [],
+            "metadata": {"note_count": 1, "relationship_count": 0},
+        }
+        return adapter
+
+    def test_writes_json_and_returns_path(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setenv("BACKUP_DIR", str(tmp_path))
+        with patch.object(backup_export, "get_neo4j_adapter", return_value=self._fake_adapter()):
+            backup_file = backup_export.create_backup()
+
+        assert backup_file.exists()
+        assert backup_file.name == "backup.json"
+        assert backup_file.parent.name.startswith("neo4j_backup_")
+        written = json.loads(backup_file.read_text())
+        assert written["metadata"]["note_count"] == 1
+
+    def test_raises_when_neo4j_unavailable(self, monkeypatch) -> None:
+        adapter = MagicMock()
+        adapter.is_available.return_value = False
+        with patch.object(backup_export, "get_neo4j_adapter", return_value=adapter):
+            try:
+                backup_export.create_backup()
+            except RuntimeError as e:
+                assert "not available" in str(e)
+            else:
+                raise AssertionError("expected RuntimeError when Neo4j is unavailable")
+
+
+class TestMain:
+    def test_returns_zero_on_success(self, tmp_path, monkeypatch, capsys) -> None:
+        monkeypatch.setenv("BACKUP_DIR", str(tmp_path))
+        adapter = MagicMock()
+        adapter.is_available.return_value = True
+        adapter.export_database.return_value = {"notes": [], "relationships": [], "metadata": {}}
+        with patch.object(backup_export, "get_neo4j_adapter", return_value=adapter):
+            assert backup_export.main() == 0
+        # Last line of stdout is the backup path, which the workflow can capture
+        assert capsys.readouterr().out.strip().endswith("backup.json")
+
+    def test_returns_one_on_failure(self, monkeypatch) -> None:
+        adapter = MagicMock()
+        adapter.is_available.return_value = False
+        with patch.object(backup_export, "get_neo4j_adapter", return_value=adapter):
+            assert backup_export.main() == 1


### PR DESCRIPTION
**Phase 3 part 1** of retiring the static admin token (#267). This removes CI's dependency on `ADMIN_TOKEN` and hardens how the deploy passes secrets to the droplet. It does **not** yet narrow the token's scope — that's part 2.

## Part A — back up over SSH, not the token-authed API
- New `backend/scripts/backup_export.py`: a CLI around `neo4j_adapter.export_database()` that writes the same zero-downtime JSON snapshot as `POST /api/admin/backup`, but needs no admin credential.
- Pre/post-deploy backup steps now run it inside the backend container over SSH (`docker compose exec -T backend python -m scripts.backup_export`), authenticated by CI's existing SSH key.

Effects:
- Drops `ADMIN_TOKEN` from both backup steps — CI no longer needs the token at all.
- Removes Cloudflare from the backup path (the old public-API `curl` was frequently blocked, hence the "single attempt" resignation in the old code).
- Eliminates the latent footgun that the `ADMIN_TOKEN` and `ADMIN_PASSKEY` GitHub secrets had to hold identical values.
- Also drops a vestigial `ADMIN_TOKEN` env from the database-health step (its `curl` never sent the header).

> `secrets.ADMIN_TOKEN` is now unreferenced by the workflow and can be deleted. The backend's token still comes from the `ADMIN_PASSKEY` secret (line 115), which passkey enrollment needs.

## Part C — base64-encode deploy secrets (folded in from the #268 fallout)
Each secret arg is base64-encoded before being passed over SSH and decoded in the heredoc under bash. `ssh` joins args into one string that the droplet's **zsh** login shell re-parses before `bash -s` runs, so a raw glob char (`* ? [ ] { }`) aborted the deploy with `no matches found` (hit live in #268). base64's alphabet has no glob chars, so encoded args survive the re-parse — and plaintext secrets no longer appear in the remote process list.

## First-deploy note
The pre-deploy backup runs against the *currently-running* container, which on the first deploy of this change predates `backup_export.py` — so it no-ops that once (`continue-on-error`). The post-deploy backup uses the freshly-built container and works immediately. Both are best-effort; nightly cron backups are unaffected.

## Tests
`tests/unit/test_backup_export.py` covers directory resolution, export-to-file, and the exit codes the workflow relies on. Full suite: **550 passing** (+7). ruff + mypy clean. Also verified the CLI end-to-end in the dev backend container (100 notes exported) and the base64 round-trip against a value containing every glob metacharacter.

Refs #267

https://claude.ai/code/session_01MgwQCvsNhqPZJsbJTjeqwW