### PR TITLE
feat: scope static admin token to passkey enrollment only (#267 pt 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -463,8 +463,11 @@ In `backend/main.py`:
 - `GET /api/auth/session` - Report auth state (200 whether or not signed in)
 - `GET|DELETE /api/auth/credentials` - List / revoke enrolled passkeys
 
-Admin endpoints accept a passkey session token **or** the static `ADMIN_TOKEN`;
-the token is retained for CI (deploy backups) and first-time enrollment.
+Admin endpoints require a passkey session token. The static `ADMIN_TOKEN` is
+scoped to passkey enrollment only (`/api/auth/register/*`, #267) - it bootstraps
+the first passkey and is the break-glass path, but is rejected (403) everywhere
+else. Deploy-time backups run over SSH (`backend/scripts/backup_export.py`), so
+CI no longer uses the token.
 
 *AI Features:*
 - `POST /api/search` - Semantic search (articles + notes)

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -134,30 +134,29 @@ def _check_session_token(token: str) -> dict[str, Any] | None:
     }
 
 
-def verify_admin(
+def _authenticate(
     request: Request,
-    credentials: HTTPAuthorizationCredentials | None = Depends(security),
-) -> bool:
-    """Verify admin credentials from the Authorization header.
+    credentials: HTTPAuthorizationCredentials | None,
+) -> dict[str, Any]:
+    """Authenticate an admin request, returning the principal or raising.
 
-    Accepts either a passkey session token (#229) or the static admin token,
-    both over `Authorization: Bearer`. Uses FastAPI's HTTPBearer security
-    scheme for proper Swagger UI integration.
+    Shared by verify_admin (passkey sessions only) and verify_enrollment
+    (sessions or the static token). Returns a dict with 'kind' ('passkey' or
+    'token'); each caller decides whether that kind is allowed for its endpoint.
 
-    Repeated invalid *static tokens* from one IP trigger a lockout (#225):
-    after MAX_FAILED_ATTEMPTS failures, that IP gets 429 for LOCKOUT_SECONDS
-    - even for requests that would otherwise carry the correct token. An
-    expired or malformed session token is reported as 401 and does not count
-    toward that budget: session tokens are HMAC-signed, so there is nothing
-    to brute-force, and counting them would let a stale browser tab lock the
-    admin out of logging back in.
+    The #225 lockout lives here because this is where the static token is
+    checked: repeated invalid tokens from one IP trigger 429 for LOCKOUT_SECONDS,
+    even for a request that would otherwise carry the correct token. A passkey
+    session is HMAC-signed and unguessable, so an expired or malformed session is
+    reported as 401 and does not count toward that budget - counting it would let
+    a stale browser tab lock the admin out of signing back in.
 
     Args:
         request: Incoming request (for the client IP)
         credentials: HTTPAuthorizationCredentials from HTTPBearer (None if missing)
 
     Returns:
-        True if authenticated
+        Principal dict with 'kind' ('passkey' or 'token')
 
     Raises:
         HTTPException: 401 if no auth header or an expired session, 403 if
@@ -186,7 +185,7 @@ def verify_admin(
     if _check_session_token(token):
         auth_tracker.record_success(ip)
         logger.debug("Admin authenticated via passkey session")
-        return True
+        return {"kind": "passkey"}
 
     if looks_like_session_token(token):
         logger.info("Rejected expired or invalid passkey session from %s", ip)
@@ -218,7 +217,61 @@ def verify_admin(
         raise HTTPException(status_code=403, detail="Invalid token.")
 
     auth_tracker.record_success(ip)
-    logger.debug("Admin authenticated successfully")
+    logger.debug("Admin authenticated via static token")
+    return {"kind": "token"}
+
+
+def verify_admin(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
+) -> bool:
+    """Full admin access: a passkey session is required (#267).
+
+    The static token no longer grants general admin access - it is scoped to
+    passkey enrollment (see verify_enrollment). A correct static token still
+    authenticates, but is rejected here with 403 directing the caller to sign in
+    with a passkey. This is the dependency behind AdminUser, used by every admin
+    operation except enrollment.
+
+    Args:
+        request: Incoming request (for the client IP)
+        credentials: HTTPAuthorizationCredentials from HTTPBearer (None if missing)
+
+    Returns:
+        True if authenticated with a passkey session
+
+    Raises:
+        HTTPException: 401 if no auth header or an expired session, 403 if the
+            credential is an invalid or enrollment-only static token, 429 if the
+            client IP is locked out
+    """
+    principal = _authenticate(request, credentials)
+    if principal["kind"] != "passkey":
+        raise HTTPException(
+            status_code=403,
+            detail="This operation requires a passkey session. Sign in with your passkey.",
+        )
+    return True
+
+
+def verify_enrollment(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
+) -> bool:
+    """Passkey-enrollment access: a passkey session OR the static token (#267).
+
+    Enrollment is the one operation the static token still authorizes, so the
+    first passkey can be created before any session exists - and as a break-glass
+    path if every passkey is lost. Once a passkey session is available, it works
+    here too.
+
+    Returns:
+        True if authenticated with either credential
+
+    Raises:
+        HTTPException: same as _authenticate (401 / 403 / 429)
+    """
+    _authenticate(request, credentials)
     return True
 
 
@@ -256,5 +309,8 @@ def verify_admin_optional(
     return unauthenticated
 
 
-# Type alias for dependency injection
+# Type aliases for dependency injection.
+# AdminUser gates full admin access (passkey session only). EnrollmentUser gates
+# passkey enrollment, which the static token may still authorize (#267).
 AdminUser = Annotated[bool, Depends(verify_admin)]
+EnrollmentUser = Annotated[bool, Depends(verify_enrollment)]

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -37,7 +37,7 @@ from webauthn.helpers.structs import (
     UserVerificationRequirement,
 )
 
-from auth import AdminUser, verify_admin_optional
+from auth import AdminUser, EnrollmentUser, verify_admin_optional
 from config import Settings, get_settings
 from core.sessions import (
     DEFAULT_TTL_SECONDS,
@@ -124,14 +124,15 @@ def create_auth_router(neo4j_adapter: Any) -> APIRouter:
     async def registration_options(
         request: Request,
         body: RegistrationOptionsRequest,
-        _admin: AdminUser,
+        _admin: EnrollmentUser,
         settings: Annotated[Settings, Depends(get_settings)],
     ) -> RegistrationOptionsResponse:
         """Begin passkey enrollment.
 
-        Requires existing admin auth: the static token for the first passkey,
-        a live passkey session for every one after. There is deliberately no
-        unauthenticated enrollment path.
+        Requires existing admin auth, and is the one place the static token
+        still qualifies (#267): the token for the first passkey, a live passkey
+        session for every one after. There is deliberately no unauthenticated
+        enrollment path.
         """
         _require_neo4j()
 
@@ -164,10 +165,13 @@ def create_auth_router(neo4j_adapter: Any) -> APIRouter:
     async def registration_verify(
         request: Request,
         body: RegistrationVerifyRequest,
-        _admin: AdminUser,
+        _admin: EnrollmentUser,
         settings: Annotated[Settings, Depends(get_settings)],
     ) -> CredentialsListResponse:
-        """Complete passkey enrollment and persist the credential."""
+        """Complete passkey enrollment and persist the credential.
+
+        Enrollment-scoped auth (#267): a passkey session or the static token.
+        """
         _require_neo4j()
 
         challenge = _challenge_from_credential(body.credential)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,7 @@
 """Pytest configuration and fixtures."""
 
 import os
+import time
 from collections.abc import Generator
 from typing import Any
 from unittest.mock import MagicMock
@@ -14,6 +15,10 @@ import pytest
 from fastapi.testclient import TestClient
 
 import main
+from config import get_settings
+from core.sessions import create_session_token, derive_session_secret
+
+TEST_ADMIN_TOKEN = "test-admin-token-for-ci"
 
 # ============================================================================
 # Mock Classes (defined first so fixtures can use them)
@@ -510,6 +515,22 @@ def client_with_mocks(
 
     # Clear all overrides
     main.app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def admin_headers() -> dict[str, str]:
+    """Passkey-session auth headers granting full admin access.
+
+    Since #267 the static admin token is scoped to passkey enrollment only, so
+    tests exercising full admin operations must present a session token. Tests
+    that specifically exercise the static-token path build their own headers.
+    """
+    settings = get_settings()
+    secret = derive_session_secret(
+        settings.admin_token or TEST_ADMIN_TOKEN, settings.session_secret
+    )
+    token = create_session_token(secret, "test-credential", time.time())
+    return {"Authorization": f"Bearer {token}"}
 
 
 @pytest.fixture

--- a/backend/tests/unit/test_admin_api.py
+++ b/backend/tests/unit/test_admin_api.py
@@ -16,25 +16,15 @@ from fastapi.testclient import TestClient
 # Set testing mode before importing app modules
 os.environ["TESTING"] = "1"
 
-from config import get_settings
 from main import app
 
-# Test admin token constant
-TEST_ADMIN_TOKEN = "test-admin-token-for-ci"
+# admin_headers (a passkey-session token) comes from conftest since #267.
 
 
 @pytest.fixture
 def client() -> TestClient:
     """Get test client for API testing."""
     return TestClient(app)
-
-
-@pytest.fixture
-def admin_headers() -> dict[str, str]:
-    """Get admin authentication headers for testing."""
-    settings = get_settings()
-    token = settings.admin_token or TEST_ADMIN_TOKEN
-    return {"Authorization": f"Bearer {token}"}
 
 
 class TestListBackups:

--- a/backend/tests/unit/test_auth_api.py
+++ b/backend/tests/unit/test_auth_api.py
@@ -286,10 +286,10 @@ class TestCredentialManagement:
         self,
         client: TestClient,
         adapter: FakeNeo4jAdapter,
-        admin_headers: dict[str, str],
+        session_headers: dict[str, str],
     ) -> None:
         adapter.create_admin_credential("dGVzdC1jcmVk", b"key", 0, "Laptop")
-        response = client.get("/api/auth/credentials", headers=admin_headers)
+        response = client.get("/api/auth/credentials", headers=session_headers)
         assert response.status_code == 200
         body = response.json()
         assert body["count"] == 1
@@ -299,10 +299,10 @@ class TestCredentialManagement:
         self,
         client: TestClient,
         adapter: FakeNeo4jAdapter,
-        admin_headers: dict[str, str],
+        session_headers: dict[str, str],
     ) -> None:
         adapter.create_admin_credential("dGVzdC1jcmVk", b"secret-key-bytes", 0, "Laptop")
-        body = client.get("/api/auth/credentials", headers=admin_headers).text
+        body = client.get("/api/auth/credentials", headers=session_headers).text
         assert "public_key" not in body
 
     def test_delete_requires_auth(self, client: TestClient) -> None:
@@ -312,29 +312,30 @@ class TestCredentialManagement:
         self,
         client: TestClient,
         adapter: FakeNeo4jAdapter,
-        admin_headers: dict[str, str],
+        session_headers: dict[str, str],
     ) -> None:
         adapter.create_admin_credential("dGVzdC1jcmVk", b"key", 0, "Laptop")
-        response = client.delete("/api/auth/credentials/dGVzdC1jcmVk", headers=admin_headers)
+        response = client.delete("/api/auth/credentials/dGVzdC1jcmVk", headers=session_headers)
         assert response.status_code == 200
         assert adapter.credentials == []
 
     def test_delete_unknown_returns_404(
-        self, client: TestClient, admin_headers: dict[str, str]
+        self, client: TestClient, session_headers: dict[str, str]
     ) -> None:
-        response = client.delete("/api/auth/credentials/missing", headers=admin_headers)
+        response = client.delete("/api/auth/credentials/missing", headers=session_headers)
         assert response.status_code == 404
 
     def test_delete_last_credential_allowed(
         self,
         client: TestClient,
         adapter: FakeNeo4jAdapter,
-        admin_headers: dict[str, str],
+        session_headers: dict[str, str],
     ) -> None:
-        """The static token is still a way back in, so this cannot lock anyone out."""
+        """Deleting the last passkey is allowed: the static token can still
+        re-enroll one (#267), so this cannot lock anyone out."""
         adapter.create_admin_credential("dGVzdC1jcmVk", b"key", 0, "Only")
         assert (
-            client.delete("/api/auth/credentials/dGVzdC1jcmVk", headers=admin_headers).status_code
+            client.delete("/api/auth/credentials/dGVzdC1jcmVk", headers=session_headers).status_code
             == 200
         )
 
@@ -400,15 +401,15 @@ class TestAuthResponsesAreNotCacheable:
         response = client.get("/api/auth/session")
         assert "no-store" in response.headers["Cache-Control"]
 
-    def test_credentials_endpoint_is_no_store(self, admin_headers: dict[str, str]) -> None:
+    def test_credentials_endpoint_is_no_store(self, session_headers: dict[str, str]) -> None:
         client = TestClient(real_app)
-        response = client.get("/api/auth/credentials", headers=admin_headers)
+        response = client.get("/api/auth/credentials", headers=session_headers)
         assert "no-store" in response.headers["Cache-Control"]
 
-    def test_auth_responses_are_private(self, admin_headers: dict[str, str]) -> None:
+    def test_auth_responses_are_private(self, session_headers: dict[str, str]) -> None:
         """A shared cache must not hold one caller's credential list."""
         client = TestClient(real_app)
-        response = client.get("/api/auth/credentials", headers=admin_headers)
+        response = client.get("/api/auth/credentials", headers=session_headers)
         assert "private" in response.headers["Cache-Control"]
 
     def test_other_get_endpoints_still_cache(self) -> None:
@@ -445,10 +446,9 @@ class TestSessionTokenAcceptedByAdminEndpoints:
         for _ in range(MAX_FAILED_ATTEMPTS + 2):
             assert client.get("/api/admin/backups", headers=headers).status_code == 401
 
-        # Not locked out: a valid token still works
-        response = client.get(
-            "/api/admin/backups", headers={"Authorization": f"Bearer {_admin_token()}"}
-        )
+        # Not locked out: a fresh session still works
+        fresh = create_session_token(secret, "cred", time.time())
+        response = client.get("/api/admin/backups", headers={"Authorization": f"Bearer {fresh}"})
         assert response.status_code == 200
 
     def test_forged_session_signature_rejected(self) -> None:
@@ -458,3 +458,52 @@ class TestSessionTokenAcceptedByAdminEndpoints:
         response = client.get("/api/admin/backups", headers={"Authorization": f"Bearer {forged}"})
         # Shaped like a session but unverifiable -> 401, never authorized
         assert response.status_code == 401
+
+
+class TestStaticTokenIsEnrollmentOnly:
+    """The static admin token is scoped to passkey enrollment (#267).
+
+    It authorizes register/* and nothing else. Every other admin operation
+    requires a passkey session, and rejects the token with 403. This is what
+    shrinks the blast radius of a leaked token: it can enroll a passkey (and is
+    the break-glass path), but cannot read, write, back up, or revoke.
+    """
+
+    def test_token_rejected_on_admin_endpoint(self) -> None:
+        client = TestClient(real_app)
+        response = client.get(
+            "/api/admin/backups", headers={"Authorization": f"Bearer {_admin_token()}"}
+        )
+        assert response.status_code == 403
+        assert "passkey session" in response.json()["detail"].lower()
+
+    def test_token_rejected_on_credentials_list(self) -> None:
+        client = TestClient(real_app)
+        response = client.get(
+            "/api/auth/credentials", headers={"Authorization": f"Bearer {_admin_token()}"}
+        )
+        assert response.status_code == 403
+
+    def test_token_rejected_on_note_creation(self) -> None:
+        client = TestClient(real_app)
+        response = client.post(
+            "/api/notes",
+            json={"content": "should be blocked"},
+            headers={"Authorization": f"Bearer {_admin_token()}"},
+        )
+        assert response.status_code == 403
+
+    def test_token_still_authorizes_enrollment(self) -> None:
+        """The one thing the token can still do: begin passkey enrollment.
+
+        Auth is checked before the endpoint body, so passing the enrollment gate
+        yields any status except 403 (200 if Neo4j is up, 503 if not) - an
+        unauthorized token would be a flat 403.
+        """
+        client = TestClient(real_app)
+        response = client.post(
+            "/api/auth/register/options",
+            json={"name": "Bootstrap"},
+            headers={"Authorization": f"Bearer {_admin_token()}"},
+        )
+        assert response.status_code != 403

--- a/backend/tests/unit/test_auth_throttle.py
+++ b/backend/tests/unit/test_auth_throttle.py
@@ -8,23 +8,15 @@ from fastapi.testclient import TestClient
 os.environ["TESTING"] = "1"
 
 from auth import MAX_FAILED_ATTEMPTS, FailedAuthTracker, auth_tracker
-from config import get_settings
 from main import app
 
-TEST_ADMIN_TOKEN = "test-admin-token-for-ci"
+# admin_headers (a passkey-session token) comes from conftest since #267.
 
 
 @pytest.fixture
 def client() -> TestClient:
     """Test client (auth_tracker reset handled by the autouse conftest fixture)."""
     return TestClient(app)
-
-
-@pytest.fixture
-def admin_headers() -> dict[str, str]:
-    settings = get_settings()
-    token = settings.admin_token or TEST_ADMIN_TOKEN
-    return {"Authorization": f"Bearer {token}"}
 
 
 BAD_HEADERS = {"Authorization": "Bearer definitely-wrong-token"}

--- a/backend/tests/unit/test_feature_flags.py
+++ b/backend/tests/unit/test_feature_flags.py
@@ -11,11 +11,10 @@ from fastapi.testclient import TestClient
 os.environ["TESTING"] = "1"
 
 import feature_flags as feature_flags_module
-from config import get_settings
 from feature_flags import FeatureFlagService
 from main import app
 
-TEST_ADMIN_TOKEN = "test-admin-token-for-ci"
+# admin_headers (a passkey-session token) comes from conftest since #267.
 
 
 class MockNeo4jFlags:
@@ -55,14 +54,6 @@ def flag_service(
 def client(flag_service: FeatureFlagService) -> TestClient:
     """Test client with the mock-backed flag service installed."""
     return TestClient(app)
-
-
-@pytest.fixture
-def admin_headers() -> dict[str, str]:
-    """Admin authentication headers."""
-    settings = get_settings()
-    token = settings.admin_token or TEST_ADMIN_TOKEN
-    return {"Authorization": f"Bearer {token}"}
 
 
 class TestFeatureFlagService:

--- a/backend/tests/unit/test_main.py
+++ b/backend/tests/unit/test_main.py
@@ -2,20 +2,10 @@
 
 from io import BytesIO
 
-import pytest
 from fastapi.testclient import TestClient
 
-from config import get_settings
-
-# Upload endpoint is admin-only (#224)
-TEST_ADMIN_TOKEN = "test-admin-token-for-ci"
-
-
-@pytest.fixture
-def admin_headers() -> dict[str, str]:
-    settings = get_settings()
-    token = settings.admin_token or TEST_ADMIN_TOKEN
-    return {"Authorization": f"Bearer {token}"}
+# Upload endpoint is admin-only (#224). admin_headers (a passkey-session token)
+# comes from conftest since #267.
 
 
 # Minimal JPEG with valid magic bytes (SOI + APP0 + JFIF + EOI)

--- a/backend/tests/unit/test_notes_api.py
+++ b/backend/tests/unit/test_notes_api.py
@@ -8,28 +8,16 @@ from fastapi.testclient import TestClient
 # Set testing mode before importing app modules
 os.environ["TESTING"] = "1"
 
-from config import get_settings
 from main import app
 from notes_service import get_notes_service
 
-# Test admin token constant
-TEST_ADMIN_TOKEN = "test-admin-token-for-ci"
+# admin_headers (a passkey-session token) comes from conftest since #267.
 
 
 @pytest.fixture
 def client() -> TestClient:
     """Get test client for API testing."""
     return TestClient(app)
-
-
-@pytest.fixture
-def admin_headers() -> dict[str, str]:
-    """Get admin authentication headers for testing."""
-    # Use the actual admin token from settings for local development
-    # In CI, this will be overridden by environment variable
-    settings = get_settings()
-    token = settings.admin_token or TEST_ADMIN_TOKEN
-    return {"Authorization": f"Bearer {token}"}
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/unit/test_upload_cleanup.py
+++ b/backend/tests/unit/test_upload_cleanup.py
@@ -12,18 +12,10 @@ from fastapi.testclient import TestClient
 os.environ["TESTING"] = "1"
 
 import main
-from config import get_settings
 from dependencies import get_neo4j, get_notes
 from main import _find_referenced_uploads, app
 
-TEST_ADMIN_TOKEN = "test-admin-token-for-ci"
-
-
-@pytest.fixture
-def admin_headers() -> dict[str, str]:
-    settings = get_settings()
-    token = settings.admin_token or TEST_ADMIN_TOKEN
-    return {"Authorization": f"Bearer {token}"}
+# admin_headers (a passkey-session token) comes from conftest since #267.
 
 
 @pytest.fixture

--- a/docs/knowledge-base/NOTES.md
+++ b/docs/knowledge-base/NOTES.md
@@ -48,17 +48,23 @@ The system:
 
 ### Admin User
 
-Admin auth gates note creation, editing, and deletion. Two credentials are
-accepted, both sent as `Authorization: Bearer <value>`:
+Admin auth gates note creation, editing, and deletion. Two credentials exist,
+both sent as `Authorization: Bearer <value>`, but they are **not**
+interchangeable since #267:
 
-| Credential | Who uses it | Lifetime | Revocable |
+| Credential | What it authorizes | Lifetime | Revocable |
 |---|---|---|---|
-| **Passkey session** (#229) | You, in the browser | 12 hours, server-enforced | per device |
-| **Static admin token** (`ADMIN_TOKEN`) | CI/automation, first-time enrollment | none | no (rotate the env var) |
+| **Passkey session** (#229) | Everything: notes, backups, credential management, feature flags | 12 hours, server-enforced | per device |
+| **Static admin token** (`ADMIN_TOKEN`) | Passkey enrollment only (`/api/auth/register/*`) | none | no (rotate the env var) |
 
-Passkeys are the normal way in. The static token is kept because the deploy
-workflow calls `/api/admin/backup` and cannot present a passkey, and because
-something has to authorize enrolling the *first* passkey.
+Passkeys are the way in for every admin operation. The static token is scoped
+down to a single job: authorizing passkey *enrollment* - the first passkey,
+before any session exists, and a break-glass path if every passkey is lost.
+Presented anywhere else it is rejected with 403. This keeps a leaked token from
+being able to read, write, back up, or revoke - only enroll.
+
+Deploy-time backups run over SSH (`scripts/backup_export.py`, #267), so CI no
+longer holds the admin token at all.
 
 ### Passkey Setup
 
@@ -68,8 +74,8 @@ something has to authorize enrolling the *first* passkey.
 
 From then on, `/login` offers **Sign in with passkey**. Enroll additional
 devices from `/admin` while signed in; revoke any of them there individually.
-Revoking the last passkey is allowed - the admin token still works, so this
-cannot lock you out.
+Revoking the last passkey is allowed - the admin token can still re-enroll one,
+so this cannot lock you out.
 
 ### How It Works
 
@@ -96,7 +102,8 @@ one that verifies the response.
 **Credentials** live as `(:AdminCredential)` nodes holding the credential id,
 COSE public key, signature counter, and device name.
 
-**Brute-force lockout** (#225) still applies to static-token guesses. Expired
+**Brute-force lockout** (#225) still applies to static-token guesses at the
+enrollment endpoints - the one place the token is checked (#267). Expired
 passkey sessions return 401 and are deliberately exempt, so a stale browser
 tab cannot lock you out of signing back in.
 
@@ -104,7 +111,7 @@ tab cannot lock you out of signing back in.
 
 ```bash
 # backend/.env
-ADMIN_TOKEN=your-admin-token          # required (enrollment + automation)
+ADMIN_TOKEN=your-admin-token          # required (passkey enrollment / break-glass)
 SESSION_SECRET=                       # optional; derived from ADMIN_TOKEN if empty
 WEBAUTHN_RP_ID=                       # optional; defaults to the first CORS origin's host
 WEBAUTHN_RP_NAME=Mongado              # shown in the OS passkey prompt

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -159,6 +159,10 @@ export default function LoginPage() {
                 <button type="submit" disabled={isLoading} className={styles.submitButton}>
                   {isLoading ? "Verifying..." : "Sign in with token"}
                 </button>
+                <p className={styles.hint}>
+                  Token sign-in is for enrolling a passkey. Add one on the admin page, then use it
+                  for everything else.
+                </p>
               </form>
             )}
           </div>


### PR DESCRIPTION
**Phase 3 part 2** of retiring the static admin token (#267), and the payoff of the series. The token no longer grants general admin access — it authorizes passkey **enrollment** and nothing else.

> Depends on #270 (part 1), which is merged and deployed — CI no longer uses the token, so narrowing it can't break deploy backups.

## Backend
`auth.py` splits `verify_admin` into a shared `_authenticate()` (keeps the #225 lockout, returns the principal `kind`) plus two dependencies:
- **`verify_admin`** (`AdminUser`) — requires a passkey session. A *correct* static token authenticates but is rejected with **403** ("requires a passkey session"). Backs every admin operation except enrollment.
- **`verify_enrollment`** (`EnrollmentUser`) — accepts a passkey session **or** the static token. Used only by `/api/auth/register/*`, so the first passkey can be enrolled before any session exists, and as a break-glass path.

The lockout stays in `_authenticate`, so token guesses are still throttled; an expired session remains a lockout-exempt 401.

`routers/auth.py`: the two registration endpoints move to `EnrollmentUser`; every other admin endpoint keeps `AdminUser` and is now passkey-session-only.

**Effect:** a leaked `ADMIN_TOKEN` can enroll a passkey (visible on the admin page and server-logged) but cannot read, write, back up, or revoke — its blast radius collapses to bootstrapping/recovery.

## Tests
Centralized `admin_headers` into `conftest.py` as a **passkey-session** token (full-admin tests must now present a session; six duplicated per-file fixtures removed). Added `TestStaticTokenIsEnrollmentOnly`: the token is 403'd on admin/credentials/notes endpoints, but still authorizes enrollment. **554 backend** pass, **81 frontend**, ruff/mypy/tsc clean.

## Frontend & docs
- Login page notes that token sign-in is for enrolling a passkey (the token-login bootstrap path still works: note-viewing is public, enrollment accepts the token; 403s on mutations surface as errors, no logout loop).
- `NOTES.md` and `CLAUDE.md` updated for the enrollment-only scope.

## After merge
Your existing passkey session is unaffected. The one behavior change: if you ever sign in with the *token* (fallback), you'll now only be able to enroll a passkey, not edit — which is the intended bootstrap/recovery flow.

Closes #267

https://claude.ai/code/session_01MgwQCvsNhqPZJsbJTjeqwW