### PR TITLE
feat: let authenticated admins see draft articles (#184)

### DIFF
--- a/backend/adapters/article_loader.py
+++ b/backend/adapters/article_loader.py
@@ -7,11 +7,9 @@ from typing import Any
 
 import frontmatter
 
-from config import get_settings
 from core.markdown_renderer import render_markdown_to_html
 
 logger = logging.getLogger(__name__)
-settings = get_settings()
 
 # Cache for loaded articles - cleared on restart
 _articles_cache: list[dict[str, Any]] | None = None
@@ -64,8 +62,9 @@ def load_static_articles_from_local(articles_dir: Path) -> list[dict[str, Any]]:
     Articles are cached in memory and only reloaded if files change.
     This provides fast response times while allowing hot-reload in development.
 
-    Draft articles (draft: true in frontmatter) are only included in development mode.
-    In production, they are filtered out.
+    All articles are loaded, including drafts (draft: true in frontmatter). Callers
+    are responsible for filtering drafts based on authentication/authorization
+    (see backend/dependencies.py get_static_articles vs get_all_static_articles).
 
     Args:
         articles_dir: Path to directory containing markdown files
@@ -107,14 +106,6 @@ def load_static_articles_from_local(articles_dir: Path) -> list[dict[str, Any]]:
     md_files = sorted(articles_dir.glob("*.md"))
     logger.info("Found %d markdown files in %s", len(md_files), articles_dir)
 
-    # Determine if we should include drafts (dev mode only)
-    is_dev_mode = settings.debug
-    logger.info(
-        "Environment mode: %s (drafts %s)",
-        "development" if is_dev_mode else "production",
-        "visible" if is_dev_mode else "hidden",
-    )
-
     for md_file in md_files:
         try:
             # Parse markdown with frontmatter
@@ -122,13 +113,6 @@ def load_static_articles_from_local(articles_dir: Path) -> list[dict[str, Any]]:
 
             # Check if article is a draft
             is_draft = post.get("draft", False)
-
-            # Skip drafts in production
-            if is_draft and not is_dev_mode:
-                logger.info(
-                    "Skipping draft article in production: %s", post.get("title", md_file.stem)
-                )
-                continue
 
             # Render markdown to HTML server-side
             try:
@@ -161,7 +145,7 @@ def load_static_articles_from_local(articles_dir: Path) -> list[dict[str, Any]]:
             continue
 
     logger.info(
-        "Successfully loaded %d articles (%d drafts filtered)",
+        "Successfully loaded %d articles (%d drafts)",
         len(articles),
         len([a for a in articles if a.get("draft", False)]),
     )

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -75,14 +75,25 @@ def get_notes() -> NotesService:
 
 # For static articles and user resources, we need callables that return
 # the current state (since these are mutable lists loaded at startup)
+# _static_articles holds the FULL list (including drafts); _published_articles
+# is derived from it and holds only non-draft articles. Keeping them in sync
+# means every existing consumer of get_static_articles() (search, ask,
+# inspire, embedding sync) stays draft-free with no code changes, while new
+# admin-only consumers can opt into get_all_static_articles().
 _static_articles: list[dict[str, Any]] = []
+_published_articles: list[dict[str, Any]] = []
 _user_resources: list[dict[str, Any]] = []
 
 
 def set_static_articles(articles: list[dict[str, Any]]) -> None:
-    """Set the static articles list (called during app startup)."""
-    global _static_articles
+    """Set the static articles list (called during app startup).
+
+    Stores the full list (including drafts) and derives the published-only
+    list used by get_static_articles().
+    """
+    global _static_articles, _published_articles
     _static_articles = articles
+    _published_articles = [a for a in articles if not a.get("draft")]
 
 
 def set_user_resources(resources: list[dict[str, Any]]) -> None:
@@ -92,10 +103,26 @@ def set_user_resources(resources: list[dict[str, Any]]) -> None:
 
 
 def get_static_articles() -> list[dict[str, Any]]:
-    """Get the current static articles list.
+    """Get the current published (non-draft) static articles list.
+
+    Deliberately excludes drafts so every existing consumer (search, ask,
+    inspire, embedding sync) stays draft-free without any code changes.
 
     This dependency can be overridden in tests:
         app.dependency_overrides[get_static_articles] = lambda: mock_articles
+    """
+    return _published_articles
+
+
+def get_all_static_articles() -> list[dict[str, Any]]:
+    """Get the full static articles list, including drafts.
+
+    Only intended for admin-authenticated consumers (see
+    routers/articles.py). Do not wire this into search/ask/inspire/embedding
+    sync - that would leak draft content to anonymous users.
+
+    This dependency can be overridden in tests:
+        app.dependency_overrides[get_all_static_articles] = lambda: mock_articles
     """
     return _static_articles
 
@@ -115,9 +142,10 @@ def reset_dependencies() -> None:
     Call this in test fixtures to ensure clean state between tests.
     """
     global _llm, _neo4j_adapter, _notes_service
-    global _static_articles, _user_resources
+    global _static_articles, _published_articles, _user_resources
     _llm = None
     _neo4j_adapter = None
     _notes_service = None
     _static_articles = []
+    _published_articles = []
     _user_resources = []

--- a/backend/main.py
+++ b/backend/main.py
@@ -22,7 +22,14 @@ from adapters.article_loader import load_static_articles
 from adapters.neo4j import get_neo4j_adapter
 from auth import verify_admin
 from config import SecretManager, Settings, get_secret_manager, get_settings
-from dependencies import get_neo4j, get_notes, get_ollama, set_static_articles, set_user_resources
+from dependencies import (
+    get_neo4j,
+    get_notes,
+    get_ollama,
+    get_static_articles,
+    set_static_articles,
+    set_user_resources,
+)
 from feature_flags import get_feature_flags, require_llm_features
 from image_optimizer import optimize_image_to_webp
 from logging_config import setup_logging
@@ -58,7 +65,11 @@ notes_service = get_notes_service()
 # LLM features are gated at runtime via feature flags (see feature_flags.py).
 # The Ollama client is created lazily on first use (dependencies.get_ollama).
 
-# Static articles (loaded from files/S3, read-only)
+# Static articles (loaded from files/S3, read-only). Holds the FULL list,
+# including drafts (#184) - the upload-cleanup scan below needs draft content
+# too, so images referenced only by a draft aren't garbage-collected. Anywhere
+# that must stay draft-free (embedding sync) uses get_static_articles() from
+# dependencies.py instead, which derives a published-only view.
 static_articles: list[dict[str, Any]] = []
 
 # User-created resources (in-memory for now, will be DB later)
@@ -76,10 +87,17 @@ async def _sync_embeddings_background() -> None:
     try:
         from embedding_sync import sync_embeddings_on_startup
 
-        # Run the sync in a thread pool (it's blocking I/O)
+        # Run the sync in a thread pool (it's blocking I/O). Uses the
+        # published-only list (get_static_articles()) - draft text must never
+        # land in Neo4j embeddings, which would leak drafts into semantic
+        # search for anonymous users.
         loop = asyncio.get_event_loop()
         await loop.run_in_executor(
-            None, sync_embeddings_on_startup, static_articles, get_ollama(), neo4j_adapter
+            None,
+            sync_embeddings_on_startup,
+            get_static_articles(),
+            get_ollama(),
+            neo4j_adapter,
         )
         _embedding_sync_ready = True
         logger.info("Background embedding sync completed - app is fully ready")
@@ -590,6 +608,8 @@ def cleanup_uploads(
             kept_recent=0,
         )
 
+    # FULL list (including drafts): a draft-only image reference must still
+    # count as "referenced" so cleanup doesn't delete it.
     texts: list[str] = []
     for article in static_articles:
         texts.append(str(article.get("content", "")))
@@ -676,8 +696,9 @@ def trigger_embedding_sync(
         # Import here to avoid circular dependency
         from embedding_sync import sync_articles_to_neo4j, sync_embeddings
 
-        # Sync articles to Neo4j first
-        created, updated, deleted = sync_articles_to_neo4j(static_articles, neo4j)
+        # Sync articles to Neo4j first. Published-only list - drafts must
+        # never be embedded/synced, or they'd leak into semantic search.
+        created, updated, deleted = sync_articles_to_neo4j(get_static_articles(), neo4j)
         logger.info(
             "Articles synced: %d created, %d updated, %d deleted", created, updated, deleted
         )

--- a/backend/routers/articles.py
+++ b/backend/routers/articles.py
@@ -8,9 +8,10 @@ import json
 import logging
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Response
 
-from dependencies import get_notes, get_ollama, get_static_articles
+from auth import verify_admin_optional
+from dependencies import get_all_static_articles, get_notes, get_ollama, get_static_articles
 from models import (
     ArticleMetadata,
     ArticleMetadataListResponse,
@@ -30,17 +31,45 @@ router = APIRouter(prefix="/api/articles", tags=["articles"])
 # Type aliases for cleaner signatures
 OllamaDep = Annotated[Any, Depends(get_ollama)]
 ArticlesDep = Annotated[list[dict[str, Any]], Depends(get_static_articles)]
+AllArticlesDep = Annotated[list[dict[str, Any]], Depends(get_all_static_articles)]
 NotesDep = Annotated[Any, Depends(get_notes)]
+# verify_admin_optional never raises - it reports auth state so anonymous
+# callers still get a 200 (published-only) response instead of a 401.
+AdminOptionalDep = Annotated[dict[str, Any], Depends(verify_admin_optional)]
+
+
+def _drafts_visible(auth: dict[str, Any]) -> bool:
+    """Whether this caller may see draft articles (#184).
+
+    Requires a passkey session specifically, not just "authenticated": the
+    static admin token is scoped to passkey enrollment only (#267) and must
+    not unlock anything else, including draft visibility - so
+    auth["authenticated"] alone is not sufficient here.
+    """
+    return bool(auth.get("authenticated")) and auth.get("kind") == "passkey"
 
 
 @router.get("", response_model=ArticleMetadataListResponse)
-def list_articles(static_articles: ArticlesDep) -> ArticleMetadataListResponse:
+def list_articles(
+    response: Response,
+    static_articles: ArticlesDep,
+    all_static_articles: AllArticlesDep,
+    auth: AdminOptionalDep,
+) -> ArticleMetadataListResponse:
     """Get all static articles metadata (without content), ordered by publication date descending.
 
     Returns lightweight metadata for article list views. Use GET /api/articles/{id}
-    to retrieve full article content.
+    to retrieve full article content. Admins (passkey session) additionally see
+    draft articles (#184); the response is marked non-cacheable whenever drafts
+    are included, so the shared 60s API cache never serves a draft-inclusive
+    response to a later anonymous request.
     """
     from dateutil import parser
+
+    drafts_visible = _drafts_visible(auth)
+    articles = all_static_articles if drafts_visible else static_articles
+    if drafts_visible:
+        response.headers["Cache-Control"] = "private, no-store, must-revalidate"
 
     # Sort by published_date (newer first), fallback to created_at
     def get_sort_key(resource: dict[str, Any]) -> Any:
@@ -53,7 +82,7 @@ def list_articles(static_articles: ArticlesDep) -> ArticleMetadataListResponse:
                 return parser.parse("1970-01-01")
         return parser.parse("1970-01-01")
 
-    sorted_articles = sorted(static_articles, key=get_sort_key, reverse=True)
+    sorted_articles = sorted(articles, key=get_sort_key, reverse=True)
 
     # Convert to ArticleMetadata (excludes content and html_content)
     metadata_list = [ArticleMetadata(**article) for article in sorted_articles]
@@ -62,9 +91,20 @@ def list_articles(static_articles: ArticlesDep) -> ArticleMetadataListResponse:
 
 
 @router.get("/{article_id}", response_model=ResourceResponse)
-def get_article(article_id: int, static_articles: ArticlesDep) -> ResourceResponse:
-    """Get a specific article by ID."""
-    for article in static_articles:
+def get_article(
+    article_id: int,
+    response: Response,
+    static_articles: ArticlesDep,
+    all_static_articles: AllArticlesDep,
+    auth: AdminOptionalDep,
+) -> ResourceResponse:
+    """Get a specific article by ID. Admins (passkey session) can also fetch drafts (#184)."""
+    drafts_visible = _drafts_visible(auth)
+    articles = all_static_articles if drafts_visible else static_articles
+    if drafts_visible:
+        response.headers["Cache-Control"] = "private, no-store, must-revalidate"
+
+    for article in articles:
         if article["id"] == article_id:
             return ResourceResponse(resource=Resource(**article))
     raise HTTPException(status_code=404, detail="Article not found")

--- a/backend/tests/unit/test_article_loader.py
+++ b/backend/tests/unit/test_article_loader.py
@@ -1,20 +1,25 @@
 """Unit tests for adapters.article_loader module.
 
 These tests verify article loading logic including:
-- Draft article filtering based on environment
+- Draft articles are always loaded (filtering happens downstream, see
+  dependencies.get_static_articles vs get_all_static_articles, #184)
 - Proper loading of date fields (published_date, updated_date)
 - Cache invalidation
 """
 
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
 
 from adapters import article_loader
 
 
 class TestArticleLoaderDraftFiltering:
-    """Tests for draft article filtering in different environments."""
+    """Tests for draft article loading.
+
+    The loader itself no longer filters drafts by environment (#184) - it
+    always loads every article, tagged with its `draft` field. Visibility is
+    decided by callers (dependencies.py, routers/articles.py).
+    """
 
     def create_test_article(self, article_dir: Path, filename: str, draft: bool = False) -> None:
         """Helper to create a test article with frontmatter."""
@@ -34,8 +39,8 @@ This is test content.
         article_path = article_dir / filename
         article_path.write_text(content)
 
-    def test_loads_published_articles_in_production(self):
-        """Should load non-draft articles in production mode."""
+    def test_loads_both_published_and_draft_articles(self):
+        """Should load both draft and published articles, regardless of mode."""
         with tempfile.TemporaryDirectory() as tmpdir:
             articles_dir = Path(tmpdir)
 
@@ -43,39 +48,16 @@ This is test content.
             self.create_test_article(articles_dir, "published.md", draft=False)
             self.create_test_article(articles_dir, "draft.md", draft=True)
 
-            # Mock production mode (debug=False)
-            with patch("adapters.article_loader.settings.debug", False):
-                # Clear cache before test
-                article_loader._articles_cache = None
-                article_loader._articles_hash = None
+            # Clear cache before test
+            article_loader._articles_cache = None
+            article_loader._articles_hash = None
 
-                articles = article_loader.load_static_articles_from_local(articles_dir)
+            articles = article_loader.load_static_articles_from_local(articles_dir)
 
-                # Should only load published article
-                assert len(articles) == 1
-                assert articles[0]["draft"] is False
-
-    def test_loads_all_articles_in_dev_mode(self):
-        """Should load both draft and published articles in dev mode."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            articles_dir = Path(tmpdir)
-
-            # Create published and draft articles
-            self.create_test_article(articles_dir, "published.md", draft=False)
-            self.create_test_article(articles_dir, "draft.md", draft=True)
-
-            # Mock dev mode (debug=True)
-            with patch("adapters.article_loader.settings.debug", True):
-                # Clear cache before test
-                article_loader._articles_cache = None
-                article_loader._articles_hash = None
-
-                articles = article_loader.load_static_articles_from_local(articles_dir)
-
-                # Should load both articles
-                assert len(articles) == 2
-                draft_count = sum(1 for a in articles if a.get("draft", False))
-                assert draft_count == 1
+            # Should load both articles, with draft field preserved
+            assert len(articles) == 2
+            draft_flags = {a["draft"] for a in articles}
+            assert draft_flags == {True, False}
 
     def test_loads_date_fields(self):
         """Should properly load published_date and updated_date fields."""

--- a/backend/tests/unit/test_articles_draft_visibility.py
+++ b/backend/tests/unit/test_articles_draft_visibility.py
@@ -1,0 +1,197 @@
+"""Tests for admin draft-article visibility (#184).
+
+Drafts must stay invisible everywhere by default. Only GET /api/articles and
+GET /api/articles/{id} reveal them, and only to a passkey-authenticated admin.
+Every other consumer of articles (search, ask, inspire, embedding sync) goes
+through dependencies.get_static_articles(), which is published-only by
+construction - see test_dependencies_draft_filtering below for that guarantee.
+"""
+
+import os
+
+os.environ["TESTING"] = "1"
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+import dependencies  # noqa: E402
+
+# admin_headers (a passkey-session token) comes from conftest since #267.
+
+_PUBLISHED_ARTICLE = {
+    "id": 9001,
+    "title": "Published Article",
+    "summary": "A published article.",
+    "content": "Published content.",
+    "html_content": "<p>Published content.</p>",
+    "content_type": "markdown",
+    "url": None,
+    "tags": [],
+    "draft": False,
+    "published_date": "2026-01-01",
+    "updated_date": None,
+    "created_at": None,
+}
+
+_DRAFT_ARTICLE = {
+    "id": 9002,
+    "title": "Draft Article",
+    "summary": "A draft article.",
+    "content": "Draft content.",
+    "html_content": "<p>Draft content.</p>",
+    "content_type": "markdown",
+    "url": None,
+    "tags": [],
+    "draft": True,
+    "published_date": "2026-01-02",
+    "updated_date": None,
+    "created_at": None,
+}
+
+
+def _set_mixed_articles() -> None:
+    dependencies.set_static_articles([_PUBLISHED_ARTICLE, _DRAFT_ARTICLE])
+
+
+class TestDependenciesDraftFiltering:
+    """Unit tests for the get_static_articles/get_all_static_articles split."""
+
+    def test_get_static_articles_excludes_drafts(self) -> None:
+        _set_mixed_articles()
+        published = dependencies.get_static_articles()
+        assert [a["id"] for a in published] == [_PUBLISHED_ARTICLE["id"]]
+
+    def test_get_all_static_articles_includes_drafts(self) -> None:
+        _set_mixed_articles()
+        full = dependencies.get_all_static_articles()
+        ids = {a["id"] for a in full}
+        assert ids == {_PUBLISHED_ARTICLE["id"], _DRAFT_ARTICLE["id"]}
+
+
+class TestListArticlesDraftVisibility:
+    def test_anonymous_list_excludes_drafts(self, client: TestClient) -> None:
+        _set_mixed_articles()
+        response = client.get("/api/articles")
+        assert response.status_code == 200
+        ids = {r["id"] for r in response.json()["resources"]}
+        assert _DRAFT_ARTICLE["id"] not in ids
+        assert _PUBLISHED_ARTICLE["id"] in ids
+
+    def test_admin_list_includes_drafts(
+        self, client: TestClient, admin_headers: dict[str, str]
+    ) -> None:
+        _set_mixed_articles()
+        response = client.get("/api/articles", headers=admin_headers)
+        assert response.status_code == 200
+        ids = {r["id"] for r in response.json()["resources"]}
+        assert ids == {_PUBLISHED_ARTICLE["id"], _DRAFT_ARTICLE["id"]}
+
+
+class TestGetArticleDraftVisibility:
+    def test_anonymous_cannot_fetch_draft(self, client: TestClient) -> None:
+        _set_mixed_articles()
+        response = client.get(f"/api/articles/{_DRAFT_ARTICLE['id']}")
+        assert response.status_code == 404
+
+    def test_admin_can_fetch_draft(
+        self, client: TestClient, admin_headers: dict[str, str]
+    ) -> None:
+        _set_mixed_articles()
+        response = client.get(f"/api/articles/{_DRAFT_ARTICLE['id']}", headers=admin_headers)
+        assert response.status_code == 200
+        assert response.json()["resource"]["id"] == _DRAFT_ARTICLE["id"]
+
+    def test_anonymous_can_still_fetch_published_article(self, client: TestClient) -> None:
+        _set_mixed_articles()
+        response = client.get(f"/api/articles/{_PUBLISHED_ARTICLE['id']}")
+        assert response.status_code == 200
+        assert response.json()["resource"]["id"] == _PUBLISHED_ARTICLE["id"]
+
+
+class TestArticlesCacheControl:
+    """Cache poisoning guard: admin (draft-inclusive) responses must never be
+    picked up by the shared 60s API cache (CacheControlMiddleware)."""
+
+    def test_anonymous_list_gets_public_cache(self, client: TestClient) -> None:
+        _set_mixed_articles()
+        response = client.get("/api/articles")
+        assert response.status_code == 200
+        cache_control = response.headers["cache-control"]
+        assert "public" in cache_control
+        assert "max-age=60" in cache_control
+
+    def test_admin_list_gets_private_no_store(
+        self, client: TestClient, admin_headers: dict[str, str]
+    ) -> None:
+        _set_mixed_articles()
+        response = client.get("/api/articles", headers=admin_headers)
+        assert response.status_code == 200
+        cache_control = response.headers["cache-control"]
+        assert "private" in cache_control
+        assert "no-store" in cache_control
+
+    def test_admin_detail_gets_private_no_store(
+        self, client: TestClient, admin_headers: dict[str, str]
+    ) -> None:
+        _set_mixed_articles()
+        response = client.get(
+            f"/api/articles/{_PUBLISHED_ARTICLE['id']}", headers=admin_headers
+        )
+        assert response.status_code == 200
+        cache_control = response.headers["cache-control"]
+        assert "private" in cache_control
+        assert "no-store" in cache_control
+
+    def test_anonymous_detail_gets_public_cache(self, client: TestClient) -> None:
+        _set_mixed_articles()
+        response = client.get(f"/api/articles/{_PUBLISHED_ARTICLE['id']}")
+        assert response.status_code == 200
+        cache_control = response.headers["cache-control"]
+        assert "public" in cache_control
+        assert "max-age=60" in cache_control
+
+
+class TestStaticTokenDoesNotUnlockDrafts:
+    """The static admin token is scoped to passkey enrollment only (#267) and
+    must not unlock draft visibility, even though verify_admin_optional
+    reports it as 'authenticated'."""
+
+    def test_static_token_does_not_reveal_drafts(self, client: TestClient) -> None:
+        from config import get_settings
+
+        _set_mixed_articles()
+        settings = get_settings()
+        token = settings.admin_token
+        if not token:
+            import pytest
+
+            pytest.skip("ADMIN_TOKEN not configured in test environment")
+
+        response = client.get("/api/articles", headers={"Authorization": f"Bearer {token}"})
+        assert response.status_code == 200
+        ids = {r["id"] for r in response.json()["resources"]}
+        assert _DRAFT_ARTICLE["id"] not in ids
+
+
+class TestSearchAndAskExcludeDrafts:
+    """Resource assembly for /api/search and /api/ask must never see drafts,
+    regardless of admin auth - both endpoints depend on get_static_articles(),
+    the published-only view."""
+
+    def test_search_never_returns_draft_content(self, client: TestClient) -> None:
+        _set_mixed_articles()
+        response = client.post("/api/search", json={"query": "Draft content", "top_k": 10})
+        assert response.status_code == 200
+        results = response.json()["results"]
+        titles = {r["title"] for r in results}
+        assert _DRAFT_ARTICLE["title"] not in titles
+
+    def test_ask_context_excludes_draft_content(self, client: TestClient) -> None:
+        _set_mixed_articles()
+        response = client.post("/api/ask", json={"question": "What is in the draft content?"})
+        # /api/ask may 503 if the LLM backend is unavailable in the mock - the
+        # point of this test is only that draft text is never in scope for
+        # whatever context gets assembled.
+        if response.status_code == 200:
+            body = response.json()
+            answer_blob = str(body)
+            assert "Draft content." not in answer_blob

--- a/frontend/src/app/knowledge-base/articles/ArticlesClient.tsx
+++ b/frontend/src/app/knowledge-base/articles/ArticlesClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 
 import AIAssistant from "@/components/AIAssistant";
@@ -8,6 +8,8 @@ import { EmptyState } from "@/components/PageState";
 import { useRouter, useSearchParams } from "next/navigation";
 import Breadcrumb from "@/components/Breadcrumb";
 import { TagPillList } from "@/components/TagPill";
+import { apiGet, isAuthenticated } from "@/lib/api/client";
+import { logger } from "@/lib/logger";
 import styles from "./page.module.scss";
 
 export interface ArticleMetadata {
@@ -34,8 +36,40 @@ export default function ArticlesClient({ resources }: { resources: ArticleMetada
   const [sortBy, setSortBy] = useState<SortOption>("newest");
   const [showAllTags, setShowAllTags] = useState(false);
 
+  // Draft articles (#184): the server fetch that produced `resources` is
+  // anonymous/cached, so it never includes drafts. When signed in, re-fetch
+  // with auth headers and merge in any draft-only entries. Starts empty to
+  // avoid a hydration mismatch (server never renders drafts) - populated
+  // client-side only, same pattern as NoteEditorForm's aiAvailable state.
+  const [draftResources, setDraftResources] = useState<ArticleMetadata[]>([]);
+
+  useEffect(() => {
+    if (!isAuthenticated()) return;
+
+    let cancelled = false;
+
+    async function fetchDrafts() {
+      try {
+        const data = await apiGet<{ resources: ArticleMetadata[] }>("/api/articles");
+        if (cancelled) return;
+        setDraftResources(data.resources.filter((r) => r.draft));
+      } catch (err) {
+        logger.error("Failed to load draft articles", err);
+      }
+    }
+
+    fetchDrafts();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const knownIds = new Set(resources.map((r) => r.id));
+  const allResources = [...resources, ...draftResources.filter((r) => !knownIds.has(r.id))];
+
   // Calculate tag counts
-  const tagCounts = resources.reduce(
+  const tagCounts = allResources.reduce(
     (acc, resource) => {
       resource.tags.forEach((tag) => {
         acc[tag] = (acc[tag] || 0) + 1;
@@ -56,7 +90,7 @@ export default function ArticlesClient({ resources }: { resources: ArticleMetada
   const otherTags = sortedTags.filter(([_, count]) => count === 1);
   const visibleTags = showAllTags ? sortedTags : topTags;
 
-  const filteredResources = resources
+  const filteredResources = allResources
     .filter((resource) => {
       // Filter by tags (OR logic - article must have at least one selected tag)
       if (selectedTags.length > 0) {
@@ -260,7 +294,8 @@ export default function ArticlesClient({ resources }: { resources: ArticleMetada
                 )}
                 <div className={styles.articleCount}>
                   Showing {filteredResources.length}
-                  {filteredResources.length !== resources.length && ` of ${resources.length}`}{" "}
+                  {filteredResources.length !== allResources.length &&
+                    ` of ${allResources.length}`}{" "}
                   {filteredResources.length === 1 ? "article" : "articles"}
                 </div>
               </div>

--- a/frontend/src/app/knowledge-base/articles/[id]/ArticleView.tsx
+++ b/frontend/src/app/knowledge-base/articles/[id]/ArticleView.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import Link from "next/link";
+import { CalendarBlank, PencilSimple, NotePencil } from "@phosphor-icons/react/dist/ssr";
+
+import AIAssistant from "@/components/AIAssistant";
+import ArticleTableOfContents from "@/components/ArticleTableOfContents";
+import Breadcrumb from "@/components/Breadcrumb";
+import Badge from "@/components/Badge";
+import { sanitizeHtml } from "@/lib/sanitize";
+import ArticleTags from "./ArticleTags";
+import RelatedNotes from "./RelatedNotes";
+import styles from "./page.module.scss";
+
+export interface Article {
+  id: number;
+  title: string;
+  content: string;
+  html_content?: string; // Pre-rendered HTML from backend
+  content_type?: string;
+  summary?: string;
+  url?: string;
+  tags: string[];
+  draft?: boolean;
+  published_date?: string;
+  updated_date?: string;
+  created_at: string; // Legacy fallback
+}
+
+/**
+ * Renders a full article. Shared by the server-rendered happy path
+ * (page.tsx) and the client-side draft fallback (DraftArticleFallback.tsx,
+ * #184) so both stay visually identical.
+ */
+export default function ArticleView({ article }: { article: Article }) {
+  const publishedDate = article.published_date || article.created_at;
+
+  return (
+    <div className={styles.container}>
+      {/* AI panel + button island (only shown when LLM features enabled) */}
+      <AIAssistant />
+
+      {/* Header */}
+      <header className={styles.header}>
+        <div className={styles.headerContent}>
+          {/* Breadcrumb */}
+          <div className={styles.headerTop}>
+            <Breadcrumb section="articles" />
+          </div>
+
+          {/* Content Type Badge and Draft Badge */}
+          <div className={styles.badgeRow}>
+            <Badge type="article" />
+            {article.draft && <span className={styles.draftBadge}>Draft</span>}
+          </div>
+
+          {/* Title */}
+          <h1 className={styles.title}>{article.title}</h1>
+
+          {/* Metadata */}
+          <div className={styles.metadata}>
+            <div className={styles.metaItem}>
+              <CalendarBlank size={14} aria-hidden="true" />
+              <span>
+                Published{" "}
+                <time dateTime={publishedDate}>
+                  {new Date(publishedDate).toLocaleDateString("en-US", {
+                    year: "numeric",
+                    month: "long",
+                    day: "numeric",
+                  })}
+                </time>
+              </span>
+            </div>
+            {article.updated_date && article.updated_date !== article.published_date && (
+              <div className={styles.metaItem}>
+                <PencilSimple size={14} aria-hidden="true" />
+                <span>
+                  Last updated{" "}
+                  <time dateTime={article.updated_date}>
+                    {new Date(article.updated_date).toLocaleDateString("en-US", {
+                      year: "numeric",
+                      month: "long",
+                      day: "numeric",
+                    })}
+                  </time>
+                </span>
+              </div>
+            )}
+          </div>
+
+          {/* Tags */}
+          {article.tags.length > 0 && (
+            <div className={styles.tags}>
+              <ArticleTags tags={article.tags} />
+            </div>
+          )}
+
+          {/* Create Note from Article */}
+          <div className={styles.actions}>
+            <Link
+              href={`/knowledge-base/notes/new?from_article=${article.id}&title=Notes on: ${encodeURIComponent(article.title)}&content=${encodeURIComponent(`See [[article:${article.id}]] for the full article.\n\n## Key Takeaways\n\n- `)}`}
+              className={styles.createNoteButton}
+            >
+              <NotePencil size={16} aria-hidden="true" /> Create Note from Article
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      {/* Content */}
+      <main className={styles.main}>
+        <div className={styles.contentGrid}>
+          {/* Main Article Content */}
+          <div className={styles.articleContent}>
+            <article className={styles.articleCard}>
+              {article.html_content ? (
+                // Use pre-rendered HTML from backend (includes footnotes, syntax highlighting)
+                // Sanitize to prevent XSS attacks
+                <div
+                  className={`${styles.renderedContent} prose prose-sm`}
+                  dangerouslySetInnerHTML={{ __html: sanitizeHtml(article.html_content) }}
+                />
+              ) : (
+                <div className="prose prose-sm max-w-none">
+                  <p className="text-gray-700">{article.content}</p>
+                </div>
+              )}
+
+              {article.url && (
+                <div className={styles.externalLink}>
+                  <h3 className={styles.linkTitle}>External Link</h3>
+                  <a
+                    href={article.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={styles.linkUrl}
+                  >
+                    {article.url}
+                  </a>
+                </div>
+              )}
+            </article>
+
+            {/* Back to articles */}
+            <Link href="/knowledge-base/articles" className={styles.backLink}>
+              ← Back to all articles
+            </Link>
+          </div>
+
+          {/* Table of Contents Sidebar */}
+          <div className={styles.tocSidebar}>
+            {(article.content_type === "markdown" || article.content_type === undefined) && (
+              <ArticleTableOfContents content={article.content} />
+            )}
+
+            {/* Related Notes Section */}
+            <RelatedNotes articleId={article.id} />
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/app/knowledge-base/articles/[id]/DraftArticleFallback.tsx
+++ b/frontend/src/app/knowledge-base/articles/[id]/DraftArticleFallback.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { apiGet, isAuthenticated } from "@/lib/api/client";
+import { logger } from "@/lib/logger";
+import { LoadingState } from "@/components/PageState";
+import ArticleView, { type Article } from "./ArticleView";
+import { ArticleNotFoundContent } from "./not-found";
+
+/**
+ * Rendered when the anonymous, server-side article fetch 404s (#184).
+ *
+ * A draft article always 404s from the public server fetch (page.tsx), since
+ * that fetch has no way to carry the admin's localStorage token during SSR.
+ * This component retries client-side with auth headers: if the caller is a
+ * signed-in admin and the article turns out to exist (i.e. it's a draft),
+ * render it with the Draft badge. Otherwise fall back to the same
+ * "article not found" UI anonymous visitors always see - so nothing about
+ * this path leaks whether an ID belongs to a draft.
+ */
+export default function DraftArticleFallback({ articleId }: { articleId: string }) {
+  const [status, setStatus] = useState<"checking" | "not-found" | "found">("checking");
+  const [article, setArticle] = useState<Article | null>(null);
+
+  useEffect(() => {
+    if (!isAuthenticated()) {
+      setStatus("not-found");
+      return;
+    }
+
+    let cancelled = false;
+
+    async function fetchDraft() {
+      try {
+        const data = await apiGet<{ resource: Article }>(`/api/articles/${articleId}`);
+        if (cancelled) return;
+        setArticle(data.resource);
+        setStatus("found");
+      } catch (err) {
+        logger.error("Failed to load draft article", err);
+        if (!cancelled) setStatus("not-found");
+      }
+    }
+
+    fetchDraft();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [articleId]);
+
+  if (status === "checking") {
+    return <LoadingState inline label="Loading article" />;
+  }
+
+  if (status === "found" && article) {
+    return <ArticleView article={article} />;
+  }
+
+  return <ArticleNotFoundContent />;
+}

--- a/frontend/src/app/knowledge-base/articles/[id]/not-found.tsx
+++ b/frontend/src/app/knowledge-base/articles/[id]/not-found.tsx
@@ -1,7 +1,14 @@
 import Link from "next/link";
 import styles from "./page.module.scss";
 
-export default function ArticleNotFound() {
+/**
+ * The "article not found" experience. Exported so DraftArticleFallback.tsx
+ * (#184) can render the identical UI for anonymous/unauthorized visitors
+ * without duplicating markup - Next's automatic not-found.tsx wiring only
+ * fires for the server-side notFound() case (published articles), not the
+ * client-side draft check.
+ */
+export function ArticleNotFoundContent() {
   return (
     <div className={styles.container}>
       <div className={styles.errorContainer}>
@@ -15,4 +22,8 @@ export default function ArticleNotFound() {
       </div>
     </div>
   );
+}
+
+export default function ArticleNotFound() {
+  return <ArticleNotFoundContent />;
 }

--- a/frontend/src/app/knowledge-base/articles/[id]/page.tsx
+++ b/frontend/src/app/knowledge-base/articles/[id]/page.tsx
@@ -1,38 +1,20 @@
 import type { Metadata } from "next";
-import Link from "next/link";
-import { notFound } from "next/navigation";
-import { CalendarBlank, PencilSimple, NotePencil } from "@phosphor-icons/react/dist/ssr";
 
-import AIAssistant from "@/components/AIAssistant";
-import ArticleTableOfContents from "@/components/ArticleTableOfContents";
-import Breadcrumb from "@/components/Breadcrumb";
-import Badge from "@/components/Badge";
-import { sanitizeHtml } from "@/lib/sanitize";
 import { getServerApiUrl } from "@/lib/server-api";
-import ArticleTags from "./ArticleTags";
-import RelatedNotes from "./RelatedNotes";
-import styles from "./page.module.scss";
+import ArticleView, { type Article } from "./ArticleView";
+import DraftArticleFallback from "./DraftArticleFallback";
 
 // Articles are static markdown cached in backend memory - render on the
 // server so content is in the initial HTML (#207). No generateStaticParams:
 // the backend isn't reachable during `docker build`, so pages render on
 // first request and are then cached (ISR) for the revalidate window.
+//
+// A draft article always 404s from this anonymous server fetch (#184) - the
+// admin token lives in localStorage, unreachable during SSR. That's fine:
+// ISR only caches this shell (or the anonymous not-found fallback), never
+// draft content, and DraftArticleFallback re-checks auth client-side on
+// every load regardless of the cached shell.
 export const revalidate = 300;
-
-interface Article {
-  id: number;
-  title: string;
-  content: string;
-  html_content?: string; // Pre-rendered HTML from backend
-  content_type?: string;
-  summary?: string;
-  url?: string;
-  tags: string[];
-  draft?: boolean;
-  published_date?: string;
-  updated_date?: string;
-  created_at: string; // Legacy fallback
-}
 
 async function fetchArticle(id: string): Promise<Article | null> {
   if (!/^\d+$/.test(id)) return null;
@@ -70,136 +52,12 @@ export default async function ArticleDetailPage({ params }: { params: Promise<{ 
   const { id } = await params;
   const article = await fetchArticle(id);
 
+  // Published article (or bad id format handled inside fetchArticle) - render
+  // normally. Otherwise this might be a draft: hand off to the client
+  // fallback, which retries with the admin's auth headers, if any.
   if (!article) {
-    notFound();
+    return <DraftArticleFallback articleId={id} />;
   }
 
-  const publishedDate = article.published_date || article.created_at;
-
-  return (
-    <div className={styles.container}>
-      {/* AI panel + button island (only shown when LLM features enabled) */}
-      <AIAssistant />
-
-      {/* Header */}
-      <header className={styles.header}>
-        <div className={styles.headerContent}>
-          {/* Breadcrumb */}
-          <div className={styles.headerTop}>
-            <Breadcrumb section="articles" />
-          </div>
-
-          {/* Content Type Badge and Draft Badge */}
-          <div className={styles.badgeRow}>
-            <Badge type="article" />
-            {article.draft && <span className={styles.draftBadge}>Draft</span>}
-          </div>
-
-          {/* Title */}
-          <h1 className={styles.title}>{article.title}</h1>
-
-          {/* Metadata */}
-          <div className={styles.metadata}>
-            <div className={styles.metaItem}>
-              <CalendarBlank size={14} aria-hidden="true" />
-              <span>
-                Published{" "}
-                <time dateTime={publishedDate}>
-                  {new Date(publishedDate).toLocaleDateString("en-US", {
-                    year: "numeric",
-                    month: "long",
-                    day: "numeric",
-                  })}
-                </time>
-              </span>
-            </div>
-            {article.updated_date && article.updated_date !== article.published_date && (
-              <div className={styles.metaItem}>
-                <PencilSimple size={14} aria-hidden="true" />
-                <span>
-                  Last updated{" "}
-                  <time dateTime={article.updated_date}>
-                    {new Date(article.updated_date).toLocaleDateString("en-US", {
-                      year: "numeric",
-                      month: "long",
-                      day: "numeric",
-                    })}
-                  </time>
-                </span>
-              </div>
-            )}
-          </div>
-
-          {/* Tags */}
-          {article.tags.length > 0 && (
-            <div className={styles.tags}>
-              <ArticleTags tags={article.tags} />
-            </div>
-          )}
-
-          {/* Create Note from Article */}
-          <div className={styles.actions}>
-            <Link
-              href={`/knowledge-base/notes/new?from_article=${article.id}&title=Notes on: ${encodeURIComponent(article.title)}&content=${encodeURIComponent(`See [[article:${article.id}]] for the full article.\n\n## Key Takeaways\n\n- `)}`}
-              className={styles.createNoteButton}
-            >
-              <NotePencil size={16} aria-hidden="true" /> Create Note from Article
-            </Link>
-          </div>
-        </div>
-      </header>
-
-      {/* Content */}
-      <main className={styles.main}>
-        <div className={styles.contentGrid}>
-          {/* Main Article Content */}
-          <div className={styles.articleContent}>
-            <article className={styles.articleCard}>
-              {article.html_content ? (
-                // Use pre-rendered HTML from backend (includes footnotes, syntax highlighting)
-                // Sanitize to prevent XSS attacks
-                <div
-                  className={`${styles.renderedContent} prose prose-sm`}
-                  dangerouslySetInnerHTML={{ __html: sanitizeHtml(article.html_content) }}
-                />
-              ) : (
-                <div className="prose prose-sm max-w-none">
-                  <p className="text-gray-700">{article.content}</p>
-                </div>
-              )}
-
-              {article.url && (
-                <div className={styles.externalLink}>
-                  <h3 className={styles.linkTitle}>External Link</h3>
-                  <a
-                    href={article.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={styles.linkUrl}
-                  >
-                    {article.url}
-                  </a>
-                </div>
-              )}
-            </article>
-
-            {/* Back to articles */}
-            <Link href="/knowledge-base/articles" className={styles.backLink}>
-              ← Back to all articles
-            </Link>
-          </div>
-
-          {/* Table of Contents Sidebar */}
-          <div className={styles.tocSidebar}>
-            {(article.content_type === "markdown" || article.content_type === undefined) && (
-              <ArticleTableOfContents content={article.content} />
-            )}
-
-            {/* Related Notes Section */}
-            <RelatedNotes articleId={article.id} />
-          </div>
-        </div>
-      </main>
-    </div>
-  );
+  return <ArticleView article={article} />;
 }


### PR DESCRIPTION
Fixes #184.

Drafts were dropped at load time whenever `settings.debug` was false, so they simply did not exist in production. Now every article loads, and draft visibility is decided **per request**.

## Backend

- `article_loader.py` — loads all `.md` files unconditionally; the `debug` branch is gone.
- `dependencies.py` — `set_static_articles()` stores the full list plus a derived published-only list. **`get_static_articles()` still returns published-only**, so every existing consumer (`routers/search.py`, `routers/ai.py`, `routers/inspire.py`, embedding sync) stays draft-free with no change. New `get_all_static_articles()` is used only by the two article endpoints.
- `routers/articles.py` — `list_articles` / `get_article` select the full list via `verify_admin_optional` (never raises, so anonymous callers still get a 200).
- `main.py` — the two consumers of the module-level list needed **different** answers, now explicit and commented: upload-cleanup uses the **full** list (otherwise images referenced only by a draft get garbage-collected), embedding sync uses **published-only** (otherwise draft text lands in Neo4j and leaks into semantic search).

### Two things worth reviewing

**Gated on `kind == "passkey"`, not bare `authenticated`.** `verify_admin_optional` also reports the static `ADMIN_TOKEN` as authenticated, but #267 scoped that token to passkey enrollment only. Using bare `authenticated` would have quietly reopened it for draft visibility. Covered by `TestStaticTokenDoesNotUnlockDrafts`.

**Cache-poisoning guard.** `CacheControlMiddleware` stamps `public, max-age=60, stale-while-revalidate=300` on any `GET /api/*` without its own header — which would let a shared cache serve an admin's draft-inclusive response to the next anonymous visitor. Draft-inclusive responses now set `private, no-store, must-revalidate` themselves, mirroring the `/api/auth/*` treatment. Tested in both directions.

## Frontend

Article pages are Server Components and the admin token lives in `localStorage`, unreachable during SSR. Rather than touch the passkey session plumbing from #229/#267, this uses client-side augmentation: the server render stays public and cached, and a client component merges drafts in when signed in. The detail route falls back to an authenticated client fetch on 404, keeping the not-found experience identical for anonymous visitors.

**Known limitation:** `generateMetadata` still returns "Article not found" for a draft's tab title — server-side, no auth visible. The body renders correctly with the Draft badge.

## Testing

14 new tests: published/full split, anonymous vs. admin visibility on list and detail, Cache-Control divergence, static-token rejection, and confirmation that `/api/search` and `/api/ask` never surface draft content. Full suite: backend 581 passed, frontend 113 passed, lint + typecheck clean.

No frontend test for the list-page augmentation — `ArticlesClient` has no Vitest harness and the mocking cost was disproportionate.

https://claude.ai/code/session_01KTENwGZUekeEwCZt2vKA4z