### PR TITLE
fix: mobile layout + design polish batch 1 — AI panel, note detail, homepage (refs #278)

### DIFF
--- a/frontend/src/__tests__/page.test.tsx
+++ b/frontend/src/__tests__/page.test.tsx
@@ -18,14 +18,19 @@ describe("Home Page", () => {
     expect(screen.getAllByText(/Birmingham, AL/).length).toBeGreaterThan(0);
   });
 
-  it("shows GitHub links", () => {
+  it("shows the GitHub social link", () => {
     render(<Home />);
-    // Should have both the social button and the projects link
     const githubLinks = screen.getAllByRole("link", { name: /github/i });
-    expect(githubLinks.length).toBeGreaterThanOrEqual(2);
-    // Both should point to GitHub
+    expect(githubLinks.length).toBeGreaterThanOrEqual(1);
     githubLinks.forEach((link) => {
       expect(link).toHaveAttribute("href", "https://github.com/DEGoodman");
     });
+  });
+
+  it("links to the knowledge base via the card", () => {
+    render(<Home />);
+    const card = screen.getByRole("link", { name: /knowledge base/i });
+    expect(card).toHaveAttribute("href", "/knowledge-base");
+    expect(screen.getByText(/curated digital garden/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/knowledge-base/notes/[id]/page.module.scss
+++ b/frontend/src/app/knowledge-base/notes/[id]/page.module.scss
@@ -55,10 +55,6 @@
     @include flex-between;
   }
 
-  .badge {
-    margin-bottom: $spacing-4;
-  }
-
   .titleRow {
     margin-bottom: $spacing-4;
 
@@ -128,7 +124,7 @@
     .viewGraphButton {
       background-color: transparent;
       color: $dusty-blue-600; // Cool info action
-      border: 2px solid $dusty-blue-600;
+      border: 1px solid $dusty-blue-600;
       text-decoration: none;
       display: inline-block;
 
@@ -151,7 +147,7 @@
     .deleteButton {
       background-color: transparent;
       color: $red-600; // Red destructive action
-      border: 2px solid $red-600; // Stronger outlined style
+      border: 1px solid $red-600;
 
       &:hover:not(:disabled) {
         background-color: $red-50;
@@ -161,16 +157,42 @@
     }
 
     .aiSuggestionsButton {
-      background-color: $teal-600; // Cool technical action
-      color: white;
+      background-color: transparent;
+      color: $teal-600; // Cool technical action, outlined: Edit stays the one fill
+      border: 1px solid $teal-600;
 
       &:hover:not(:disabled) {
-        background-color: $teal-700;
+        background-color: $teal-50;
+        border-color: $teal-700;
+        color: $teal-700;
       }
 
       &.prewarming {
         opacity: 0.7;
       }
+    }
+  }
+
+  // Mobile: the head matter must not fill the whole first screen (#278).
+  // Placed after the base rules so equal-specificity overrides win.
+  @media (max-width: 768px) {
+    padding: $spacing-4;
+    margin-bottom: $spacing-6;
+
+    .headerTop,
+    .titleRow,
+    .meta,
+    .tags {
+      margin-bottom: $spacing-3;
+    }
+
+    .titleRow .noteTitle {
+      font-size: $font-size-2xl;
+    }
+
+    .meta {
+      @include text-meta-mono;
+      gap: $spacing-3;
     }
   }
 }

--- a/frontend/src/app/knowledge-base/notes/[id]/page.tsx
+++ b/frontend/src/app/knowledge-base/notes/[id]/page.tsx
@@ -370,14 +370,10 @@ function NoteDetailContent() {
                 <Breadcrumb section="notes" />
               </div>
 
-              {/* Content Type Badge */}
-              <div className={styles.badge}>
-                <Badge type="note" />
-              </div>
-
-              {/* Title and metadata */}
+              {/* Title and metadata; type badge shares the id row to keep the head compact */}
               <div className={styles.titleRow}>
                 <div className={styles.noteIdRow}>
+                  <Badge type="note" />
                   {mascotFor(note.id) && (
                     <span className="delight-mascot" aria-hidden="true">
                       {mascotFor(note.id)}

--- a/frontend/src/app/page.module.scss
+++ b/frontend/src/app/page.module.scss
@@ -20,18 +20,18 @@
 .main {
   @include container;
   max-width: 52rem;
-  padding-top: $spacing-16;
+  padding-top: $spacing-12;
   padding-bottom: $spacing-8;
 
   @media (max-width: 640px) {
     // Clear the theme toggle pinned to the top-right corner
-    padding-top: $spacing-16;
+    padding-top: $spacing-12;
   }
 }
 
 // ===== HERO SECTION =====
 .hero {
-  margin-bottom: $spacing-16;
+  margin-bottom: $spacing-12;
 
   .eyebrow {
     @include text-label-mono;
@@ -42,7 +42,7 @@
   .title {
     @include heading-h1;
     color: $neutral-900;
-    font-size: clamp(2.75rem, 7vw, 4rem);
+    font-size: clamp(2.25rem, 7vw, 4rem);
     line-height: 1.05;
     margin: 0;
     text-wrap: balance;
@@ -52,7 +52,7 @@
     width: 4rem;
     height: 3px;
     background-color: $color-interactive-primary;
-    margin: $spacing-6 0;
+    margin: $spacing-4 0;
   }
 
   .bio {
@@ -61,6 +61,10 @@
     line-height: $line-height-relaxed;
     color: $color-text-secondary;
     margin: 0 0 $spacing-6;
+
+    @media (max-width: 640px) {
+      font-size: $font-size-base;
+    }
   }
 }
 
@@ -96,8 +100,8 @@
 // ===== KNOWLEDGE BASE SECTION =====
 .kbSection {
   border-top: 1px solid $color-border-default;
-  padding-top: $spacing-10;
-  margin-bottom: $spacing-12;
+  padding-top: $spacing-8;
+  margin-bottom: $spacing-10;
 
   .kbEyebrow {
     @include text-label-mono;
@@ -119,40 +123,67 @@
     margin: 0 0 $spacing-6;
   }
 
-  .kbButton {
-    display: inline-flex;
-    align-items: center;
-    gap: $spacing-2;
-    padding: $spacing-3 $spacing-6;
-    border-radius: $border-radius-button;
-    font-size: $font-size-base;
-    font-weight: $font-weight-semibold;
-    text-decoration: none;
-    color: $color-interactive-primary-text;
-    background-color: $color-interactive-primary;
-    box-shadow: $shadow-button;
-    transition:
-      background-color 0.2s ease,
-      box-shadow 0.2s ease,
-      transform 0.2s ease;
+  .kbLinks {
+    @include cluster($spacing-6);
 
-    &:hover {
-      background-color: $color-interactive-primary-hover;
-      box-shadow: $shadow-button-hover;
-      transform: translateY(-1px);
-    }
-
-    &:focus-visible {
-      outline: 2px solid $color-interactive-primary-focus;
-      outline-offset: 3px;
-    }
-
-    @media (prefers-reduced-motion: reduce) {
-      transition: none;
+    a {
+      font-family: $font-family-mono;
+      font-size: $font-size-sm;
+      letter-spacing: $letter-spacing-wide;
+      color: $color-link-default;
+      text-decoration: none;
 
       &:hover {
-        transform: none;
+        color: $color-link-hover;
+        text-decoration: underline;
+        text-underline-offset: 3px;
       }
+
+      &:focus-visible {
+        outline: 2px solid $color-interactive-primary-focus;
+        outline-offset: 3px;
+        border-radius: 2px;
+      }
+    }
+  }
+}
+
+// Primary CTA - lives in the hero so the knowledge base is one tap
+// from landing on any viewport (#278)
+.kbButton {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-2;
+  margin-bottom: $spacing-6;
+  padding: $spacing-3 $spacing-6;
+  border-radius: $border-radius-button;
+  font-size: $font-size-base;
+  font-weight: $font-weight-semibold;
+  text-decoration: none;
+  color: $color-interactive-primary-text;
+  background-color: $color-interactive-primary;
+  box-shadow: $shadow-button;
+  transition:
+    background-color 0.2s ease,
+    box-shadow 0.2s ease,
+    transform 0.2s ease;
+
+  &:hover {
+    background-color: $color-interactive-primary-hover;
+    box-shadow: $shadow-button-hover;
+    transform: translateY(-1px);
+  }
+
+  &:focus-visible {
+    outline: 2px solid $color-interactive-primary-focus;
+    outline-offset: 3px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+
+    &:hover {
+      transform: none;
     }
   }
 }

--- a/frontend/src/app/page.module.scss
+++ b/frontend/src/app/page.module.scss
@@ -52,7 +52,7 @@
     width: 4rem;
     height: 3px;
     background-color: $color-interactive-primary;
-    margin: $spacing-4 0;
+    margin: $spacing-4 0 $spacing-6;
   }
 
   .bio {
@@ -66,6 +66,23 @@
       font-size: $font-size-base;
     }
   }
+}
+
+// Intro column + KB card share the space under the name (#278)
+.heroGrid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: $spacing-6;
+  align-items: start;
+
+  @media (min-width: 768px) {
+    grid-template-columns: minmax(0, 1fr) 19rem;
+    gap: $spacing-10;
+  }
+}
+
+.heroIntro {
+  min-width: 0;
 }
 
 // ===== SOCIAL LINKS (quiet mono text links) =====
@@ -97,81 +114,33 @@
   }
 }
 
-// ===== KNOWLEDGE BASE SECTION =====
-.kbSection {
-  border-top: 1px solid $color-border-default;
-  padding-top: $spacing-8;
-  margin-bottom: $spacing-10;
-
-  .kbEyebrow {
-    @include text-label-mono;
-    margin-bottom: $spacing-3;
-  }
-
-  .kbTitle {
-    @include heading-h2;
-    color: $neutral-900;
-    margin-bottom: $spacing-4;
-    text-wrap: balance;
-  }
-
-  .kbDescription {
-    max-width: 40rem;
-    font-size: $font-size-base;
-    line-height: $line-height-relaxed;
-    color: $color-text-secondary;
-    margin: 0 0 $spacing-6;
-  }
-
-  .kbLinks {
-    @include cluster($spacing-6);
-
-    a {
-      font-family: $font-family-mono;
-      font-size: $font-size-sm;
-      letter-spacing: $letter-spacing-wide;
-      color: $color-link-default;
-      text-decoration: none;
-
-      &:hover {
-        color: $color-link-hover;
-        text-decoration: underline;
-        text-underline-offset: 3px;
-      }
-
-      &:focus-visible {
-        outline: 2px solid $color-interactive-primary-focus;
-        outline-offset: 3px;
-        border-radius: 2px;
-      }
-    }
-  }
-}
-
-// Primary CTA - lives in the hero so the knowledge base is one tap
-// from landing on any viewport (#278)
-.kbButton {
-  display: inline-flex;
-  align-items: center;
+// ===== KNOWLEDGE BASE CARD =====
+// The one primary action on the page: a clickable card nestled beside
+// the intro, above the fold on every viewport (#278)
+.kbCard {
+  display: flex;
+  flex-direction: column;
   gap: $spacing-2;
-  margin-bottom: $spacing-6;
-  padding: $spacing-3 $spacing-6;
-  border-radius: $border-radius-button;
-  font-size: $font-size-base;
-  font-weight: $font-weight-semibold;
+  padding: $spacing-5;
+  border: 1px solid $color-border-default;
+  border-left: 3px solid $color-interactive-primary;
+  border-radius: $border-radius-lg;
+  background-color: $color-surface-default;
   text-decoration: none;
-  color: $color-interactive-primary-text;
-  background-color: $color-interactive-primary;
   box-shadow: $shadow-button;
   transition:
-    background-color 0.2s ease,
+    border-color 0.2s ease,
     box-shadow 0.2s ease,
     transform 0.2s ease;
 
   &:hover {
-    background-color: $color-interactive-primary-hover;
+    border-color: $color-interactive-primary;
     box-shadow: $shadow-button-hover;
-    transform: translateY(-1px);
+    transform: translateY(-2px);
+
+    .kbCardArrow {
+      transform: translateX(3px);
+    }
   }
 
   &:focus-visible {
@@ -185,7 +154,31 @@
     &:hover {
       transform: none;
     }
+
+    .kbCardArrow {
+      transition: none;
+    }
   }
+}
+
+.kbCardTitle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $spacing-2;
+  font-size: $font-size-lg;
+  font-weight: $font-weight-semibold;
+  color: $color-text-heading;
+}
+
+.kbCardArrow {
+  color: $color-interactive-primary;
+  transition: transform 0.2s ease;
+}
+
+.kbCardDescription {
+  @include text-secondary;
+  line-height: $line-height-relaxed;
 }
 
 // ===== OTHER SECTIONS =====

--- a/frontend/src/app/page.module.scss
+++ b/frontend/src/app/page.module.scss
@@ -11,32 +11,30 @@
   background-color: $color-page-bg;
 }
 
-.themeCorner {
-  position: absolute;
-  top: $spacing-4;
-  right: $spacing-4;
-}
-
 .main {
   @include container;
   max-width: 52rem;
-  padding-top: $spacing-12;
+  padding-top: $spacing-8;
   padding-bottom: $spacing-8;
-
-  @media (max-width: 640px) {
-    // Clear the theme toggle pinned to the top-right corner
-    padding-top: $spacing-12;
-  }
 }
 
 // ===== HERO SECTION =====
 .hero {
   margin-bottom: $spacing-12;
 
+  // Eyebrow and theme toggle share the top line, in flow on every viewport
+  .heroTopRow {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: $spacing-4;
+    margin-bottom: $spacing-3;
+  }
+
   .eyebrow {
     @include text-label-mono;
     color: $color-link-hover;
-    margin-bottom: $spacing-3;
+    margin: 0;
   }
 
   .title {
@@ -57,18 +55,15 @@
 
   .bio {
     max-width: 40rem;
-    font-size: $font-size-lg;
+    font-size: $font-size-base;
     line-height: $line-height-relaxed;
     color: $color-text-secondary;
     margin: 0 0 $spacing-6;
-
-    @media (max-width: 640px) {
-      font-size: $font-size-base;
-    }
   }
 }
 
-// Intro column + KB card share the space under the name (#278)
+// Intro column + KB card share the space under the name (#278).
+// The card column is wide and the gap modest so it tucks under the name.
 .heroGrid {
   display: grid;
   grid-template-columns: 1fr;
@@ -76,8 +71,8 @@
   align-items: start;
 
   @media (min-width: 768px) {
-    grid-template-columns: minmax(0, 1fr) 19rem;
-    gap: $spacing-10;
+    grid-template-columns: minmax(0, 1fr) 22rem;
+    gap: $spacing-8;
   }
 }
 
@@ -181,35 +176,16 @@
   line-height: $line-height-relaxed;
 }
 
-// ===== OTHER SECTIONS =====
-.projectsLink {
-  margin-bottom: $spacing-8;
-
-  a {
-    @include link-default;
-    color: $color-text-secondary;
-    font-size: $font-size-sm;
-
-    &:hover {
-      color: $color-primary;
-    }
-  }
-}
-
+// ===== FOOTER =====
 .footer {
   margin-top: $spacing-8;
   padding: $spacing-6 0;
   border-top: 1px solid $color-border-default;
-  @include text-secondary;
-
-  p {
-    margin-bottom: $spacing-2;
-  }
 
   .copyright {
     font-family: $font-family-mono;
     font-size: $font-size-xs;
     color: $color-text-tertiary;
-    margin-top: $spacing-2;
+    margin: 0;
   }
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,15 +6,15 @@ import styles from "./page.module.scss";
 export default function Home() {
   return (
     <div className={styles.container}>
-      <div className={styles.themeCorner}>
-        <ThemeToggle />
-      </div>
       <main className={styles.main}>
         {/* Hero: name spans the page, the columns below share the space */}
         <header className={styles.hero}>
-          <p className={styles.eyebrow}>
-            {siteConfig.author.title} — {siteConfig.author.location}
-          </p>
+          <div className={styles.heroTopRow}>
+            <p className={styles.eyebrow}>
+              {siteConfig.author.title} — {siteConfig.author.location}
+            </p>
+            <ThemeToggle />
+          </div>
           <h1 className={styles.title}>{siteConfig.author.fullTitle}</h1>
           <div className={styles.rule} aria-hidden="true" />
 
@@ -47,19 +47,9 @@ export default function Home() {
           </div>
         </header>
 
-        {/* Other Projects Link */}
-        <div className={styles.projectsLink}>
-          <a href={siteConfig.links.github} target="_blank" rel="noopener noreferrer">
-            View more projects on GitHub →
-          </a>
-        </div>
-
         {/* Footer note */}
         <footer className={styles.footer}>
-          <p>Built with Next.js, FastAPI, and Python</p>
-          <p className={styles.copyright}>
-            © 2025 {siteConfig.author.name} • {siteConfig.author.location}
-          </p>
+          <p className={styles.copyright}>© 2025 {siteConfig.author.name}</p>
         </footer>
       </main>
     </div>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -10,56 +10,42 @@ export default function Home() {
         <ThemeToggle />
       </div>
       <main className={styles.main}>
-        {/* Hero Section */}
+        {/* Hero: name spans the page, the columns below share the space */}
         <header className={styles.hero}>
           <p className={styles.eyebrow}>
             {siteConfig.author.title} — {siteConfig.author.location}
           </p>
           <h1 className={styles.title}>{siteConfig.author.fullTitle}</h1>
           <div className={styles.rule} aria-hidden="true" />
-          <p className={styles.bio}>{siteConfig.author.bio}</p>
 
-          <Link href="/knowledge-base" className={styles.kbButton}>
-            Explore the knowledge base
-            <svg
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              width="18"
-              height="18"
-              aria-hidden="true"
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-            </svg>
-          </Link>
+          <div className={styles.heroGrid}>
+            <div className={styles.heroIntro}>
+              <p className={styles.bio}>{siteConfig.author.bio}</p>
 
-          <nav className={styles.socialLinks} aria-label="Social links">
-            <a href={siteConfig.links.github} target="_blank" rel="noopener noreferrer">
-              github ↗
-            </a>
-            <a href={siteConfig.links.linkedin} target="_blank" rel="noopener noreferrer">
-              linkedin ↗
-            </a>
-            <a href={siteConfig.links.email}>email ↗</a>
-          </nav>
+              <nav className={styles.socialLinks} aria-label="Social links">
+                <a href={siteConfig.links.github} target="_blank" rel="noopener noreferrer">
+                  github ↗
+                </a>
+                <a href={siteConfig.links.linkedin} target="_blank" rel="noopener noreferrer">
+                  linkedin ↗
+                </a>
+                <a href={siteConfig.links.email}>email ↗</a>
+              </nav>
+            </div>
+
+            <Link href="/knowledge-base" className={styles.kbCard}>
+              <span className={styles.kbCardTitle}>
+                Knowledge base
+                <span className={styles.kbCardArrow} aria-hidden="true">
+                  →
+                </span>
+              </span>
+              <span className={styles.kbCardDescription}>
+                A curated digital garden of engineering and leadership insights.
+              </span>
+            </Link>
+          </div>
         </header>
-
-        {/* Knowledge Base Section */}
-        <section className={styles.kbSection}>
-          <p className={styles.kbEyebrow}>Knowledge base</p>
-          <h2 className={styles.kbTitle}>Part published blog, part digital garden</h2>
-          <p className={styles.kbDescription}>
-            A curated collection of engineering and leadership insights. Long-form articles on
-            topics I&apos;m passionate about, alongside quick-reference notes and interconnected
-            thoughts following a Zettelkasten approach — from technical deep-dives to frameworks
-            like &quot;The 5 Dysfunctions of a Team&quot; and Daniel Pink&apos;s motivation triad.
-          </p>
-          <nav className={styles.kbLinks} aria-label="Knowledge base sections">
-            <Link href="/knowledge-base/articles">Browse articles →</Link>
-            <Link href="/knowledge-base/notes">Browse notes →</Link>
-            <Link href="/knowledge-base/notes/graph">View the graph →</Link>
-          </nav>
-        </section>
 
         {/* Other Projects Link */}
         <div className={styles.projectsLink}>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { siteConfig } from "@/lib/site-config";
 import ThemeToggle from "@/components/ThemeToggle";
 import styles from "./page.module.scss";
@@ -17,6 +18,20 @@ export default function Home() {
           <h1 className={styles.title}>{siteConfig.author.fullTitle}</h1>
           <div className={styles.rule} aria-hidden="true" />
           <p className={styles.bio}>{siteConfig.author.bio}</p>
+
+          <Link href="/knowledge-base" className={styles.kbButton}>
+            Explore the knowledge base
+            <svg
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              width="18"
+              height="18"
+              aria-hidden="true"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </Link>
 
           <nav className={styles.socialLinks} aria-label="Social links">
             <a href={siteConfig.links.github} target="_blank" rel="noopener noreferrer">
@@ -39,19 +54,11 @@ export default function Home() {
             thoughts following a Zettelkasten approach — from technical deep-dives to frameworks
             like &quot;The 5 Dysfunctions of a Team&quot; and Daniel Pink&apos;s motivation triad.
           </p>
-          <a href="/knowledge-base" className={styles.kbButton}>
-            Explore the knowledge base
-            <svg
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              width="18"
-              height="18"
-              aria-hidden="true"
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-            </svg>
-          </a>
+          <nav className={styles.kbLinks} aria-label="Knowledge base sections">
+            <Link href="/knowledge-base/articles">Browse articles →</Link>
+            <Link href="/knowledge-base/notes">Browse notes →</Link>
+            <Link href="/knowledge-base/notes/graph">View the graph →</Link>
+          </nav>
         </section>
 
         {/* Other Projects Link */}

--- a/frontend/src/components/AIPanel.module.scss
+++ b/frontend/src/components/AIPanel.module.scss
@@ -19,13 +19,18 @@
   border-left: $border-default;
   background-color: $white;
 
-  // Desktop: right-side panel (24rem = 384px)
+  // Desktop: right-side panel
   @media (min-width: 768px) {
     inset: auto;
     right: 0;
     top: 0;
     height: 100vh;
-    width: 24rem;
+    width: 26rem;
+  }
+
+  // Wide desktop: more breathing room for conversations
+  @media (min-width: 1280px) {
+    width: 30rem;
   }
 }
 
@@ -131,11 +136,13 @@
 // ===== MODE SWITCHER =====
 .modeSwitcher {
   display: flex;
+  flex-wrap: wrap;
   gap: $spacing-2;
 }
 
 .modeButton {
   flex: 1;
+  min-width: 0;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -144,7 +151,17 @@
   border-radius: $border-radius-md;
   @include text-secondary;
   font-weight: $font-weight-medium;
+  white-space: nowrap;
   @include transition-default;
+
+  // 4 tabs (with Suggest) don't fit 390px with icons; text alone does
+  @media (max-width: 480px) {
+    padding: $spacing-2;
+
+    svg {
+      display: none;
+    }
+  }
 
   &.active {
     background-color: $color-interactive-primary;
@@ -236,6 +253,11 @@
   &.userMessage {
     background-color: $color-interactive-primary;
     color: $color-interactive-primary-text;
+
+    // text mixins on children set their own color; the bubble's must win
+    .messageContent {
+      color: inherit;
+    }
   }
 
   &.assistantMessage {
@@ -374,9 +396,13 @@
 }
 
 .clearButton {
+  display: block;
+  margin-left: auto;
   margin-bottom: $spacing-2;
-  @include text-tertiary;
+  @include text-meta-mono;
   color: $neutral-500;
+  text-decoration: underline;
+  text-underline-offset: 2px;
   @include transition-colors;
 
   &:hover {
@@ -391,10 +417,14 @@
 
 .input {
   flex: 1;
+  min-width: 0;
+  min-height: 2.75rem; // 44px touch target
   padding: $spacing-2 $spacing-3;
   border: $border-width-thin solid $neutral-300;
   border-radius: $border-radius-md;
   font-size: $font-size-base;
+  background-color: $color-input-bg;
+  color: $color-input-text;
 
   &:focus {
     outline: none;
@@ -408,11 +438,12 @@
 }
 
 .submitButton {
+  min-width: 4.5rem; // keeps size stable when the label changes
   padding: $spacing-2 $spacing-4;
   border-radius: $border-radius-md;
   @include text-secondary;
   background-color: $color-interactive-primary;
-  color: $color-interactive-primary-text;
+  color: $color-interactive-primary-text; // after the mixin: it sets its own color
   @include transition-default;
 
   &:hover:not(:disabled) {

--- a/frontend/src/components/AIPanel.tsx
+++ b/frontend/src/components/AIPanel.tsx
@@ -528,7 +528,7 @@ export default function AIPanel({ isOpen, onClose, defaultTab, suggest }: AIPane
               disabled={loading || !input.trim()}
               className={styles.submitButton}
             >
-              {loading ? "..." : tab === "ask" ? "Send" : "Search"}
+              {tab === "ask" ? "Send" : "Search"}
             </button>
           </form>
         </div>


### PR DESCRIPTION
## Summary

First batch of layout fixes from the comprehensive UI review (#278). Theme work (Phosphor Console dark theme + PDP-11/70 accents) follows in a separate PR.

### AI Assistant panel
- **Chat bubble contrast fix**: the user bubble's inner text was overridden to `text-secondary` (blue-grey) by the typography mixin — now inherits the bubble's on-primary color. This was the unreadable blue-on-orange text in both themes.
- All 4 mode tabs fit 390px (icons hidden <480px, wrap as safety net)
- Send button keeps its label while a request is pending and holds a stable width (no more brown "…" square)
- "Clear conversation" styled as a right-aligned mono metadata action
- Input gets a 44px touch target and explicit input bg/text tokens
- Desktop panel widens to 26rem (30rem ≥1280px)

### Note detail
- NOTE badge merged into the note-id row; mobile header padding 64→16px; title steps down to 2xl; meta collapses to mono — content now starts well above the fold on an iPhone 12 (was ~1.5 screens down)
- Button hierarchy per design system: Edit is the single filled primary; AI Suggestions becomes a teal outline; View in Graph / Delete thin to 1px ghosts

### Homepage
- New hero layout: name spans the page; bio + social links in a left column; clickable **Knowledge base** card ("A curated digital garden of engineering and leadership insights") tucked under the name on the right
- Theme toggle moved into the eyebrow row (in flow) — fixes the awkward floating corner placement on mobile
- Dropped "View more projects on GitHub" and the built-with footer line; footer is now a single copyright line
- Whole page fits one 390×844 screen in both themes

## Testing

- `make lint-frontend` ✓, `make typecheck-frontend` ✓, `make test-frontend` ✓ (121 tests, homepage tests updated for the new structure), prettier ✓
- Manual verification via Chrome DevTools at 390×844 (iPhone 12) and 1440×900, light + dark, screenshots reviewed for: AI panel (empty, pending, error states), note detail, notes list, homepage

Refs #278
