### PR TITLE
feat: context-aware writing partner — #146 Phase 2

### DIFF
--- a/backend/core/ai.py
+++ b/backend/core/ai.py
@@ -301,8 +301,15 @@ EDITOR_CONTEXT_CHAR_BUDGET = 4000
 # deliberately excluded here and rejected by this function.
 EDITOR_TRANSFORM_COMMANDS = ("expand", "simplify", "summarize", "continue", "rephrase")
 
-# All commands the editor-assist endpoints accept, including "link".
-EDITOR_COMMANDS = (*EDITOR_TRANSFORM_COMMANDS, "link")
+# Context-aware "writing partner" commands (#146 Phase 2), handled by
+# build_writing_partner_prompt. Unlike the transforms above, these never
+# replace document text - they return advisory markdown commentary plus the
+# notes it drew on, backed by the same RAG retrieval ladder synthesis uses.
+EDITOR_PARTNER_COMMANDS = ("challenge", "gaps", "contradictions")
+
+# All commands the editor-assist endpoints accept: transforms, "link", and
+# the writing-partner commands.
+EDITOR_COMMANDS = (*EDITOR_TRANSFORM_COMMANDS, "link", *EDITOR_PARTNER_COMMANDS)
 
 _EDITOR_COMMAND_INSTRUCTIONS: dict[str, str] = {
     "expand": (
@@ -395,6 +402,129 @@ def build_editor_command_prompt(
         )
 
     return instruction
+
+
+# Character budget for the writing-partner commands (#146 Phase 2).
+#
+# Unlike EDITOR_CONTEXT_CHAR_BUDGET (a single note's own content, included
+# only for voice/tone), these commands carry multiple *retrieved* documents
+# from other notes/articles that the model must actually reason over and cite
+# - closer in shape to SYNTHESIS_CONTEXT_CHAR_BUDGET's "many full documents"
+# case than to a single-note budget. But the retrieval here is narrower
+# (top_k~6, see routers/ai.py) and focused on one passage rather than a
+# corpus-wide query, so the combined document context is smaller too. Using
+# the same ~4 chars/token estimate as SYNTHESIS_CONTEXT_CHAR_BUDGET, this
+# reserves room for the instructions + the passage under review + the
+# retrieved documents + the model's own commentary, while staying well under
+# an 8192-token context window.
+WRITING_PARTNER_CONTEXT_CHAR_BUDGET = 12000
+
+_WRITING_PARTNER_INSTRUCTIONS: dict[str, str] = {
+    "challenge": (
+        "Play devil's advocate against the following text. Argue the "
+        "strongest case against its claims - be specific to what it "
+        "actually argues, not generically contrarian. Where the retrieved "
+        "notes below support a counter-argument, cite them by title. Where "
+        "they don't, say plainly that the pushback is not grounded in the "
+        "knowledge base and is your own critical reasoning instead."
+    ),
+    "gaps": (
+        "Identify gaps in the reasoning of the following text: what it "
+        "omits, what it assumes without support, and what it leaves "
+        "unresolved. Where the retrieved notes below fill in a gap or "
+        "surface a missing consideration, cite them by title. Where the "
+        "knowledge base has nothing on a gap you raise, say so plainly "
+        "rather than inventing a source for it."
+    ),
+    "contradictions": (
+        "Check the following text against the retrieved notes below for "
+        "contradictions. For each conflict you find, name or quote the "
+        "conflicting note and explain the disagreement. If you find no "
+        "contradictions, say so plainly instead of inventing one - do not "
+        "strain to manufacture a conflict where the notes simply agree or "
+        "are silent on the point."
+    ),
+}
+
+
+def build_writing_partner_prompt(
+    command: str,
+    text: str,
+    note_title: str | None,
+    context_documents: list[dict[str, Any]],
+    max_context_chars: int = WRITING_PARTNER_CONTEXT_CHAR_BUDGET,
+) -> str:
+    """Build a prompt for a RAG-backed writing-partner command (#146 Phase 2).
+
+    Covers the three advisory commands (challenge, gaps, contradictions).
+    These are never text transforms: the model's output is commentary about
+    `text`, not replacement text, and the caller must not use the result to
+    overwrite document content.
+
+    Pure function: No I/O, no side effects, deterministic.
+
+    Args:
+        command: One of EDITOR_PARTNER_COMMANDS
+        text: The passage being reviewed (selection, or the whole note)
+        note_title: Title of the note being edited, for context
+        context_documents: Retrieved notes/articles to check against, each
+            with 'title' and 'content' - already retrieved by the caller
+            (reuse the existing RAG retrieval ladder, do not fetch here)
+        max_context_chars: Character budget for the combined retrieved
+            document context; split evenly across documents actually
+            included, each truncated to its share
+
+    Returns:
+        Complete prompt string for LLM, instructing markdown prose output
+        (no fences, no preamble) that cites retrieved notes by title and
+        says plainly when the knowledge base doesn't support a point.
+
+    Raises:
+        ValueError: If command is not a recognized writing-partner command
+    """
+    if command not in EDITOR_PARTNER_COMMANDS:
+        raise ValueError(
+            f"Unknown writing-partner command: {command!r}. "
+            f"Must be one of {EDITOR_PARTNER_COMMANDS}"
+        )
+
+    instruction = _WRITING_PARTNER_INSTRUCTIONS[command]
+
+    if context_documents:
+        # Split the budget evenly across the documents actually included, so
+        # a shorter retrieval result gets more room per document instead of
+        # always truncating to a worst-case slice (mirrors
+        # build_synthesis_prompt's per-document truncation).
+        per_doc_budget = max(max_context_chars // len(context_documents), 200)
+        parts = []
+        for i, doc in enumerate(context_documents, 1):
+            title = doc.get("title", f"Document {i}")
+            content = doc.get("content", "")
+            if len(content) > per_doc_budget:
+                content = content[:per_doc_budget].rstrip() + "\n... [truncated]"
+            parts.append(f"### {title}\n{content}\n")
+        context = "\n".join(parts)
+    else:
+        context = "No related notes were found in the knowledge base."
+
+    title_line = f"Note title: {note_title}\n\n" if note_title else ""
+
+    return f"""You are a critical writing partner helping refine a personal knowledge-base note. {instruction}
+
+{title_line}Text under review:
+{text}
+
+Retrieved notes from the knowledge base (for grounding, not as the subject of the review):
+{context}
+
+Instructions:
+1. Write your response as markdown prose - no code fences, no JSON, no preamble like "Here is my analysis:".
+2. Cite retrieved notes by title, e.g. "(Incident Response Basics)", right after the claim they support.
+3. Ground every substantive claim in either the text under review or a cited retrieved note.
+4. If the knowledge base does not support a point you want to make, say so plainly instead of inventing a citation.
+5. Keep it focused and specific to the text under review - do not summarize the retrieved notes for their own sake.
+
+Response:"""
 
 
 def build_summary_prompt(content: str, content_type: str = "article") -> str:

--- a/backend/models/ai.py
+++ b/backend/models/ai.py
@@ -43,15 +43,22 @@ class EditorAssistRequest(BaseModel):
 
 
 class EditorAssistResponse(BaseModel):
-    """Non-streaming response model for editor slash commands (#146 Phase 1).
+    """Non-streaming response model for editor slash commands (#146).
 
     Text-transform commands (expand/simplify/summarize/continue/rephrase)
-    populate `result`; `/link` populates `suggestions` instead.
+    populate `result`; `/link` populates `suggestions` instead. Writing-
+    partner commands (challenge/gaps/contradictions, Phase 2) populate both
+    `result` (markdown commentary) and `sources` (the retrieved notes it
+    drew on, in the id/type/title/content/score shape SourceList.tsx
+    renders) - `suggestions` stays unused for these. `sources` is optional
+    and defaults to None so Phase 1 clients parsing this response are
+    unaffected.
     """
 
     command: str
     result: str | None = None
     suggestions: list[dict[str, Any]] | None = None
+    sources: list[dict[str, Any]] | None = None
     degraded: bool = False
 
 

--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -243,6 +243,42 @@ def _parse_link_command_response(
     return suggestions[:5]
 
 
+# Editor writing-partner commands (#146 Phase 2): narrower retrieval than
+# synthesis's top_k=12 - this is focused critique of one passage (the text
+# under review in the editor), not a corpus-wide summary, so a handful of the
+# most relevant notes is plenty and keeps the prompt small/fast to generate.
+# Fetch one extra so excluding the current note (see below) still leaves up
+# to WRITING_PARTNER_TOP_K results rather than quietly shrinking the pull.
+WRITING_PARTNER_TOP_K = 6
+
+
+def _retrieve_for_writing_partner(
+    text: str,
+    note_title: str | None,
+    note_id: str | None,
+    ollama: Any,
+    neo4j: Any,
+    all_resources: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Retrieve context documents for a writing-partner command (#146 Phase 2).
+
+    Reuses _retrieve_documents_for_synthesis (the same chunk -> whole-doc ->
+    on-demand retrieval ladder /api/synthesize uses) rather than writing a
+    third copy. The query is the note title plus the text under review, so
+    retrieval is anchored to what's actually being critiqued.
+
+    Excludes the current note from its own results when note_id is known -
+    a note "contradicting itself" is just noise, not a finding.
+    """
+    query = f"{note_title}\n\n{text}" if note_title else text
+    docs = _retrieve_documents_for_synthesis(
+        query, ollama, neo4j, all_resources, top_k=WRITING_PARTNER_TOP_K + (1 if note_id else 0)
+    )
+    if note_id:
+        docs = [d for d in docs if d.get("note_id") != note_id]
+    return docs[:WRITING_PARTNER_TOP_K]
+
+
 # Type aliases for cleaner signatures
 OllamaDep = Annotated[Any, Depends(get_llm)]
 NotesDep = Annotated[Any, Depends(get_notes)]
@@ -952,11 +988,16 @@ def editor_assist(
     assist_request: EditorAssistRequest,
     ollama: OllamaDep,
     notes_service: NotesDep,
+    neo4j: Neo4jDep,
+    static_articles: ArticlesDep,
+    user_resources: UserResourcesDep,
     _admin: AdminUser,
 ) -> EditorAssistResponse:
     """Non-streaming counterpart to /api/editor/assist/stream, for fallback.
 
-    Text-transform commands return `result`; `/link` returns `suggestions`.
+    Text-transform commands return `result`; `/link` returns `suggestions`;
+    writing-partner commands (challenge/gaps/contradictions, Phase 2) return
+    both `result` (markdown commentary) and `sources` (the notes it drew on).
     """
     command = assist_request.command
 
@@ -987,6 +1028,47 @@ def editor_assist(
         suggestions = _parse_link_command_response(response_text, candidate_notes)
         return EditorAssistResponse(command=command, suggestions=suggestions)
 
+    if command in ai_core.EDITOR_PARTNER_COMMANDS:
+        all_resources = _get_all_resources(static_articles, user_resources, notes_service)
+        relevant_docs = _retrieve_for_writing_partner(
+            assist_request.text,
+            assist_request.note_title,
+            assist_request.note_id,
+            ollama,
+            neo4j,
+            all_resources,
+        )
+
+        if not relevant_docs:
+            # Never call the LLM with an empty context - a clean, honest
+            # "nothing to check against" beats a hallucinated critique.
+            return EditorAssistResponse(
+                command=command,
+                result=(
+                    "There's nothing in the knowledge base yet to check this "
+                    "against."
+                ),
+                sources=[],
+                degraded=True,
+            )
+
+        prompt = ai_core.build_writing_partner_prompt(
+            command, assist_request.text, assist_request.note_title, relevant_docs
+        )
+        result = ollama.generate(prompt, role="chat")
+        if not result:
+            logger.error("Empty response from LLM for writing-partner command %s", command)
+            return EditorAssistResponse(
+                command=command, result="", sources=_format_sources(relevant_docs), degraded=True
+            )
+
+        return EditorAssistResponse(
+            command=command,
+            result=result,
+            sources=_format_sources(relevant_docs),
+            degraded=False,
+        )
+
     try:
         prompt = ai_core.build_editor_command_prompt(
             command, assist_request.text, assist_request.note_title, assist_request.note_content
@@ -1009,6 +1091,9 @@ def editor_assist_stream(
     assist_request: EditorAssistRequest,
     ollama: OllamaDep,
     notes_service: NotesDep,
+    neo4j: Neo4jDep,
+    static_articles: ArticlesDep,
+    user_resources: UserResourcesDep,
     _admin: AdminUser,
 ) -> StreamingResponse:
     """Stream an editor slash-command result via Server-Sent Events (#146).
@@ -1018,7 +1103,10 @@ def editor_assist_stream(
     frontend uses the fetch()-based reader in frontend/src/lib/sse.ts.
 
     Event types:
-    - token: incremental text chunk (text-transform commands only)
+    - sources: retrieved notes (writing-partner commands only), sent before
+      any token so citations can render before prose arrives
+    - token: incremental text chunk (text-transform and writing-partner
+      commands)
     - link: one link suggestion ({note_id, title, reason, confidence}) (`/link` only)
     - complete: command finished
     - error: something failed; the stream ends without raising
@@ -1028,6 +1116,9 @@ def editor_assist_stream(
     """
     _ollama = ollama
     _notes_service = notes_service
+    _neo4j = neo4j
+    _static_articles = static_articles
+    _user_resources = user_resources
     _command = assist_request.command
     _text = assist_request.text
     _title = assist_request.note_title
@@ -1081,6 +1172,73 @@ def editor_assist_stream(
             except Exception as e:
                 logger.error("Editor /link stream: generation failed: %s", e)
                 yield format_sse({"type": "error", "message": "Failed to generate link suggestions"})
+
+            return
+
+        if _command in ai_core.EDITOR_PARTNER_COMMANDS:
+            try:
+                all_resources = _get_all_resources(
+                    _static_articles, _user_resources, _notes_service
+                )
+                relevant_docs = _retrieve_for_writing_partner(
+                    _text, _title, _note_id, _ollama, _neo4j, all_resources
+                )
+            except Exception as e:
+                logger.error(
+                    "Editor writing-partner stream: retrieval failed (%s): %s", _command, e
+                )
+                yield format_sse({"type": "error", "message": "Failed to retrieve context"})
+                return
+
+            # Sources first, so citations render before prose arrives.
+            yield format_sse({"type": "sources", "sources": _format_sources(relevant_docs)})
+
+            if not relevant_docs:
+                # Never call the LLM with an empty context - a clean, honest
+                # "nothing to check against" beats a hallucinated critique.
+                yield format_sse(
+                    {
+                        "type": "token",
+                        "text": (
+                            "There's nothing in the knowledge base yet to check "
+                            "this against."
+                        ),
+                    }
+                )
+                yield format_sse({"type": "complete", "degraded": True})
+                return
+
+            try:
+                prompt = ai_core.build_writing_partner_prompt(
+                    _command, _text, _title, relevant_docs
+                )
+            except ValueError as e:
+                yield format_sse({"type": "error", "message": str(e)})
+                return
+
+            try:
+                token_count = 0
+                for chunk in _ollama.generate_stream(prompt, role="chat"):
+                    token_count += 1
+                    yield format_sse({"type": "token", "text": chunk})
+
+                if token_count == 0:
+                    logger.warning(
+                        "Writing-partner stream: empty response from LLM (%s)", _command
+                    )
+                    yield format_sse({"type": "error", "message": "Failed to generate response"})
+                    return
+
+                logger.info(
+                    "Writing-partner stream complete: %s (%d tokens)", _command, token_count
+                )
+                yield format_sse({"type": "complete"})
+
+            except Exception as e:
+                logger.error(
+                    "Writing-partner stream: generation failed (%s): %s", _command, e
+                )
+                yield format_sse({"type": "error", "message": "Failed to generate response"})
 
             return
 

--- a/backend/tests/unit/test_ai_api.py
+++ b/backend/tests/unit/test_ai_api.py
@@ -531,21 +531,34 @@ class _EditorLLM:
         available: bool = True,
         generate_response: str | None = "Expanded version of the text.",
         stream_tokens: list[str] | None = None,
+        embeddings_available: bool = True,
     ) -> None:
         self._available = available
         self._generate_response = generate_response
         self._stream_tokens = (
             stream_tokens if stream_tokens is not None else ["Expanded ", "text."]
         )
+        self._embeddings_available = embeddings_available
 
     def is_available(self) -> bool:
         return self._available
+
+    def embeddings_available(self) -> bool:
+        return self._embeddings_available
 
     def generate(self, prompt: str, **kwargs: Any) -> str | None:
         return self._generate_response
 
     def generate_stream(self, prompt: str, **kwargs: Any) -> Generator[str]:
         yield from self._stream_tokens
+
+    def semantic_search(
+        self, query: str, documents: list[dict[str, Any]], top_k: int = 5
+    ) -> list[dict[str, Any]]:
+        results = []
+        for i, doc in enumerate(documents[:top_k]):
+            results.append({**doc, "score": 0.9 - (i * 0.1)})
+        return results
 
 
 class _EditorNotesService:
@@ -577,6 +590,14 @@ class _EditorNotesService:
 def _editor_client(llm: Any, notes_service: Any | None = None) -> Generator[TestClient]:
     app.dependency_overrides[get_llm] = lambda: llm
     app.dependency_overrides[get_notes] = lambda: notes_service or _EditorNotesService()
+    # Writing-partner commands (#146 Phase 2) also depend on neo4j/static
+    # articles/user resources for retrieval. _UnavailableNeo4j forces the
+    # retrieval ladder down to tier 3 (on-demand embeddings via
+    # llm.semantic_search), same as _synthesis_client, so these tests don't
+    # need a real Neo4j instance.
+    app.dependency_overrides[get_neo4j] = lambda: _UnavailableNeo4j()
+    app.dependency_overrides[get_static_articles] = lambda: []
+    app.dependency_overrides[get_user_resources] = lambda: []
     try:
         with TestClient(app) as test_client:
             yield test_client
@@ -752,6 +773,329 @@ class TestEditorAssistStream:
         types = [e["type"] for e in events]
         assert "error" in types
         assert "complete" not in types
+
+
+class _PartnerNotesService:
+    """Stand-in notes service for writing-partner tests: two other notes plus
+    the note currently being edited (curious-elephant), so tests can assert
+    the current note is excluded from its own retrieval results."""
+
+    def list_notes(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "id": "curious-elephant",
+                "title": "Current Note",
+                "content": "This is the note being edited right now.",
+                "tags": [],
+                "links": [],
+            },
+            {
+                "id": "wise-mountain",
+                "title": "Blameless Postmortems",
+                "content": "Focus on systems, not people.",
+                "tags": ["sre"],
+                "links": [],
+            },
+            {
+                "id": "brave-otter",
+                "title": "Incident Response Basics",
+                "content": "Runbooks matter a lot.",
+                "tags": ["sre"],
+                "links": [],
+            },
+        ]
+
+    def get_note(self, note_id: str) -> dict[str, Any] | None:
+        return next((n for n in self.list_notes() if n["id"] == note_id), None)
+
+
+class TestEditorAssistWritingPartner:
+    """Tests for the challenge/gaps/contradictions commands on POST /api/editor/assist (#146 Phase 2)."""
+
+    @pytest.mark.parametrize("command", ["challenge", "gaps", "contradictions"])
+    def test_happy_path_returns_result_and_sources(
+        self, command: str, admin_headers: dict[str, str]
+    ) -> None:
+        with _editor_client(
+            _EditorLLM(generate_response="This is my critique. (Blameless Postmortems)"),
+            notes_service=_PartnerNotesService(),
+        ) as client:
+            response = client.post(
+                "/api/editor/assist",
+                json={
+                    "command": command,
+                    "text": "Postmortems should always assign blame.",
+                    "note_title": "My Draft",
+                    "note_id": "curious-elephant",
+                },
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["command"] == command
+        assert data["result"] == "This is my critique. (Blameless Postmortems)"
+        assert data["degraded"] is False
+        assert len(data["sources"]) > 0
+        source = data["sources"][0]
+        assert {"id", "type", "title", "content", "score"} <= source.keys()
+
+    def test_current_note_excluded_from_its_own_sources(
+        self, admin_headers: dict[str, str]
+    ) -> None:
+        with _editor_client(
+            _EditorLLM(generate_response="Critique."),
+            notes_service=_PartnerNotesService(),
+        ) as client:
+            response = client.post(
+                "/api/editor/assist",
+                json={
+                    "command": "contradictions",
+                    "text": "Some claim.",
+                    "note_title": "Current Note",
+                    "note_id": "curious-elephant",
+                },
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        source_ids = {s["id"] for s in data["sources"]}
+        assert "curious-elephant" not in source_ids
+
+    def test_unauthenticated_rejected(self) -> None:
+        with _editor_client(_EditorLLM(), notes_service=_PartnerNotesService()) as client:
+            response = client.post(
+                "/api/editor/assist", json={"command": "gaps", "text": "hi"}
+            )
+
+        assert response.status_code == 401
+
+    def test_ai_unavailable_returns_503(self, admin_headers: dict[str, str]) -> None:
+        with _editor_client(
+            _EditorLLM(available=False), notes_service=_PartnerNotesService()
+        ) as client:
+            response = client.post(
+                "/api/editor/assist",
+                json={"command": "gaps", "text": "hi"},
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 503
+
+    def test_empty_llm_response_is_degraded(self, admin_headers: dict[str, str]) -> None:
+        with _editor_client(
+            _EditorLLM(generate_response=None), notes_service=_PartnerNotesService()
+        ) as client:
+            response = client.post(
+                "/api/editor/assist",
+                json={"command": "gaps", "text": "hi"},
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["degraded"] is True
+
+    def test_zero_retrieval_returns_degraded_without_calling_llm(
+        self, admin_headers: dict[str, str]
+    ) -> None:
+        """No embeddings available -> retrieval returns nothing -> the
+        endpoint must not call the LLM with an empty context."""
+
+        class _NoEmbeddingsLLM(_EditorLLM):
+            def generate(self, prompt: str, **kwargs: Any) -> str | None:
+                raise AssertionError("LLM must not be called when retrieval is empty")
+
+        with _editor_client(
+            _NoEmbeddingsLLM(embeddings_available=False),
+            notes_service=_PartnerNotesService(),
+        ) as client:
+            response = client.post(
+                "/api/editor/assist",
+                json={"command": "gaps", "text": "hi", "note_id": "curious-elephant"},
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["degraded"] is True
+        assert data["sources"] == []
+
+    def test_phase1_transform_command_unchanged(self, admin_headers: dict[str, str]) -> None:
+        """Regression: transform commands still return result/degraded only,
+        with sources absent (None), unaffected by the new deps."""
+        with _editor_client(
+            _EditorLLM(generate_response="Expanded version."),
+            notes_service=_PartnerNotesService(),
+        ) as client:
+            response = client.post(
+                "/api/editor/assist",
+                json={"command": "expand", "text": "short text"},
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["result"] == "Expanded version."
+        assert data.get("sources") is None
+
+    def test_phase1_link_command_unchanged(self, admin_headers: dict[str, str]) -> None:
+        """Regression: /link still returns suggestions, unaffected by the new deps."""
+        with _editor_client(
+            _EditorLLM(
+                generate_response=(
+                    '[{"note_id": "wise-mountain", "confidence": 0.8, "reason": "related"}]'
+                )
+            ),
+            notes_service=_EditorNotesService(),
+        ) as client:
+            response = client.post(
+                "/api/editor/assist",
+                json={
+                    "command": "link",
+                    "text": "some text about postmortems",
+                    "note_id": "curious-elephant",
+                },
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["suggestions"][0]["note_id"] == "wise-mountain"
+
+
+class TestEditorAssistStreamWritingPartner:
+    """Tests for the challenge/gaps/contradictions commands on POST /api/editor/assist/stream (#146 Phase 2)."""
+
+    def _events(self, response: Any) -> list[dict[str, Any]]:
+        import json as _json
+
+        events = []
+        for line in response.text.split("\n\n"):
+            line = line.strip()
+            if line.startswith("data: "):
+                events.append(_json.loads(line[len("data: ") :]))
+        return events
+
+    def test_stream_emits_sources_before_tokens_then_completes(
+        self, admin_headers: dict[str, str]
+    ) -> None:
+        with _editor_client(
+            _EditorLLM(stream_tokens=["This ", "is ", "my critique."]),
+            notes_service=_PartnerNotesService(),
+        ) as client:
+            response = client.post(
+                "/api/editor/assist/stream",
+                json={
+                    "command": "challenge",
+                    "text": "Postmortems should assign blame.",
+                    "note_title": "My Draft",
+                    "note_id": "curious-elephant",
+                },
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 200
+        events = self._events(response)
+        types = [e["type"] for e in events]
+
+        assert types[0] == "sources"
+        assert "token" in types
+        assert types[-1] == "complete"
+        assert types.index("sources") < types.index("token")
+
+    def test_current_note_excluded_from_stream_sources(
+        self, admin_headers: dict[str, str]
+    ) -> None:
+        with _editor_client(
+            _EditorLLM(stream_tokens=["Critique."]),
+            notes_service=_PartnerNotesService(),
+        ) as client:
+            response = client.post(
+                "/api/editor/assist/stream",
+                json={
+                    "command": "contradictions",
+                    "text": "Some claim.",
+                    "note_title": "Current Note",
+                    "note_id": "curious-elephant",
+                },
+                headers=admin_headers,
+            )
+
+        events = self._events(response)
+        sources_event = next(e for e in events if e["type"] == "sources")
+        source_ids = {s["id"] for s in sources_event["sources"]}
+        assert "curious-elephant" not in source_ids
+
+    def test_unauthenticated_rejected(self) -> None:
+        with _editor_client(_EditorLLM(), notes_service=_PartnerNotesService()) as client:
+            response = client.post(
+                "/api/editor/assist/stream", json={"command": "gaps", "text": "hi"}
+            )
+
+        assert response.status_code == 401
+
+    def test_stream_degrades_gracefully_when_ai_unavailable(
+        self, admin_headers: dict[str, str]
+    ) -> None:
+        with _editor_client(
+            _EditorLLM(available=False), notes_service=_PartnerNotesService()
+        ) as client:
+            response = client.post(
+                "/api/editor/assist/stream",
+                json={"command": "gaps", "text": "hi"},
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 200
+        events = self._events(response)
+        assert events[0]["type"] == "error"
+
+    def test_zero_retrieval_emits_sources_then_degraded_complete_without_calling_llm(
+        self, admin_headers: dict[str, str]
+    ) -> None:
+        class _NoEmbeddingsLLM(_EditorLLM):
+            def generate_stream(self, prompt: str, **kwargs: Any) -> Generator[str]:
+                raise AssertionError("LLM must not be called when retrieval is empty")
+                yield ""  # pragma: no cover - unreachable, satisfies generator typing
+
+        with _editor_client(
+            _NoEmbeddingsLLM(embeddings_available=False),
+            notes_service=_PartnerNotesService(),
+        ) as client:
+            response = client.post(
+                "/api/editor/assist/stream",
+                json={"command": "gaps", "text": "hi", "note_id": "curious-elephant"},
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 200
+        events = self._events(response)
+        types = [e["type"] for e in events]
+        assert types[0] == "sources"
+        assert events[0]["sources"] == []
+        assert "token" in types  # the "nothing to check against" message
+        complete_event = next(e for e in events if e["type"] == "complete")
+        assert complete_event.get("degraded") is True
+
+    def test_phase1_transform_stream_unchanged(self, admin_headers: dict[str, str]) -> None:
+        """Regression: transform command streams still emit token/complete only,
+        no sources event, unaffected by the new deps."""
+        with _editor_client(
+            _EditorLLM(stream_tokens=["Ex", "pand", "ed."]),
+            notes_service=_PartnerNotesService(),
+        ) as client:
+            response = client.post(
+                "/api/editor/assist/stream",
+                json={"command": "expand", "text": "hi"},
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 200
+        events = self._events(response)
+        types = [e["type"] for e in events]
+        assert types == ["token", "token", "token", "complete"]
 
 
 class TestMockOllamaClientUnit:

--- a/backend/tests/unit/test_core_ai.py
+++ b/backend/tests/unit/test_core_ai.py
@@ -305,6 +305,78 @@ class TestBuildEditorCommandPrompt:
         assert "do not repeat" in prompt.lower()
 
 
+class TestBuildWritingPartnerPrompt:
+    """Tests for the RAG-backed writing-partner prompt construction (#146 Phase 2)."""
+
+    @pytest.mark.parametrize("command", ["challenge", "gaps", "contradictions"])
+    def test_builds_prompt_for_each_partner_command(self, command):
+        docs = [{"title": "Incident Response Basics", "content": "Runbooks matter."}]
+        prompt = ai.build_writing_partner_prompt(command, "My claim.", "My Note", docs)
+
+        assert "My claim." in prompt
+        assert "Incident Response Basics" in prompt
+        assert "Runbooks matter." in prompt
+        assert "My Note" in prompt
+        assert "markdown prose" in prompt.lower()
+        assert "no code fences" in prompt.lower()
+
+    def test_each_command_has_a_distinct_instruction(self):
+        docs = [{"title": "Doc", "content": "content"}]
+        prompts = {
+            command: ai.build_writing_partner_prompt(command, "text", None, docs)
+            for command in ai.EDITOR_PARTNER_COMMANDS
+        }
+
+        assert prompts["challenge"] != prompts["gaps"]
+        assert prompts["gaps"] != prompts["contradictions"]
+        assert prompts["challenge"] != prompts["contradictions"]
+
+        assert "devil's advocate" in prompts["challenge"].lower()
+        assert "gaps in the reasoning" in prompts["gaps"].lower()
+        assert "contradictions" in prompts["contradictions"].lower()
+
+    def test_unknown_command_raises_value_error(self):
+        with pytest.raises(ValueError, match="Unknown writing-partner command"):
+            ai.build_writing_partner_prompt("frobnicate", "text", None, [])
+
+    def test_transform_commands_rejected(self):
+        """Transform commands belong to build_editor_command_prompt, not this
+        function - each must reject the other's commands."""
+        with pytest.raises(ValueError, match="Unknown writing-partner command"):
+            ai.build_writing_partner_prompt("expand", "text", None, [])
+
+    def test_empty_context_documents_handled(self):
+        prompt = ai.build_writing_partner_prompt("gaps", "My claim.", "My Note", [])
+
+        assert "My claim." in prompt
+        assert "no related notes were found" in prompt.lower()
+
+    def test_per_document_truncation_kicks_in_at_budget(self):
+        big_content = "x" * 10000
+        docs = [
+            {"title": "Doc One", "content": big_content},
+            {"title": "Doc Two", "content": big_content},
+        ]
+        prompt = ai.build_writing_partner_prompt(
+            "contradictions", "text", None, docs, max_context_chars=1000
+        )
+
+        assert "[truncated]" in prompt
+        assert big_content not in prompt
+
+    def test_no_title_omits_title_line(self):
+        prompt = ai.build_writing_partner_prompt("challenge", "text", None, [])
+        assert "Note title:" not in prompt
+
+    def test_cites_notes_by_title_instruction_present(self):
+        prompt = ai.build_writing_partner_prompt("gaps", "text", None, [])
+        assert "cite" in prompt.lower()
+
+    def test_editor_commands_include_partner_commands(self):
+        for command in ai.EDITOR_PARTNER_COMMANDS:
+            assert command in ai.EDITOR_COMMANDS
+
+
 class TestParseJSONResponse:
     """Tests for defensive JSON parsing."""
 

--- a/frontend/src/__tests__/slashCommands.test.ts
+++ b/frontend/src/__tests__/slashCommands.test.ts
@@ -127,9 +127,47 @@ describe("getPrecedingText", () => {
 });
 
 describe("SLASH_COMMANDS registry", () => {
-  it("contains exactly the six commands from the issue", () => {
+  it("contains the six Phase 1 commands plus the three Phase 2 writing-partner commands", () => {
     expect(SLASH_COMMANDS.map((c) => c.name).sort()).toEqual(
-      ["continue", "expand", "link", "rephrase", "simplify", "summarize"].sort()
+      [
+        "continue",
+        "expand",
+        "link",
+        "rephrase",
+        "simplify",
+        "summarize",
+        "challenge",
+        "gaps",
+        "contradictions",
+      ].sort()
     );
+  });
+
+  it("tags the three new Phase 2 commands as kind: partner", () => {
+    for (const name of ["challenge", "gaps", "contradictions"]) {
+      expect(getSlashCommand(name)?.kind).toBe("partner");
+    }
+  });
+
+  it("keeps the Phase 1 transform commands tagged as kind: transform", () => {
+    for (const name of ["expand", "simplify", "summarize", "continue", "rephrase"]) {
+      expect(getSlashCommand(name)?.kind).toBe("transform");
+    }
+  });
+
+  it("keeps /link tagged as kind: link", () => {
+    expect(getSlashCommand("link")?.kind).toBe("link");
+  });
+});
+
+describe("filterSlashCommands with the expanded registry", () => {
+  it("still filters by prefix correctly with partner commands present", () => {
+    expect(filterSlashCommands("cha").map((c) => c.name)).toEqual(["challenge"]);
+    expect(filterSlashCommands("g").map((c) => c.name)).toEqual(["gaps"]);
+    expect(
+      filterSlashCommands("con")
+        .map((c) => c.name)
+        .sort()
+    ).toEqual(["continue", "contradictions"].sort());
   });
 });

--- a/frontend/src/components/NoteEditor.module.scss
+++ b/frontend/src/components/NoteEditor.module.scss
@@ -286,6 +286,140 @@
   font-weight: $font-weight-medium;
 }
 
+// ===== WRITING PARTNER ADVISORY CARD (#146 Phase 2) =====
+// Dismissible card for challenge/gaps/contradictions results - anchored near
+// the cursor like the palette, but wider and taller since it holds streamed
+// prose plus citations rather than a short list of options.
+.partnerCard {
+  position: fixed;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  width: 380px;
+  max-width: calc(100vw - 2 * #{$spacing-2});
+  max-height: min(28rem, calc(100vh - 2 * #{$spacing-2}));
+  overflow-y: auto;
+  border: $border-width-thin solid $neutral-200;
+  border-radius: $border-radius-md;
+  background-color: $white;
+  box-shadow: $shadow-popover;
+}
+
+.partnerCardHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: $spacing-3 $spacing-4;
+  border-bottom: $border-width-thin solid $neutral-100;
+}
+
+.partnerCardLabel {
+  @include text-secondary;
+  font-weight: $font-weight-medium;
+  color: $neutral-900;
+}
+
+.partnerCardBody {
+  padding: $spacing-3 $spacing-4;
+}
+
+.partnerCardPending {
+  display: flex;
+  align-items: center;
+  gap: $spacing-2;
+  @include text-tertiary;
+  color: $color-text-tertiary;
+}
+
+.partnerCardProse {
+  @include text-secondary;
+  color: $neutral-800;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: monospace;
+}
+
+.synthesisStreamingCursorLocal {
+  display: inline-block;
+  width: 0.5em;
+  height: 1em;
+  margin-left: 2px;
+  vertical-align: text-bottom;
+  background-color: $color-interactive-primary;
+  animation: partner-card-pulse 1s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+// CSS Modules scope @keyframes per file, so this can't reuse
+// AIPanel.module.scss's identically-named "pulse" keyframe.
+@keyframes partner-card-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+.partnerCardDegradedNote {
+  margin-top: $spacing-2;
+  @include text-tertiary;
+  color: $color-text-tertiary;
+}
+
+.partnerCardError {
+  @include text-secondary;
+  color: $color-error-text;
+}
+
+.partnerCardActions {
+  display: flex;
+  align-items: center;
+  gap: $spacing-2;
+  padding: $spacing-2 $spacing-4 $spacing-3;
+  border-top: $border-width-thin solid $neutral-100;
+}
+
+.partnerCardButton {
+  padding: $spacing-1 $spacing-3;
+  border: none;
+  border-radius: $border-radius-sm;
+  @include text-tertiary;
+  @include transition-colors;
+  cursor: pointer;
+  background: transparent;
+
+  &:hover:not(:disabled) {
+    background-color: $neutral-100;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+}
+
+.partnerCardButtonPrimary {
+  padding: $spacing-1 $spacing-3;
+  border: none;
+  border-radius: $border-radius-sm;
+  @include text-tertiary;
+  @include transition-colors;
+  cursor: pointer;
+  background-color: $teal-600;
+  color: $white;
+  font-weight: $font-weight-medium;
+
+  &:hover:not(:disabled) {
+    background-color: $teal-700;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+}
+
 // Subtle word count anchored to the bottom of the zen screen
 .zenFooter {
   position: fixed;

--- a/frontend/src/components/NoteEditor.tsx
+++ b/frontend/src/components/NoteEditor.tsx
@@ -9,6 +9,7 @@ import { EditorView } from "@codemirror/view";
 import { logger } from "@/lib/logger";
 import { Note } from "@/lib/api/notes";
 import EditorDropdown, { EditorDropdownItem } from "@/components/EditorDropdown";
+import WritingPartnerCard from "@/components/WritingPartnerCard";
 import {
   SlashCommandDef,
   detectSlashCommandTrigger,
@@ -16,7 +17,12 @@ import {
   getParagraphBounds,
   getPrecedingText,
 } from "@/lib/slashCommands";
-import { runEditorAssist, streamEditorAssist, EditorLinkSuggestion } from "@/lib/api/editorAssist";
+import {
+  runEditorAssist,
+  streamEditorAssist,
+  EditorLinkSuggestion,
+  EditorAssistSource,
+} from "@/lib/api/editorAssist";
 import styles from "./NoteEditor.module.scss";
 
 interface NoteEditorProps {
@@ -76,6 +82,20 @@ export default function NoteEditor({
     position: { top: number; left: number };
   } | null>(null);
 
+  // ===== Writing-partner advisory card state (#146 Phase 2) =====
+  const [partnerCard, setPartnerCard] = useState<{
+    label: string;
+    position: { top: number; left: number };
+    /** Doc position where the trigger was typed - "Insert as quote" targets
+     * this, not wherever the cursor happens to be by the time it's clicked. */
+    insertAt: number;
+    prose: string;
+    sources: EditorAssistSource[];
+    streaming: boolean;
+    degraded: boolean;
+    error: string | null;
+  } | null>(null);
+
   // Absolute doc position of the "/" that opened the palette. Kept in a ref
   // (not state) because it's read synchronously inside handleChange/keydown
   // handlers that fire between renders.
@@ -111,6 +131,16 @@ export default function NoteEditor({
     setLinkCandidates([]);
   }, []);
 
+  // Dismiss the writing-partner advisory card, aborting an in-flight stream
+  // if one is running. Palette, wikilink dropdown, and this card are
+  // mutually exclusive surfaces - call sites that open one of the others
+  // also call this.
+  const closePartnerCard = useCallback(() => {
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = null;
+    setPartnerCard(null);
+  }, []);
+
   const getCoords = useCallback((view: EditorView, pos: number) => {
     const coords = view.coordsAtPos(pos);
     return coords ? { top: coords.bottom, left: coords.left } : { top: 0, left: 0 };
@@ -141,6 +171,7 @@ export default function NoteEditor({
 
       if (wikilinkMatch) {
         closeSlashPalette();
+        closePartnerCard();
         setAutocompleteQuery(wikilinkMatch[1]);
         setSelectedIndex(0);
         setAutocompletePosition(getCoords(view, pos));
@@ -160,6 +191,7 @@ export default function NoteEditor({
       const trigger = detectSlashCommandTrigger(lineTextBeforeCursor);
 
       if (trigger) {
+        closePartnerCard();
         slashTriggerFromRef.current = line.from + trigger.slashIndex;
         setSlashQuery(trigger.query);
         setSlashSelectedIndex(0);
@@ -170,7 +202,7 @@ export default function NoteEditor({
         closeSlashPalette();
       }
     },
-    [onChange, slashCommandsArmed, slashOpen, closeSlashPalette, getCoords]
+    [onChange, slashCommandsArmed, slashOpen, closeSlashPalette, closePartnerCard, getCoords]
   );
 
   // Insert wikilink at cursor
@@ -416,6 +448,104 @@ export default function NoteEditor({
     [noteTitle, noteId, getCoords, restoreSnapshot, finishBusy, flashError]
   );
 
+  const executePartnerCommand = useCallback(
+    async (
+      view: EditorView,
+      cmd: SlashCommandDef,
+      noteContentSnapshot: string,
+      targetText: string,
+      insertAt: number
+    ) => {
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+
+      setPartnerCard({
+        label: cmd.label,
+        position: getCoords(view, insertAt),
+        insertAt,
+        prose: "",
+        sources: [],
+        streaming: true,
+        degraded: false,
+        error: null,
+      });
+
+      let receivedAny = false;
+      let sawError = false;
+      let sawDegraded = false;
+
+      const requestBody = {
+        command: cmd.name,
+        text: targetText,
+        note_title: noteTitle,
+        note_content: noteContentSnapshot,
+        note_id: noteId,
+      };
+
+      await streamEditorAssist(requestBody, {
+        signal: controller.signal,
+        onEvent: (event) => {
+          if (event.type === "sources") {
+            setPartnerCard((prev) => (prev ? { ...prev, sources: event.sources } : prev));
+          } else if (event.type === "token") {
+            receivedAny = true;
+            setPartnerCard((prev) => (prev ? { ...prev, prose: prev.prose + event.text } : prev));
+          } else if (event.type === "complete") {
+            sawDegraded = !!event.degraded;
+          } else if (event.type === "error") {
+            sawError = true;
+          }
+        },
+        onError: () => {
+          sawError = true;
+        },
+      });
+
+      if (controller.signal.aborted) {
+        // The card was dismissed (or Escape hit) mid-stream - state was
+        // already cleared by closePartnerCard, don't touch it again.
+        finishBusy();
+        return;
+      }
+
+      if (sawError || !receivedAny) {
+        try {
+          const resp = await runEditorAssist(requestBody);
+          if (resp.result) {
+            setPartnerCard((prev) =>
+              prev
+                ? {
+                    ...prev,
+                    prose: resp.result || "",
+                    sources: resp.sources || [],
+                    degraded: resp.degraded,
+                    streaming: false,
+                    error: null,
+                  }
+                : prev
+            );
+            finishBusy();
+            return;
+          }
+        } catch (err) {
+          slashCommandLogger.error("Writing-partner fallback failed", err);
+        }
+
+        setPartnerCard((prev) =>
+          prev ? { ...prev, streaming: false, error: `/${cmd.name} failed - try again` } : prev
+        );
+        finishBusy();
+        return;
+      }
+
+      setPartnerCard((prev) =>
+        prev ? { ...prev, streaming: false, degraded: sawDegraded } : prev
+      );
+      finishBusy();
+    },
+    [noteTitle, noteId, getCoords, finishBusy]
+  );
+
   const runSlashCommand = useCallback(
     (cmd: SlashCommandDef) => {
       if (!editorView || busyRef.current) return;
@@ -430,6 +560,7 @@ export default function NoteEditor({
 
       busyRef.current = true;
       closeSlashPalette();
+      closePartnerCard();
 
       // Remove the typed "/cmd" trigger text.
       view.dispatch({ changes: { from: triggerFrom, to: cursorPos, insert: "" } });
@@ -456,10 +587,18 @@ export default function NoteEditor({
         targetText = docText.slice(targetFrom, targetTo);
       }
 
-      if (cmd.name === "link") {
+      if (cmd.kind === "link") {
         // /link never consumes the target text - it only inserts a wikilink
         // at the cursor once a candidate is chosen.
         void executeLinkCommand(view, snapshotText, targetText, triggerFrom);
+        return;
+      }
+
+      if (cmd.kind === "partner") {
+        // Advisory commands never mutate the document as part of running -
+        // the trigger text above is the only thing removed. The target text
+        // is read (not deleted) purely as the passage under review.
+        void executePartnerCommand(view, cmd, docText, targetText, triggerFrom);
         return;
       }
 
@@ -478,8 +617,32 @@ export default function NoteEditor({
         insertAt
       );
     },
-    [editorView, closeSlashPalette, executeLinkCommand, executeTransformCommand]
+    [
+      editorView,
+      closeSlashPalette,
+      closePartnerCard,
+      executeLinkCommand,
+      executePartnerCommand,
+      executeTransformCommand,
+    ]
   );
+
+  const insertPartnerResultAsQuote = useCallback(() => {
+    if (!editorView || !partnerCard) return;
+    const view = editorView;
+    const quoted = partnerCard.prose
+      .split("\n")
+      .map((line) => (line.length ? `> ${line}` : ">"))
+      .join("\n");
+    const insertAt = Math.min(partnerCard.insertAt, view.state.doc.length);
+
+    view.focus();
+    view.dispatch({
+      changes: { from: insertAt, to: insertAt, insert: quoted },
+      selection: { anchor: insertAt + quoted.length },
+    });
+    setPartnerCard(null);
+  }, [editorView, partnerCard]);
 
   const selectLinkCandidate = useCallback(
     (candidate: EditorLinkSuggestion) => {
@@ -577,14 +740,14 @@ export default function NoteEditor({
       if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === "f") {
         e.preventDefault();
         setZen((prev) => !prev);
-      } else if (e.key === "Escape" && zen && !showAutocomplete && !slashOpen) {
+      } else if (e.key === "Escape" && zen && !showAutocomplete && !slashOpen && !partnerCard) {
         setZen(false);
       }
     };
 
     window.addEventListener("keydown", handleZenKeys);
     return () => window.removeEventListener("keydown", handleZenKeys);
-  }, [zen, showAutocomplete, slashOpen]);
+  }, [zen, showAutocomplete, slashOpen, partnerCard]);
 
   // Lock page scroll while zen mode is open
   useEffect(() => {
@@ -758,6 +921,21 @@ export default function NoteEditor({
           >
             {errorFlash.message}
           </div>
+        )}
+
+        {/* Writing-partner advisory card (#146 Phase 2: challenge/gaps/contradictions) */}
+        {partnerCard && (
+          <WritingPartnerCard
+            label={partnerCard.label}
+            anchor={partnerCard.position}
+            prose={partnerCard.prose}
+            streaming={partnerCard.streaming}
+            degraded={partnerCard.degraded}
+            sources={partnerCard.sources}
+            errorMessage={partnerCard.error}
+            onInsertQuote={insertPartnerResultAsQuote}
+            onDismiss={closePartnerCard}
+          />
         )}
       </div>
 

--- a/frontend/src/components/WritingPartnerCard.tsx
+++ b/frontend/src/components/WritingPartnerCard.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+/**
+ * Advisory card for the #146 Phase 2 writing-partner commands (challenge /
+ * gaps / contradictions). Unlike Phase 1's transforms, these commands never
+ * touch the document - the result is commentary with citations, rendered
+ * here and left entirely up to the user to act on ("Insert as quote") or
+ * discard ("Dismiss"). NoteEditor.tsx owns all state and streaming; this
+ * component is a pure presentational shell so it's cheaply testable in
+ * isolation.
+ *
+ * Markdown prose is rendered as raw text (white-space: pre-wrap), matching
+ * SynthesisView.tsx (#166) - the app doesn't run a markdown parser over
+ * streamed AI prose anywhere else, so this doesn't introduce a new pattern.
+ * Citations reuse SourceList.tsx verbatim; the backend's source shape
+ * (id/type/title/content/score) was matched to it deliberately.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import SourceList, { type Source } from "@/components/SourceList";
+import styles from "./NoteEditor.module.scss";
+
+export interface WritingPartnerCardProps {
+  /** Command label shown as the card heading, e.g. "Challenge this assumption". */
+  label: string;
+  /** Anchor point (from CodeMirror's coordsAtPos), pre-clamp. */
+  anchor: { top: number; left: number };
+  /** Accumulated markdown prose streamed so far (or the non-streaming result). */
+  prose: string;
+  /** True while a stream is in flight and more tokens may still arrive. */
+  streaming: boolean;
+  /** True for the zero-retrieval case: prose is a fixed honest message, not
+   * an LLM output - render as information, not as an error. */
+  degraded: boolean;
+  sources: Source[];
+  /** Set when both streaming and the non-streaming fallback failed. */
+  errorMessage: string | null;
+  onInsertQuote: () => void;
+  onDismiss: () => void;
+}
+
+const CARD_MARGIN = 8;
+
+export default function WritingPartnerCard({
+  label,
+  anchor,
+  prose,
+  streaming,
+  degraded,
+  sources,
+  errorMessage,
+  onInsertQuote,
+  onDismiss,
+}: WritingPartnerCardProps) {
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  const [position, setPosition] = useState(anchor);
+  const [copied, setCopied] = useState(false);
+
+  // Re-clamp on every render that could change the card's size (new tokens,
+  // sources landing, error state) so it never overflows the viewport.
+  useEffect(() => {
+    const el = cardRef.current;
+    if (!el) return;
+
+    const rect = el.getBoundingClientRect();
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+
+    let left = anchor.left;
+    let top = anchor.top;
+
+    if (left + rect.width + CARD_MARGIN > viewportWidth) {
+      left = Math.max(CARD_MARGIN, viewportWidth - rect.width - CARD_MARGIN);
+    }
+    if (top + rect.height + CARD_MARGIN > viewportHeight) {
+      // Flip above the anchor point when it would overflow the bottom edge;
+      // fall back to clamping against the bottom if there isn't room above
+      // either (e.g. a very tall card on a short viewport).
+      const flippedTop = anchor.top - rect.height - CARD_MARGIN;
+      top =
+        flippedTop >= CARD_MARGIN
+          ? flippedTop
+          : Math.max(CARD_MARGIN, viewportHeight - rect.height - CARD_MARGIN);
+    }
+
+    setPosition({ top, left });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [anchor, prose, sources.length, streaming, errorMessage, degraded]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onDismiss();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onDismiss]);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(prose);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API can fail silently (permissions, insecure context) -
+      // not worth surfacing as an error; the user can still select the text.
+    }
+  };
+
+  const hasProse = prose.length > 0;
+  const canAct = !streaming && !errorMessage && hasProse;
+
+  return (
+    <div
+      ref={cardRef}
+      className={styles.partnerCard}
+      style={{ top: `${position.top}px`, left: `${position.left}px` }}
+      role="dialog"
+      aria-label={label}
+    >
+      <div className={styles.partnerCardHeader}>
+        <span className={styles.partnerCardLabel}>{label}</span>
+      </div>
+
+      <div className={styles.partnerCardBody}>
+        {errorMessage ? (
+          <div className={styles.partnerCardError}>{errorMessage}</div>
+        ) : (
+          <>
+            {!hasProse && streaming && (
+              <div className={styles.partnerCardPending}>
+                <span className={styles.slashPendingDot} aria-hidden="true" />
+                Thinking…
+              </div>
+            )}
+            {hasProse && (
+              <div className={styles.partnerCardProse}>
+                {prose}
+                {streaming && (
+                  <span className={styles.synthesisStreamingCursorLocal} aria-hidden="true" />
+                )}
+              </div>
+            )}
+            {degraded && !streaming && (
+              <div className={styles.partnerCardDegradedNote}>
+                Nothing in the knowledge base yet to check this against.
+              </div>
+            )}
+          </>
+        )}
+
+        {sources.length > 0 && <SourceList sources={sources} />}
+      </div>
+
+      <div className={styles.partnerCardActions}>
+        <button
+          type="button"
+          className={styles.partnerCardButtonPrimary}
+          onClick={onInsertQuote}
+          disabled={!canAct}
+        >
+          Insert as quote
+        </button>
+        <button
+          type="button"
+          className={styles.partnerCardButton}
+          onClick={handleCopy}
+          disabled={!canAct}
+        >
+          {copied ? "Copied ✓" : "Copy"}
+        </button>
+        <button type="button" className={styles.partnerCardButton} onClick={onDismiss}>
+          Dismiss
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/api/editorAssist.ts
+++ b/frontend/src/lib/api/editorAssist.ts
@@ -29,16 +29,29 @@ export interface EditorLinkSuggestion {
   confidence?: number;
 }
 
+/** Citation shape for writing-partner commands (#146 Phase 2) - matches
+ * SourceList.tsx's `Source` prop exactly; the backend was built to this
+ * shape deliberately so the component can be reused as-is. */
+export interface EditorAssistSource {
+  id: number | string;
+  type?: "article" | "note";
+  title: string;
+  content: string;
+  score?: number;
+}
+
 export type EditorAssistEvent =
+  | { type: "sources"; sources: EditorAssistSource[] }
   | { type: "token"; text: string }
   | ({ type: "link" } & EditorLinkSuggestion)
-  | { type: "complete" }
+  | { type: "complete"; degraded?: boolean }
   | { type: "error"; message?: string };
 
 export interface EditorAssistResponse {
   command: string;
   result?: string | null;
   suggestions?: EditorLinkSuggestion[] | null;
+  sources?: EditorAssistSource[] | null;
   degraded: boolean;
 }
 

--- a/frontend/src/lib/slashCommands.ts
+++ b/frontend/src/lib/slashCommands.ts
@@ -6,12 +6,34 @@
  */
 
 export type SlashCommandName =
-  "expand" | "simplify" | "summarize" | "continue" | "rephrase" | "link";
+  | "expand"
+  | "simplify"
+  | "summarize"
+  | "continue"
+  | "rephrase"
+  | "link"
+  | "challenge"
+  | "gaps"
+  | "contradictions";
+
+/**
+ * How a command's result is meant to be used, so call sites can route by
+ * kind instead of special-casing individual command names:
+ * - "transform": streams plain prose that replaces the target text
+ *   (expand/simplify/summarize/continue/rephrase).
+ * - "link": streams wikilink candidates; never consumes/replaces text.
+ * - "partner": advisory writing-partner commands (#146 Phase 2 -
+ *   challenge/gaps/contradictions). Result is commentary with citations,
+ *   rendered in a dismissible card; never inserted into the document
+ *   automatically.
+ */
+export type SlashCommandKind = "transform" | "link" | "partner";
 
 export interface SlashCommandDef {
   name: SlashCommandName;
   label: string;
   description: string;
+  kind: SlashCommandKind;
   /** Whether this command operates on the current selection specifically
    * (vs. falling back to the current paragraph/preceding text). All six
    * commands use the selection when one exists; this flags commands where a
@@ -26,45 +48,72 @@ export const SLASH_COMMANDS: readonly SlashCommandDef[] = [
     name: "expand",
     label: "Expand",
     description: "Expand the current paragraph with more detail",
+    kind: "transform",
     needsSelection: false,
   },
   {
     name: "simplify",
     label: "Simplify",
     description: "Simplify complex text",
+    kind: "transform",
     needsSelection: false,
   },
   {
     name: "summarize",
     label: "Summarize",
     description: "Summarize selected text",
+    kind: "transform",
     needsSelection: true,
   },
   {
     name: "continue",
     label: "Continue",
     description: "Continue writing from cursor position",
+    kind: "transform",
     needsSelection: false,
   },
   {
     name: "rephrase",
     label: "Rephrase",
     description: "Offer alternative phrasings",
+    kind: "transform",
     needsSelection: false,
   },
   {
     name: "link",
     label: "Link",
     description: "Find and insert relevant wikilinks",
+    kind: "link",
+    needsSelection: false,
+  },
+  {
+    name: "challenge",
+    label: "Challenge this assumption",
+    description: "Push back on an assumption, citing your notes",
+    kind: "partner",
+    needsSelection: false,
+  },
+  {
+    name: "gaps",
+    label: "What am I missing?",
+    description: "Surface gaps against what's already in your notes",
+    kind: "partner",
+    needsSelection: false,
+  },
+  {
+    name: "contradictions",
+    label: "Find contradictions",
+    description: "Check this text against your notes for contradictions",
+    kind: "partner",
     needsSelection: false,
   },
 ];
 
 /** Text-transform commands: their result streams as plain prose tokens that
- * replace the target text. "link" is excluded - it streams link candidates
- * instead of prose. */
+ * replace the target text. "link" and the writing-partner commands are
+ * excluded - they never overwrite the target text. */
 export const SLASH_TRANSFORM_COMMANDS: readonly SlashCommandName[] = SLASH_COMMANDS.filter(
-  (c) => c.name !== "link"
+  (c) => c.kind === "transform"
 ).map((c) => c.name);
 
 export function getSlashCommand(name: string): SlashCommandDef | undefined {


### PR DESCRIPTION
Closes #146. Phase 3 (inline Copilot-style suggestions) is split out into #277 and iceboxed, so this PR completes the issue.

Adds three RAG-backed advisory actions to the editor slash palette: `/challenge` ("Challenge this assumption"), `/gaps` ("What am I missing?"), `/contradictions` ("Find contradictions").

## The design decision that shaped this

Phase 1's commands transform text — they stream a replacement into the document. Phase 2's commands produce **critique**, and streaming a devil's-advocate argument into the note body would be wrong. So these render in an **inline advisory card** anchored near the cursor, with their cited sources. The document is untouched unless you explicitly click "Insert as quote", which makes the AC "accept/reject leaves the document in a clean state either way" true by construction rather than by careful rollback handling.

Routing is by an explicit `kind: "transform" | "link" | "partner"` discriminator on `SlashCommandDef`, set on all nine commands — not name-based special-casing at call sites.

## Backend

- `core/ai.py` — `EDITOR_PARTNER_COMMANDS`, folded into the existing `EDITOR_COMMANDS` validation; `build_writing_partner_prompt()` (pure) with `WRITING_PARTNER_CONTEXT_CHAR_BUDGET = 12000` and per-document truncation. Each action gets a distinct instruction; all three must cite retrieved notes by title and say plainly when the knowledge base doesn't support a point — `contradictions` in particular is told to report no conflict rather than invent one.
- Both existing endpoints gained a third branch rather than new routes, so the `AdminUser` gate and `ai_editor` rate limit are inherited. `EditorAssistResponse` gained `sources`; `result`/`suggestions` semantics are unchanged, so **Phase 1 clients in production keep working**.
- Retrieval reuses `_retrieve_documents_for_synthesis` from #166 at `top_k=6` rather than synthesis's 12 — this is focused critique of one passage, not a corpus-wide summary. **The current note is excluded from its own results** (fetch `top_k+1`, filter by `note_id`); a note contradicting itself is noise.
- **Zero-retrieval case**: when retrieval comes back empty, the LLM is never called. Returns a fixed honest message with `degraded: true` instead of asking a model to critique against nothing.

SSE contract: `sources` always first (so citations render before prose), then `token` deltas, then `complete`.

## Frontend

- `WritingPartnerCard.tsx` — positioned via the palette's `coordsAtPos` approach, then measured and clamped/flipped against the viewport on every content change so it can't stream itself off-screen. Escape and Dismiss both close it **and abort the in-flight stream**. Reuses `SourceList.tsx` from #166 — the backend's source shape was matched to it deliberately.
- Palette, wikilink dropdown, and card are mutually exclusive. Zen-mode Escape now checks for the card first, so one Escape closes the card rather than exiting zen.
- "Insert as quote" is the only path that mutates the document: a plain undoable dispatch at the original trigger position, each line prefixed `> `. Failure paths leave the document untouched — easy here, since nothing is inserted until you click.

## Testing

Backend: unit tests for the prompt builder (distinct instructions per action, `ValueError` on unknown command, truncation, empty context) plus integration tests for both endpoints — happy path, 401 unauthenticated, AI-unavailable, zero-retrieval, SSE ordering, current-note exclusion, and a regression test that Phase 1 transform and `/link` responses are unchanged.

Frontend: 26 tests in `slashCommands.test.ts` over the nine-command registry — `kind` assignment, prefix filtering, trigger detection unchanged.

`make test-backend` 621 passed · `make test-frontend` 117 passed · lint, typecheck, and `format:check` clean on both.

**Runtime-verified against the live stack:** non-streaming `gaps` returned the documented shape; streaming `contradictions` produced exactly one `sources` event (6 sources), 329 `token` events, then `complete`; the note under review never appeared in its own sources.

## Two caveats

- **The zero-retrieval degraded path was not live-verified** — dev Neo4j always returns something for similarity search, and forcing true zero-retrieval would mean emptying the shared dev knowledge base. It's implemented against the backend contract and covered by tests, but has not run end-to-end against a real empty corpus.
- In prod these commands go through the **Groq→Gemini chain** (`llm_use_api` routes all generation, not just embedding sync), which is known-flaky per #260/#263. The backend agent hit a real Groq 429 → Gemini 503 during verification and the degraded path handled it correctly — but expect occasional degradation in prod, same as the other AI features.

https://claude.ai/code/session_01KTENwGZUekeEwCZt2vKA4z