### PR TITLE
feat: knowledge synthesis across notes and articles (#166)

### DIFF
--- a/backend/core/ai.py
+++ b/backend/core/ai.py
@@ -205,6 +205,87 @@ Answer:"""
     return prompt
 
 
+# Character budget for synthesis context (#166).
+#
+# Synthesis pulls ~12 full documents rather than the 5 short excerpts used by
+# build_qa_prompt, so an unbounded context can blow past the model's context
+# window. Token math: local/hosted models we route to (llama3.2, qwen2.5,
+# Groq/Gemini defaults) are typically run with num_ctx in the 4096-8192 range.
+# Using the common ~4 chars/token estimate, 8192 tokens is ~32800 chars total.
+# Reserve room for the prompt template/instructions (~1000 chars) and the
+# model's own response (~2000-3000 tokens / ~10000 chars), leaving roughly
+# 20000 chars of headroom for document context. Round down for safety margin.
+SYNTHESIS_CONTEXT_CHAR_BUDGET = 18000
+
+
+def build_synthesis_prompt(
+    query: str,
+    context_documents: list[dict[str, Any]],
+    max_docs: int = 12,
+    max_context_chars: int = SYNTHESIS_CONTEXT_CHAR_BUDGET,
+) -> str:
+    """Build a deep-synthesis prompt across many documents (#166).
+
+    Unlike build_qa_prompt (short answer from a handful of excerpts), this
+    asks the model to synthesize a structured markdown summary across up to
+    `max_docs` full documents. Because whole documents (not short excerpts)
+    are included, each document is truncated to a share of
+    `max_context_chars` so the combined context stays within the model's
+    context window.
+
+    Pure function: No I/O, no side effects, deterministic.
+
+    Args:
+        query: The topic/question to synthesize knowledge about
+        context_documents: Relevant documents with 'title' and 'content'
+        max_docs: Maximum number of documents to include
+        max_context_chars: Character budget for the combined document context
+
+    Returns:
+        Complete prompt string for LLM, instructing markdown output with a
+        fixed section structure (Key Concepts / Your Positions / Gaps &
+        Open Questions) and inline citation by source title.
+    """
+    docs = context_documents[:max_docs]
+
+    if docs:
+        # Split the budget evenly across the documents actually included, so
+        # a shorter document list gets more room per document instead of
+        # always truncating to a worst-case (max_docs-sized) slice.
+        per_doc_budget = max(max_context_chars // len(docs), 200)
+        parts = []
+        for i, doc in enumerate(docs, 1):
+            title = doc.get("title", f"Document {i}")
+            content = doc.get("content", "")
+            if len(content) > per_doc_budget:
+                content = content[:per_doc_budget].rstrip() + "\n... [truncated]"
+            parts.append(f"### {title}\n{content}\n")
+        context = "\n".join(parts)
+    else:
+        context = "No relevant documents were found in the knowledge base."
+
+    return f"""You are synthesizing knowledge from a personal knowledge base to answer a broad query.
+
+Knowledge Base Documents:
+{context}
+
+Query: {query}
+
+Instructions:
+1. Write a cohesive synthesis in markdown using EXACTLY these three section headers, in this order:
+   ## Key Concepts
+   ## Your Positions
+   ## Gaps & Open Questions
+2. "Key Concepts": summarize the main ideas and themes found across the documents.
+3. "Your Positions": summarize the specific arguments, opinions, or conclusions expressed in the documents (this is the author's own knowledge base, so frame it as their thinking).
+4. "Gaps & Open Questions": call out topics related to the query that the documents do NOT cover, or where the documents are thin, contradictory, or inconclusive.
+5. Cite sources inline using the document's title in parentheses, e.g. "(Incident Response Basics)", right after the claim it supports.
+6. Do not invent information. If the knowledge base does not cover an aspect of the query, say so plainly in "Gaps & Open Questions" instead of filling the gap with general knowledge.
+7. If no documents were found at all, say so plainly and keep all three section headers with a brief note that the knowledge base has no coverage yet.
+
+Synthesis:"""
+
+
 def build_summary_prompt(content: str, content_type: str = "article") -> str:
     """Build prompt for content summarization.
 

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -24,6 +24,8 @@ from models.ai import (
     QuestionRequest,
     QuestionResponse,
     SummaryResponse,
+    SynthesisRequest,
+    SynthesisResponse,
     WarmupResponse,
 )
 from models.auth import (
@@ -86,6 +88,8 @@ __all__ = [
     "QuestionRequest",
     "QuestionResponse",
     "SummaryResponse",
+    "SynthesisRequest",
+    "SynthesisResponse",
     "WarmupResponse",
     # Auth models (passkeys)
     "AuthenticationOptionsResponse",

--- a/backend/models/ai.py
+++ b/backend/models/ai.py
@@ -18,6 +18,20 @@ class QuestionResponse(BaseModel):
     sources: list[dict[str, Any]]
 
 
+class SynthesisRequest(BaseModel):
+    """Request model for deep-synthesis (#166)."""
+
+    query: str
+
+
+class SynthesisResponse(BaseModel):
+    """Response model for deep-synthesis (#166)."""
+
+    synthesis: str  # Markdown-formatted synthesis
+    sources: list[dict[str, Any]]
+    degraded: bool = False
+
+
 class SummaryResponse(BaseModel):
     """Response model for article/note summary."""
 

--- a/backend/rate_limiter.py
+++ b/backend/rate_limiter.py
@@ -21,6 +21,7 @@ RATE_LIMITS = {
     "ai_suggest": "30/minute",  # Link/tag suggestions
     "ai_warmup": "5/minute",  # Model warmup
     "ai_stream": "20/minute",  # Streaming suggestions
+    "ai_synthesis": "5/minute",  # Deep synthesis across many documents (expensive)
     # Search endpoints
     "search": "60/minute",  # Semantic search
     # Upload endpoints

--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -20,6 +20,8 @@ from models import (
     LinkSuggestionsResponse,
     QuestionRequest,
     QuestionResponse,
+    SynthesisRequest,
+    SynthesisResponse,
     TagSuggestion,
     TagSuggestionsResponse,
     WarmupResponse,
@@ -54,6 +56,115 @@ def _get_all_resources(
 
     result: list[dict[str, Any]] = static_articles + user_resources + normalized_notes
     return result
+
+
+def _format_sources(docs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Normalize retrieved documents into the id/type/title/content/score shape
+    the frontend already renders (mirrors routers/search.py's
+    _normalize_search_result, kept separate since that helper returns a
+    SearchResult model rather than a plain dict).
+    """
+    sources = []
+    for doc in docs:
+        is_note = "note_id" in doc
+        sources.append(
+            {
+                "id": doc.get("note_id") if is_note else doc.get("id"),
+                "type": "note" if is_note else "article",
+                "title": doc.get("title", "Untitled"),
+                "content": doc.get("content", ""),
+                "score": doc.get("score", 0.0),
+            }
+        )
+    return sources
+
+
+def _retrieve_documents_for_synthesis(
+    query: str,
+    ollama: Any,
+    neo4j: Any,
+    all_resources: list[dict[str, Any]],
+    top_k: int = 12,
+) -> list[dict[str, Any]]:
+    """Retrieve up to top_k documents for deep synthesis (#166).
+
+    Mirrors the chunk -> whole-doc -> on-demand fallback ladder used by
+    /api/search's semantic mode (routers/search.py:184-286), widened to
+    top_k~12 parent docs (vs. /api/ask's top_k=5 whole-doc-only retrieval).
+
+    This is intentionally its own helper rather than a shared one with
+    search.py: the two callers need different output shapes (search.py
+    builds SearchResult models with snippets; synthesis needs raw document
+    dicts to feed into the synthesis prompt) and the pull sizes/priorities
+    differ enough that trying to unify them would just add parameters to
+    thread through. The three fallback tiers below are commented to keep
+    the duplication with search.py explicit and auditable.
+    """
+    if not ollama.embeddings_available():
+        return []
+
+    if neo4j.is_available():
+        # Tier 1: chunk-level scoring (#192) - a document ranks on its
+        # best-matching section instead of one diluted whole-document vector.
+        chunk_data = neo4j.get_all_chunk_embeddings()
+        if chunk_data:
+            query_embedding = ollama.generate_embedding(query, use_cache=False)
+            if not query_embedding:
+                logger.warning("Synthesis: failed to generate query embedding")
+                return []
+
+            ranked = ai_core.rank_parents_by_chunk_similarity(query_embedding, chunk_data, top_k)
+            docs = []
+            for item in ranked:
+                full_doc = next(
+                    (
+                        doc
+                        for doc in all_resources
+                        if (item["type"] == "Article" and str(doc.get("id")) == item["id"])
+                        or (item["type"] == "Note" and doc.get("note_id") == item["id"])
+                    ),
+                    None,
+                )
+                if full_doc:
+                    docs.append({**full_doc, "score": item["score"]})
+            if docs:
+                logger.info("Synthesis: chunk-based retrieval found %d documents", len(docs))
+                return docs
+            logger.info("Synthesis: chunk embeddings present but matched no documents")
+
+        # Tier 2: whole-document precomputed embeddings.
+        embeddings_data = neo4j.get_all_embeddings()
+        if embeddings_data:
+            documents_with_embeddings = []
+            for emb_data in embeddings_data:
+                doc_id = emb_data["id"]
+                doc_type = emb_data["type"]
+                full_doc = next(
+                    (
+                        doc
+                        for doc in all_resources
+                        if (doc_type == "Article" and str(doc.get("id")) == doc_id)
+                        or (doc_type == "Note" and doc.get("note_id") == doc_id)
+                    ),
+                    None,
+                )
+                if full_doc:
+                    documents_with_embeddings.append(
+                        {**full_doc, "embedding": emb_data["embedding"]}
+                    )
+            if documents_with_embeddings:
+                docs = ollama.semantic_search_with_precomputed_embeddings(
+                    query, documents_with_embeddings, top_k
+                )
+                if docs:
+                    logger.info("Synthesis: whole-doc retrieval found %d documents", len(docs))
+                    result: list[dict[str, Any]] = docs
+                    return result
+
+    # Tier 3: generate embeddings on-demand (slow, but works without Neo4j).
+    logger.info("Synthesis: falling back to on-demand embedding generation")
+    fallback: list[dict[str, Any]] = ollama.semantic_search(query, all_resources, top_k)
+    return fallback
 
 
 # Type aliases for cleaner signatures
@@ -605,6 +716,140 @@ def suggest_stream(
 
         # === COMPLETE ===
         yield format_sse({"type": "complete"})
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",  # Disable nginx buffering
+        },
+    )
+
+
+# Synthesis (#166): "deep synthesis" mode of /api/ask - wider retrieval
+# (chunk-ranked, top_k~12 parent docs) + a structured markdown prompt
+# instead of a short answer.
+SYNTHESIS_TOP_K = 12
+
+
+@router.post("/synthesize", response_model=SynthesisResponse)
+@limiter.limit(RATE_LIMITS["ai_synthesis"])
+def synthesize(
+    request: Request,
+    synthesis_request: SynthesisRequest,
+    ollama: OllamaDep,
+    notes_service: NotesDep,
+    neo4j: Neo4jDep,
+    static_articles: ArticlesDep,
+    user_resources: UserResourcesDep,
+) -> SynthesisResponse:
+    """Synthesize a structured markdown summary across the knowledge base (#166).
+
+    Non-streaming counterpart to /api/synthesize/stream. Uses the same
+    chunk-first retrieval ladder, widened to ~12 parent documents, and the
+    synthesis-specific prompt (Key Concepts / Your Positions / Gaps & Open
+    Questions) instead of the short-answer Q&A prompt.
+    """
+    if not ollama.is_available():
+        raise HTTPException(
+            status_code=503,
+            detail="AI synthesis feature is not available. LLM is not running or not configured.",
+        )
+
+    all_resources = _get_all_resources(static_articles, user_resources, notes_service)
+    relevant_docs = _retrieve_documents_for_synthesis(
+        synthesis_request.query, ollama, neo4j, all_resources, top_k=SYNTHESIS_TOP_K
+    )
+
+    prompt = ai_core.build_synthesis_prompt(synthesis_request.query, relevant_docs)
+    synthesis_text = ollama.generate(prompt, role="chat")
+
+    if not synthesis_text:
+        logger.warning("Synthesis: empty response from LLM")
+        return SynthesisResponse(
+            synthesis="", sources=_format_sources(relevant_docs), degraded=True
+        )
+
+    return SynthesisResponse(
+        synthesis=synthesis_text, sources=_format_sources(relevant_docs), degraded=False
+    )
+
+
+@router.post("/synthesize/stream")
+@limiter.limit(RATE_LIMITS["ai_synthesis"])
+def synthesize_stream(
+    request: Request,
+    synthesis_request: SynthesisRequest,
+    ollama: OllamaDep,
+    notes_service: NotesDep,
+    neo4j: Neo4jDep,
+    static_articles: ArticlesDep,
+    user_resources: UserResourcesDep,
+) -> StreamingResponse:
+    """Stream a deep-synthesis response via Server-Sent Events (#166).
+
+    POST (not GET) because the query plus a wide document pull won't fit a
+    querystring - so the browser can't use EventSource for this endpoint;
+    the frontend uses a fetch()-based SSE reader instead (frontend/src/lib/sse.ts).
+
+    Event types:
+    - sources: the retrieved documents, sent first so citations can render
+      before any prose arrives
+    - token: incremental text chunks of the synthesis
+    - complete: synthesis finished
+    - error: something failed; the stream ends without raising
+    """
+    # Capture dependencies for use in generator (it runs after the request
+    # handler returns, so dependencies must be captured now, not resolved lazily).
+    _ollama = ollama
+    _notes_service = notes_service
+    _neo4j = neo4j
+    _static_articles = static_articles
+    _user_resources = user_resources
+    _query = synthesis_request.query
+
+    def format_sse(data: dict[str, Any]) -> str:
+        return f"data: {json.dumps(data)}\n\n"
+
+    def event_generator() -> Generator[str]:
+        if not _ollama.is_available():
+            yield format_sse({"type": "error", "message": "AI service unavailable"})
+            return
+
+        try:
+            all_resources = _get_all_resources(_static_articles, _user_resources, _notes_service)
+            relevant_docs = _retrieve_documents_for_synthesis(
+                _query, _ollama, _neo4j, all_resources, top_k=SYNTHESIS_TOP_K
+            )
+        except Exception as e:
+            logger.error("Synthesis stream: retrieval failed: %s", e)
+            yield format_sse({"type": "error", "message": "Failed to retrieve documents"})
+            return
+
+        # Sources first, so citations render before prose arrives.
+        yield format_sse({"type": "sources", "sources": _format_sources(relevant_docs)})
+
+        prompt = ai_core.build_synthesis_prompt(_query, relevant_docs)
+
+        try:
+            token_count = 0
+            for text in _ollama.generate_stream(prompt, role="chat"):
+                token_count += 1
+                yield format_sse({"type": "token", "text": text})
+
+            if token_count == 0:
+                logger.warning("Synthesis stream: empty response from LLM")
+                yield format_sse({"type": "error", "message": "Failed to generate synthesis"})
+                return
+
+            logger.info("Synthesis stream complete (%d tokens)", token_count)
+            yield format_sse({"type": "complete"})
+
+        except Exception as e:
+            logger.error("Synthesis stream: generation failed: %s", e)
+            yield format_sse({"type": "error", "message": "Failed to generate synthesis"})
 
     return StreamingResponse(
         event_generator(),

--- a/backend/tests/unit/test_ai_api.py
+++ b/backend/tests/unit/test_ai_api.py
@@ -15,7 +15,7 @@ from typing import Any
 import pytest
 from fastapi.testclient import TestClient
 
-from dependencies import get_llm, get_notes
+from dependencies import get_llm, get_neo4j, get_notes, get_static_articles, get_user_resources
 from main import app
 
 # Mark for slow tests that hit real Ollama
@@ -342,6 +342,185 @@ class TestExtractConcepts:
             data = response.json()
             assert data["concepts"] == []
             assert data["count"] == 0
+
+
+class _SynthesisLLM:
+    """Scriptable stand-in for the routed LLM client, for synthesis tests."""
+
+    def __init__(
+        self,
+        available: bool = True,
+        generate_response: str | None = "## Key Concepts\nStuff.\n\n## Your Positions\nMore.\n\n## Gaps & Open Questions\nUnknown.",
+        stream_tokens: list[str] | None = None,
+    ) -> None:
+        self._available = available
+        self._generate_response = generate_response
+        self._stream_tokens = (
+            stream_tokens if stream_tokens is not None else ["## Key Concepts\n", "Stuff.\n"]
+        )
+
+    def is_available(self) -> bool:
+        return self._available
+
+    def embeddings_available(self) -> bool:
+        return self._available
+
+    def generate(self, prompt: str, **kwargs: Any) -> str | None:
+        return self._generate_response
+
+    def generate_stream(self, prompt: str, **kwargs: Any) -> Generator[str]:
+        yield from self._stream_tokens
+
+    def semantic_search(
+        self, query: str, documents: list[dict[str, Any]], top_k: int = 5
+    ) -> list[dict[str, Any]]:
+        results = []
+        for i, doc in enumerate(documents[:top_k]):
+            results.append({**doc, "score": 0.9 - (i * 0.1)})
+        return results
+
+
+class _UnavailableNeo4j:
+    """Stands in for the Neo4j adapter, always reporting unavailable.
+
+    This forces retrieval down to tier 3 (on-demand embedding generation via
+    ollama.semantic_search), which is enough to exercise the endpoints without
+    needing a real Neo4j instance.
+    """
+
+    def is_available(self) -> bool:
+        return False
+
+
+class _SynthesisNotesService:
+    def list_notes(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "id": "curious-elephant",
+                "title": "Incident Response Basics",
+                "content": "Runbooks matter a lot.",
+                "tags": ["sre"],
+            }
+        ]
+
+
+@contextmanager
+def _synthesis_client(
+    llm: Any, notes_service: Any | None = None
+) -> Generator[TestClient]:
+    app.dependency_overrides[get_llm] = lambda: llm
+    app.dependency_overrides[get_notes] = lambda: notes_service or _SynthesisNotesService()
+    app.dependency_overrides[get_neo4j] = lambda: _UnavailableNeo4j()
+    app.dependency_overrides[get_static_articles] = lambda: [
+        {"id": 1, "title": "SRE Practices", "content": "On-call and monitoring."}
+    ]
+    app.dependency_overrides[get_user_resources] = lambda: []
+    try:
+        with TestClient(app) as test_client:
+            yield test_client
+    finally:
+        app.dependency_overrides.clear()
+
+
+class TestSynthesize:
+    """Tests for POST /api/synthesize."""
+
+    def test_happy_path_returns_synthesis_and_sources(self) -> None:
+        with _synthesis_client(_SynthesisLLM()) as client:
+            response = client.post(
+                "/api/synthesize", json={"query": "incident response"}
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "## Key Concepts" in data["synthesis"]
+        assert data["degraded"] is False
+        assert len(data["sources"]) > 0
+        # Sources use the id/type/title/content/score shape the frontend renders.
+        source = data["sources"][0]
+        assert {"id", "type", "title", "content", "score"} <= source.keys()
+
+    def test_ai_unavailable_returns_503(self) -> None:
+        with _synthesis_client(_SynthesisLLM(available=False)) as client:
+            response = client.post(
+                "/api/synthesize", json={"query": "incident response"}
+            )
+
+        assert response.status_code == 503
+
+    def test_empty_llm_response_is_degraded(self) -> None:
+        with _synthesis_client(_SynthesisLLM(generate_response=None)) as client:
+            response = client.post(
+                "/api/synthesize", json={"query": "incident response"}
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["degraded"] is True
+        assert data["synthesis"] == ""
+
+    def test_missing_query_rejected(self) -> None:
+        with _synthesis_client(_SynthesisLLM()) as client:
+            response = client.post("/api/synthesize", json={})
+
+        assert response.status_code == 422
+
+
+class TestSynthesizeStream:
+    """Tests for POST /api/synthesize/stream."""
+
+    def _events(self, response: Any) -> list[dict[str, Any]]:
+        import json as _json
+
+        events = []
+        for line in response.text.split("\n\n"):
+            line = line.strip()
+            if line.startswith("data: "):
+                events.append(_json.loads(line[len("data: ") :]))
+        return events
+
+    def test_stream_emits_sources_before_tokens_then_completes(self) -> None:
+        with _synthesis_client(
+            _SynthesisLLM(stream_tokens=["## Key Concepts\n", "Some ", "text."])
+        ) as client:
+            response = client.post(
+                "/api/synthesize/stream", json={"query": "incident response"}
+            )
+
+        assert response.status_code == 200
+        events = self._events(response)
+        types = [e["type"] for e in events]
+
+        assert types[0] == "sources"
+        assert "token" in types
+        assert types[-1] == "complete"
+        # sources must precede every token event
+        sources_index = types.index("sources")
+        first_token_index = types.index("token")
+        assert sources_index < first_token_index
+
+    def test_stream_degrades_gracefully_when_ai_unavailable(self) -> None:
+        with _synthesis_client(_SynthesisLLM(available=False)) as client:
+            response = client.post(
+                "/api/synthesize/stream", json={"query": "incident response"}
+            )
+
+        assert response.status_code == 200
+        events = self._events(response)
+        assert events[0]["type"] == "error"
+
+    def test_stream_emits_error_on_empty_generation(self) -> None:
+        with _synthesis_client(_SynthesisLLM(stream_tokens=[])) as client:
+            response = client.post(
+                "/api/synthesize/stream", json={"query": "incident response"}
+            )
+
+        assert response.status_code == 200
+        events = self._events(response)
+        types = [e["type"] for e in events]
+        assert "sources" in types
+        assert "error" in types
+        assert "complete" not in types
 
 
 class TestMockOllamaClientUnit:

--- a/backend/tests/unit/test_core_ai.py
+++ b/backend/tests/unit/test_core_ai.py
@@ -159,6 +159,92 @@ class TestBuildQAPrompt:
         assert "don't have enough information" in prompt.lower()
 
 
+class TestBuildSynthesisPrompt:
+    """Tests for deep-synthesis prompt construction (#166)."""
+
+    def test_includes_fixed_section_structure(self):
+        """Prompt instructs the model to use the three fixed markdown headers."""
+        docs = [{"title": "Incident Response Basics", "content": "Some content about IR."}]
+
+        prompt = ai.build_synthesis_prompt("incident response", docs)
+
+        assert "## Key Concepts" in prompt
+        assert "## Your Positions" in prompt
+        assert "## Gaps & Open Questions" in prompt
+        # Order matters: Key Concepts before Positions before Gaps
+        assert prompt.index("## Key Concepts") < prompt.index("## Your Positions")
+        assert prompt.index("## Your Positions") < prompt.index("## Gaps & Open Questions")
+
+    def test_includes_query_and_document_content(self):
+        """Prompt includes the query and document titles/content."""
+        docs = [{"title": "Incident Response Basics", "content": "Runbooks matter."}]
+
+        prompt = ai.build_synthesis_prompt("incident response", docs)
+
+        assert "incident response" in prompt
+        assert "Incident Response Basics" in prompt
+        assert "Runbooks matter." in prompt
+
+    def test_instructs_markdown_and_citation_by_title(self):
+        """Prompt asks for markdown output and inline citation by title."""
+        docs = [{"title": "Doc A", "content": "Content A"}]
+
+        prompt = ai.build_synthesis_prompt("topic", docs)
+
+        assert "markdown" in prompt.lower()
+        assert "cite" in prompt.lower() or "citing" in prompt.lower()
+
+    def test_instructs_plain_gap_disclosure(self):
+        """Prompt tells the model not to invent info and to state gaps plainly."""
+        docs = [{"title": "Doc A", "content": "Content A"}]
+
+        prompt = ai.build_synthesis_prompt("topic", docs)
+
+        assert "do not invent" in prompt.lower() or "not invent" in prompt.lower()
+
+    def test_truncates_documents_to_stay_within_budget(self):
+        """Per-document content is truncated so the combined context respects
+        max_context_chars, unlike build_context_from_documents (no truncation)."""
+        # Two documents, each far larger than half the budget.
+        big_content = "x" * 10000
+        docs = [
+            {"title": "Doc A", "content": big_content},
+            {"title": "Doc B", "content": big_content},
+        ]
+
+        prompt = ai.build_synthesis_prompt("topic", docs, max_docs=12, max_context_chars=1000)
+
+        # Each doc should be truncated to roughly max_context_chars / len(docs)
+        assert "[truncated]" in prompt
+        # The full untruncated content must not appear verbatim
+        assert big_content not in prompt
+        # But some content from each document is retained
+        assert "x" in prompt
+
+    def test_respects_max_docs_limit(self):
+        """Only the first max_docs documents are included in the prompt."""
+        docs = [{"title": f"Doc {i}", "content": f"Content {i}"} for i in range(20)]
+
+        prompt = ai.build_synthesis_prompt("topic", docs, max_docs=3)
+
+        assert "Doc 0" in prompt
+        assert "Doc 1" in prompt
+        assert "Doc 2" in prompt
+        assert "Doc 3" not in prompt
+        assert "Doc 19" not in prompt
+
+    def test_empty_context_still_has_section_structure(self):
+        """With no documents, the prompt still asks for the fixed sections and
+        plainly notes the knowledge base has no coverage rather than omitting
+        structure or inventing content."""
+        prompt = ai.build_synthesis_prompt("topic with no notes", [])
+
+        assert "## Key Concepts" in prompt
+        assert "## Your Positions" in prompt
+        assert "## Gaps & Open Questions" in prompt
+        assert "no relevant documents" in prompt.lower() or "no documents" in prompt.lower()
+
+
 class TestParseJSONResponse:
     """Tests for defensive JSON parsing."""
 

--- a/frontend/src/__tests__/sse.test.ts
+++ b/frontend/src/__tests__/sse.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for the generic fetch()-based SSE reader (src/lib/sse.ts).
+ *
+ * Covers what #146 (slash commands) will also depend on: multiple events in
+ * one chunk, an event split across two chunks, [DONE]/terminal handling,
+ * and abort behavior.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { streamSSE } from "@/lib/sse";
+
+/** Build a Response whose body streams the given raw string chunks. */
+function streamingResponse(chunks: string[], init?: { ok?: boolean; status?: number }): Response {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+
+  return {
+    ok: init?.ok ?? true,
+    status: init?.status ?? 200,
+    statusText: "OK",
+    body,
+  } as unknown as Response;
+}
+
+describe("streamSSE", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("parses multiple events delivered in a single chunk", async () => {
+    const events: unknown[] = [];
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        streamingResponse([`data: {"type":"a","n":1}\n\ndata: {"type":"b","n":2}\n\n`])
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await streamSSE("/api/thing", { onEvent: (e) => events.push(e) });
+
+    expect(events).toEqual([
+      { type: "a", n: 1 },
+      { type: "b", n: 2 },
+    ]);
+  });
+
+  it("parses an event whose frame is split across two chunks", async () => {
+    const events: unknown[] = [];
+    const fetchMock = vi.fn().mockResolvedValue(
+      streamingResponse([
+        `data: {"type":"tok`, // split mid-JSON-value
+        `en","text":"hello"}\n\n`,
+      ])
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await streamSSE("/api/thing", { onEvent: (e) => events.push(e) });
+
+    expect(events).toEqual([{ type: "token", text: "hello" }]);
+  });
+
+  it("parses an event whose blank-line frame boundary is split across chunks", async () => {
+    const events: unknown[] = [];
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(streamingResponse([`data: {"type":"a"}\n`, `\ndata: {"type":"b"}\n\n`]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await streamSSE("/api/thing", { onEvent: (e) => events.push(e) });
+
+    expect(events).toEqual([{ type: "a" }, { type: "b" }]);
+  });
+
+  it("stops at a [DONE] sentinel and calls onDone without emitting it as an event", async () => {
+    const events: unknown[] = [];
+    const doneFn = vi.fn();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        streamingResponse([`data: {"type":"a"}\n\ndata: [DONE]\n\ndata: {"type":"never"}\n\n`])
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await streamSSE("/api/thing", { onEvent: (e) => events.push(e), onDone: doneFn });
+
+    expect(events).toEqual([{ type: "a" }]);
+    expect(doneFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onDone when the stream ends normally without a [DONE] sentinel", async () => {
+    const doneFn = vi.fn();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(streamingResponse([`data: {"type":"complete"}\n\n`]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await streamSSE("/api/thing", { onEvent: vi.fn(), onDone: doneFn });
+
+    expect(doneFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("flushes a final frame that has no trailing blank line", async () => {
+    const events: unknown[] = [];
+    const fetchMock = vi.fn().mockResolvedValue(streamingResponse([`data: {"type":"last"}`]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await streamSSE("/api/thing", { onEvent: (e) => events.push(e) });
+
+    expect(events).toEqual([{ type: "last" }]);
+  });
+
+  it("calls onError and skips onDone when the response is not ok", async () => {
+    const errorFn = vi.fn();
+    const doneFn = vi.fn();
+    const fetchMock = vi.fn().mockResolvedValue(streamingResponse([], { ok: false, status: 503 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await streamSSE("/api/thing", { onEvent: vi.fn(), onError: errorFn, onDone: doneFn });
+
+    expect(errorFn).toHaveBeenCalledWith(expect.any(Error));
+    expect(doneFn).not.toHaveBeenCalled();
+  });
+
+  it("does not call onError when fetch rejects due to an aborted signal", async () => {
+    const errorFn = vi.fn();
+    const controller = new AbortController();
+    const abortError = new DOMException("The operation was aborted.", "AbortError");
+    const fetchMock = vi.fn().mockRejectedValue(abortError);
+    vi.stubGlobal("fetch", fetchMock);
+    controller.abort();
+
+    await streamSSE("/api/thing", {
+      onEvent: vi.fn(),
+      onError: errorFn,
+      signal: controller.signal,
+    });
+
+    expect(errorFn).not.toHaveBeenCalled();
+  });
+
+  it("passes method, headers, body, and signal through to fetch", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(streamingResponse([]));
+    vi.stubGlobal("fetch", fetchMock);
+    const controller = new AbortController();
+
+    await streamSSE("/api/thing", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query: "x" }),
+      signal: controller.signal,
+      onEvent: vi.fn(),
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/thing", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query: "x" }),
+      signal: controller.signal,
+    });
+  });
+
+  it("defaults to POST when no method is given", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(streamingResponse([]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await streamSSE("/api/thing", { onEvent: vi.fn() });
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.method).toBe("POST");
+  });
+});

--- a/frontend/src/components/AIPanel.module.scss
+++ b/frontend/src/components/AIPanel.module.scss
@@ -682,6 +682,67 @@
   }
 }
 
+// ===== SYNTHESIS TAB (#166) =====
+
+.synthesisView {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.synthesisResults {
+  flex: 1;
+  overflow-y: auto;
+  padding: $spacing-4;
+}
+
+.synthesisOutput {
+  @include text-secondary;
+  margin-bottom: $spacing-4;
+  padding: $spacing-4;
+  border: $border-width-thin solid $neutral-200;
+  border-radius: $border-radius-md;
+  color: $neutral-800;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: monospace;
+}
+
+.synthesisStreamingCursor {
+  display: inline-block;
+  width: 0.5em;
+  height: 1em;
+  margin-left: 2px;
+  vertical-align: text-bottom;
+  background-color: $color-interactive-primary;
+  animation: pulse 1s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+.synthesisActions {
+  @include flex-start;
+  gap: $spacing-2;
+  margin-bottom: $spacing-4;
+}
+
+.saveDraftButton {
+  padding: $spacing-2 $spacing-3;
+  border-radius: $border-radius-sm;
+  @include text-tertiary;
+  font-weight: $font-weight-medium;
+  background-color: $color-interactive-primary;
+  color: $color-interactive-primary-text;
+  @include transition-default;
+
+  &:hover {
+    background-color: $color-interactive-primary-hover;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
 .suggestionReason {
   @include text-tertiary;
   line-height: 1.6;

--- a/frontend/src/components/AIPanel.tsx
+++ b/frontend/src/components/AIPanel.tsx
@@ -8,6 +8,7 @@ import {
   Warning,
   Tag,
   LinkSimple,
+  Books,
 } from "@phosphor-icons/react";
 import { logger } from "@/lib/logger";
 import type { AiMode } from "@/lib/settings";
@@ -19,13 +20,15 @@ import {
   type LinkSuggestion,
   type StreamPhase,
 } from "@/lib/aiSuggestionsStream";
+import SourceList, { type Source } from "@/components/SourceList";
+import SynthesisView from "@/components/SynthesisView";
 import styles from "./AIPanel.module.scss";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 const IS_DEVELOPMENT = process.env.NODE_ENV === "development";
 const SUGGEST_DEBOUNCE_MS = 5000; // real-time mode: refetch after typing pauses
 
-export type PanelTab = "search" | "ask" | "suggest";
+export type PanelTab = "search" | "ask" | "suggest" | "synthesize";
 
 /** Note context that enables the Suggest tab (requires a saved note) */
 export interface SuggestContext {
@@ -41,13 +44,7 @@ interface Message {
   id: string;
   role: "user" | "assistant";
   content: string;
-  sources?: Array<{
-    id: number | string;
-    type?: "article" | "note";
-    title: string;
-    content: string;
-    score?: number;
-  }>;
+  sources?: Source[];
 }
 
 interface AIPanelProps {
@@ -255,8 +252,9 @@ export default function AIPanel({ isOpen, onClose, defaultTab, suggest }: AIPane
 
   const handleTabChange = (newTab: PanelTab) => {
     setTab(newTab);
-    // Clear messages when switching between search and ask for clarity
-    if (newTab !== "suggest") {
+    // Clear messages when switching between search and ask for clarity.
+    // Suggest and Synthesize keep their own state, kept mounted below.
+    if (newTab !== "suggest" && newTab !== "synthesize") {
       setMessages([]);
     }
   };
@@ -322,6 +320,7 @@ export default function AIPanel({ isOpen, onClose, defaultTab, suggest }: AIPane
   if (!isOpen) return null;
 
   const suggestActive = tab === "suggest" && suggest !== undefined;
+  const synthesizeActive = tab === "synthesize";
 
   return (
     <div className={styles.panel}>
@@ -417,6 +416,12 @@ export default function AIPanel({ isOpen, onClose, defaultTab, suggest }: AIPane
               <Sparkle size={14} aria-hidden="true" /> Suggest
             </button>
           )}
+          <button
+            onClick={() => handleTabChange("synthesize")}
+            className={`${styles.modeButton} ${tab === "synthesize" ? styles.active : styles.inactive}`}
+          >
+            <Books size={14} aria-hidden="true" /> Synthesize
+          </button>
         </div>
       </div>
 
@@ -427,8 +432,13 @@ export default function AIPanel({ isOpen, onClose, defaultTab, suggest }: AIPane
         </div>
       )}
 
+      {/* Synthesis view - kept mounted so results survive tab switches */}
+      <div hidden={!synthesizeActive} className={styles.suggestContainer}>
+        <SynthesisView active={synthesizeActive} />
+      </div>
+
       {/* Search / Ask view */}
-      <div hidden={suggestActive} className={styles.chatContainer}>
+      <div hidden={suggestActive || synthesizeActive} className={styles.chatContainer}>
         <div className={styles.messagesContainer} style={{ WebkitOverflowScrolling: "touch" }}>
           {messages.length === 0 && (
             <div className={styles.emptyState}>
@@ -477,53 +487,7 @@ export default function AIPanel({ isOpen, onClose, defaultTab, suggest }: AIPane
                 <p className={styles.messageContent}>{message.content}</p>
 
                 {/* Sources */}
-                {message.sources && message.sources.length > 0 && (
-                  <div className={styles.sources}>
-                    {message.sources.map((source, idx) => {
-                      const resourcePath =
-                        source.type === "article"
-                          ? `/knowledge-base/articles/${source.id}`
-                          : source.type === "note"
-                            ? `/knowledge-base/notes/${source.id}`
-                            : null;
-
-                      return (
-                        <div key={`${source.id}-${idx}`} className={styles.sourceCard}>
-                          <div className={styles.sourceHeader}>
-                            <div className={styles.sourceInfo}>
-                              <span className={styles.sourceTitle}>
-                                <span className={styles.sourceType} data-type={source.type}>
-                                  {source.type === "article"
-                                    ? "ART"
-                                    : source.type === "note"
-                                      ? "NOTE"
-                                      : "REF"}
-                                </span>{" "}
-                                {source.title || `Document ${source.id}`}
-                              </span>
-                              {source.score && (
-                                <span className={styles.sourceScore}>
-                                  {source.score.toFixed(3)}
-                                </span>
-                              )}
-                            </div>
-                            {resourcePath && (
-                              <a
-                                href={resourcePath}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className={styles.sourceLink}
-                              >
-                                View →
-                              </a>
-                            )}
-                          </div>
-                          <div className={styles.sourceContent}>{source.content}</div>
-                        </div>
-                      );
-                    })}
-                  </div>
-                )}
+                {message.sources && <SourceList sources={message.sources} />}
               </div>
             </div>
           ))}

--- a/frontend/src/components/SourceList.tsx
+++ b/frontend/src/components/SourceList.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+/**
+ * Shared source-citation card list, used by both the Ask/Search message
+ * list and the Synthesis view (#166). Extracted from AIPanel.tsx so the
+ * id/type/title/content/score rendering (links to /knowledge-base/articles/
+ * or /knowledge-base/notes/) exists in exactly one place.
+ */
+
+import styles from "./AIPanel.module.scss";
+
+export interface Source {
+  id: number | string;
+  type?: "article" | "note";
+  title: string;
+  content: string;
+  score?: number;
+}
+
+export default function SourceList({ sources }: { sources: Source[] }) {
+  if (!sources || sources.length === 0) return null;
+
+  return (
+    <div className={styles.sources}>
+      {sources.map((source, idx) => {
+        const resourcePath =
+          source.type === "article"
+            ? `/knowledge-base/articles/${source.id}`
+            : source.type === "note"
+              ? `/knowledge-base/notes/${source.id}`
+              : null;
+
+        return (
+          <div key={`${source.id}-${idx}`} className={styles.sourceCard}>
+            <div className={styles.sourceHeader}>
+              <div className={styles.sourceInfo}>
+                <span className={styles.sourceTitle}>
+                  <span className={styles.sourceType} data-type={source.type}>
+                    {source.type === "article" ? "ART" : source.type === "note" ? "NOTE" : "REF"}
+                  </span>{" "}
+                  {source.title || `Document ${source.id}`}
+                </span>
+                {source.score && (
+                  <span className={styles.sourceScore}>{source.score.toFixed(3)}</span>
+                )}
+              </div>
+              {resourcePath && (
+                <a
+                  href={resourcePath}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={styles.sourceLink}
+                >
+                  View →
+                </a>
+              )}
+            </div>
+            <div className={styles.sourceContent}>{source.content}</div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/SynthesisView.tsx
+++ b/frontend/src/components/SynthesisView.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+/**
+ * Deep-synthesis tab (#166): "deep synthesis" mode of the existing /api/ask
+ * pipeline - wide retrieval across the knowledge base plus a structured
+ * markdown synthesis (Key Concepts / Your Positions / Gaps & Open Questions).
+ *
+ * Mirrors the structure of SuggestView (AIPanel.tsx): a self-contained view
+ * that stays mounted while the panel is open so results survive tab
+ * switches, with its own loading/error/streaming state.
+ */
+
+import { useState, useRef, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { Warning } from "@phosphor-icons/react";
+import { logger } from "@/lib/logger";
+import { streamSSE } from "@/lib/sse";
+import { saveDraft } from "@/lib/draft";
+import SourceList, { type Source } from "@/components/SourceList";
+import styles from "./AIPanel.module.scss";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+const REQUEST_TIMEOUT_MS = 120000; // CPU inference can be slow, same budget as Ask
+
+type SynthesisEvent =
+  | { type: "sources"; sources: Source[] }
+  | { type: "token"; text: string }
+  | { type: "complete" }
+  | { type: "error"; message?: string };
+
+interface SynthesisViewProps {
+  active: boolean;
+}
+
+export default function SynthesisView({ active }: SynthesisViewProps) {
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+  const [submittedQuery, setSubmittedQuery] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [synthesis, setSynthesis] = useState("");
+  const [sources, setSources] = useState<Source[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [unavailable, setUnavailable] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const runNonStreaming = useCallback(async (submittedQueryValue: string) => {
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+      const response = await fetch(`${API_URL}/api/synthesize`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ query: submittedQueryValue }),
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+
+      if (response.status === 503) {
+        setUnavailable(true);
+        setLoading(false);
+        return;
+      }
+      if (!response.ok) {
+        throw new Error(`Request failed: ${response.statusText}`);
+      }
+
+      const data = await response.json();
+      setSources(data.sources || []);
+      if (data.degraded || !data.synthesis) {
+        setError("The AI didn't return a synthesis. Try a different query, or try again.");
+      } else {
+        setSynthesis(data.synthesis);
+      }
+    } catch (err) {
+      logger.error("Synthesis (non-streaming) failed", err);
+      setError(err instanceof Error ? err.message : "Failed to generate synthesis.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const performSynthesis = useCallback(
+    async (trimmed: string) => {
+      if (!trimmed || loading) return;
+
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      setSubmittedQuery(trimmed);
+      setLoading(true);
+      setError(null);
+      setUnavailable(false);
+      setSaved(false);
+      setSynthesis("");
+      setSources([]);
+
+      // EventSource can't do POST, so this always goes through the fetch-based
+      // reader. If streaming itself is unusable in this environment, or the
+      // stream fails outright, fall back to the non-streaming endpoint.
+      if (typeof ReadableStream === "undefined") {
+        await runNonStreaming(trimmed);
+        return;
+      }
+
+      let streamedAnyToken = false;
+      let sawError = false;
+
+      await streamSSE<SynthesisEvent>(`${API_URL}/api/synthesize/stream`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ query: trimmed }),
+        signal: controller.signal,
+        onEvent: (event) => {
+          switch (event.type) {
+            case "sources":
+              setSources(event.sources || []);
+              break;
+            case "token":
+              streamedAnyToken = true;
+              setSynthesis((prev) => prev + event.text);
+              break;
+            case "complete":
+              setLoading(false);
+              break;
+            case "error":
+              sawError = true;
+              logger.warn("Synthesis stream reported an error", { message: event.message });
+              break;
+          }
+        },
+        onError: (err) => {
+          sawError = true;
+          logger.warn("Synthesis stream transport error, falling back", err);
+        },
+        onDone: () => {
+          setLoading(false);
+        },
+      });
+
+      // Degrade gracefully: a stream that errored (transport or application)
+      // without producing any prose falls back to the non-streaming endpoint,
+      // which may succeed independently (e.g. a mid-stream generation hiccup).
+      if (sawError && !streamedAnyToken) {
+        setSynthesis("");
+        setLoading(true);
+        await runNonStreaming(trimmed);
+      }
+    },
+    [loading, runNonStreaming]
+  );
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      void performSynthesis(query.trim());
+    },
+    [query, performSynthesis]
+  );
+
+  const handleRetry = useCallback(() => {
+    void performSynthesis(submittedQuery);
+  }, [performSynthesis, submittedQuery]);
+
+  const handleSaveDraft = useCallback(() => {
+    if (!synthesis) return;
+    saveDraft({
+      title: `Synthesis: ${submittedQuery}`,
+      content: synthesis,
+      tags: "synthesis",
+      isReference: false,
+    });
+    setSaved(true);
+    logger.info("Synthesis saved as note draft", { query: submittedQuery });
+    router.push("/knowledge-base/notes/new");
+  }, [synthesis, submittedQuery, router]);
+
+  const hasResult = synthesis.length > 0 || sources.length > 0;
+
+  return (
+    <div className={styles.synthesisView}>
+      <div className={styles.synthesisResults}>
+        {!active ? null : !hasResult && !loading && !error && !unavailable ? (
+          <div className={styles.emptyState}>
+            <p className={styles.emptyTitle}>Deep Synthesis</p>
+            <p className={styles.emptyDescription}>
+              Ask a broad question like &quot;Synthesize everything I know about incident
+              response.&quot; I&apos;ll pull from up to 12 notes and articles and produce a
+              structured summary with key concepts, your positions, and gaps in your knowledge base
+              - with citations.
+            </p>
+          </div>
+        ) : null}
+
+        {unavailable && (
+          <div className={styles.errorBanner}>
+            AI synthesis is not available. The LLM is not running or not configured.
+          </div>
+        )}
+
+        {error && !unavailable && (
+          <div className={styles.errorBanner}>
+            {error}
+            <button onClick={handleRetry} className={styles.retryButton}>
+              Retry
+            </button>
+          </div>
+        )}
+
+        {loading && !synthesis && (
+          <div className={styles.streamingProgress}>
+            <div className={styles.suggestLoadingContent}>
+              <div className={styles.spinner}></div>
+              <div className={styles.progressText}>
+                <span className={styles.progressStatus}>
+                  Gathering sources and generating synthesis...
+                </span>
+                {sources.length > 0 && (
+                  <span className={styles.progressCounts}>
+                    {sources.length} source{sources.length !== 1 ? "s" : ""} found
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {synthesis && (
+          <>
+            <div className={styles.synthesisOutput}>
+              {synthesis}
+              {loading && <span className={styles.synthesisStreamingCursor} />}
+            </div>
+
+            {!loading && (
+              <div className={styles.synthesisActions}>
+                <button
+                  onClick={handleSaveDraft}
+                  className={styles.saveDraftButton}
+                  disabled={saved}
+                >
+                  {saved ? "Saved as draft ✓" : "Save as note draft"}
+                </button>
+              </div>
+            )}
+          </>
+        )}
+
+        {sources.length > 0 && <SourceList sources={sources} />}
+
+        {loading && (
+          <div className={styles.performanceNotice}>
+            <p className={styles.noticeTitle}>
+              <Warning size={14} aria-hidden="true" /> This can take a while
+            </p>
+            <p className={styles.noticeDescription}>
+              Synthesis pulls from many documents and can take 30-120+ seconds, especially on
+              CPU-only infrastructure.
+            </p>
+          </div>
+        )}
+      </div>
+
+      <div className={styles.inputArea}>
+        <form onSubmit={handleSubmit} className={styles.inputForm}>
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Synthesize everything I know about..."
+            className={styles.input}
+            disabled={loading}
+          />
+          <button type="submit" disabled={loading || !query.trim()} className={styles.submitButton}>
+            {loading ? "..." : "Synthesize"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/sse.ts
+++ b/frontend/src/lib/sse.ts
@@ -1,0 +1,136 @@
+/**
+ * Generic fetch()-based Server-Sent Events (SSE) reader.
+ *
+ * `EventSource` cannot send a POST body or custom headers, which rules it
+ * out for endpoints that need a request body (e.g. a long query/prompt that
+ * won't fit a querystring - see /api/synthesize/stream, #166). This module
+ * reads an SSE stream from any `fetch()` response body instead: it parses
+ * `data: ...\n\n` frames out of the raw byte stream, tolerating frames that
+ * are split across chunk boundaries, and JSON-decodes each frame's payload.
+ *
+ * Kept intentionally small and generic (no synthesis-specific types) so a
+ * later caller (#146, slash commands) can reuse it verbatim for a different
+ * event shape - just pass a different `T`.
+ */
+
+import { logger } from "@/lib/logger";
+
+const sseLogger = logger.withContext("SSE");
+
+/** Sentinel some SSE producers send to mark the end of a stream. */
+const DONE_SENTINEL = "[DONE]";
+
+export interface StreamSSEOptions<T> {
+  /** HTTP method; defaults to "POST" since that's the reason this exists. */
+  method?: string;
+  headers?: Record<string, string>;
+  body?: BodyInit;
+  signal?: AbortSignal;
+  /** Called once per parsed event, in stream order. */
+  onEvent: (event: T) => void;
+  /** Called on a request/parse/stream failure. Not called on intentional abort. */
+  onError?: (error: Error) => void;
+  /** Called once the stream ends normally (server closed the connection, or [DONE] seen). */
+  onDone?: () => void;
+}
+
+/**
+ * Extract the `data:` payload from one SSE frame (the text between two
+ * `\n\n` boundaries). Per the SSE spec, a frame may have multiple `data:`
+ * lines, which are joined with `\n`. Lines that aren't `data:` (e.g. `event:`,
+ * `id:`, comments starting with `:`) are ignored - this reader only needs
+ * the data payload, matching what the backend's `format_sse` emits.
+ */
+function extractData(frame: string): string | null {
+  const dataLines = frame
+    .split("\n")
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice("data:".length).replace(/^ /, ""));
+
+  if (dataLines.length === 0) {
+    return null;
+  }
+  return dataLines.join("\n");
+}
+
+/**
+ * Stream Server-Sent Events from a `fetch()` request (typically POST).
+ *
+ * Resolves once the stream ends (normally, via [DONE], or via abort);
+ * rejects only in unexpected caller-error situations (it otherwise routes
+ * failures through `onError` so callers can degrade gracefully rather than
+ * needing a try/catch around every call site).
+ */
+export async function streamSSE<T = unknown>(
+  url: string,
+  options: StreamSSEOptions<T>
+): Promise<void> {
+  const { method = "POST", headers, body, signal, onEvent, onError, onDone } = options;
+
+  let response: Response;
+  try {
+    response = await fetch(url, { method, headers, body, signal });
+  } catch (err) {
+    if (signal?.aborted) return;
+    onError?.(err instanceof Error ? err : new Error(String(err)));
+    return;
+  }
+
+  if (!response.ok || !response.body) {
+    onError?.(new Error(`SSE request failed: ${response.status} ${response.statusText}`));
+    return;
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  const handleFrame = (frame: string): boolean => {
+    // Returns false if this frame signals stream termination.
+    const data = extractData(frame);
+    if (data === null) return true;
+    if (data === DONE_SENTINEL) return false;
+
+    try {
+      onEvent(JSON.parse(data) as T);
+    } catch (err) {
+      sseLogger.warn("Failed to parse SSE event payload", { data, error: err });
+    }
+    return true;
+  };
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+
+      // Frames are separated by a blank line. The last (possibly partial)
+      // frame is kept in the buffer for the next chunk - this is what
+      // handles an event split across two chunk boundaries.
+      const frames = buffer.split("\n\n");
+      buffer = frames.pop() ?? "";
+
+      for (const frame of frames) {
+        if (!handleFrame(frame)) {
+          onDone?.();
+          return;
+        }
+      }
+    }
+
+    // Flush a final frame if the stream ended without a trailing blank line.
+    if (buffer.trim()) {
+      handleFrame(buffer);
+    }
+
+    onDone?.();
+  } catch (err) {
+    if (signal?.aborted) {
+      onDone?.();
+      return;
+    }
+    onError?.(err instanceof Error ? err : new Error(String(err)));
+  }
+}


### PR DESCRIPTION
Fixes #166.

Built as a **deep-synthesis mode of the existing `/api/ask` pipeline**, per the scoping comment on the issue — wider retrieval, a synthesis-specific prompt, streaming, and save-as-draft. Not a new subsystem. The "evolution of thinking over time" bullet is dropped here; #163 owns it.

## Backend

- **`core/ai.py` — `build_synthesis_prompt()`** (pure). Emits markdown with fixed sections (`## Key Concepts`, `## Your Positions`, `## Gaps & Open Questions`), cites sources inline by title, and is instructed to say when the knowledge base doesn't cover something rather than invent. Unlike `build_context_from_documents`, it enforces a character budget (`SYNTHESIS_CONTEXT_CHAR_BUDGET = 18000`, token math in a comment) because synthesis pulls ~12 full documents.
- **Retrieval.** `/api/ask` only ever used whole-document embeddings at `top_k=5`; the better chunk-based path (`get_all_chunk_embeddings()` + `rank_parents_by_chunk_similarity`, #192) lived only in `search.py`. Synthesis uses the chunk path at `top_k=12` with the same fallback ladder (chunk → whole-doc → on-demand). `_retrieve_documents_for_synthesis` is shared by both new endpoints but deliberately not unified with `search.py`'s version — different output shapes (raw dicts vs. `SearchResult` models); noted in code.
- **Endpoints.** `POST /api/synthesize` (non-streaming) and `POST /api/synthesize/stream` (SSE over POST). Events: `sources` first so citations render before prose, then `token` deltas, then `complete`; failures emit `error` and return rather than raising out of the generator. New rate limit `ai_synthesis: 5/minute` — synthesis is far more expensive than `/api/ask`, so it does not reuse that preset. Both sit on `ai_router`, already gated behind the `llm_features` flag.

## Frontend

- **`lib/sse.ts` (new).** `EventSource` can't POST or send headers, and the query plus prompt won't fit a querystring — so this is a `fetch` + `ReadableStream` SSE reader that tolerates frames split across chunk boundaries. Kept generic on purpose: #146 reuses it verbatim.
- **`SynthesisView.tsx` (new).** Fourth panel tab. `AIPanel.tsx` was already 949 lines, so the view lives in its own file mirroring `SuggestView`. Citation markup was extracted to a shared `SourceList.tsx` so Ask and Synthesize use one implementation rather than two.
- **Save as note draft** hands off through the existing `lib/draft.ts` localStorage draft, which `/knowledge-base/notes/new` already auto-restores on mount. Not URL params — a multi-KB synthesis blows past safe URL length. Zero changes to the notes/new page, and no backend draft concept was invented.
- Falls back to the non-streaming endpoint on transport failure; shows the panel's usual unavailable messaging rather than crashing.

## Testing

Backend: 7 unit tests for the prompt builder (section structure, truncation at budget, empty context) plus integration tests for both endpoints (happy path, 503 degradation, empty-response degradation, SSE ordering). Frontend: 10 Vitest tests for `sse.ts` — multi-event frames, an event split across two chunks, `[DONE]`, abort. Worth the investment since #146 depends on it.

Full suite: backend 581 passed, frontend 113 passed, lint + typecheck clean.

**Runtime verification against the live stack:** `POST /api/synthesize` returned a real 3.7KB synthesis with all three sections and 12 sources from Groq. The stream was verified end-to-end (`sources` → 506 `token` events → `complete`). Separately, a run where Groq 429'd and Gemini returned empty confirmed the degraded path: `sources` then `error`, no spurious `complete` — the known provider flakiness from #260/#263.

https://claude.ai/code/session_01KTENwGZUekeEwCZt2vKA4z