### PR TITLE
feat: Phosphor Console dark theme + PDP-11/70 accents (refs #278)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,12 +1,19 @@
 # Design System
 
 Mongado's visual identity: **future-retro, grey and orange**. Warm paper-grey
-surfaces, cool grey text, a single orange interactive accent, Space Grotesk
-for prose, Space Mono as the "terminal layer" for metadata. Dark mode is a
-warm dark-grey ground where the orange reads as amber phosphor.
+surfaces, cool grey text, a single warm interactive accent, Space Grotesk
+for prose, Space Mono as the "terminal layer" for metadata.
+
+Dark mode is the **Phosphor Console**: amber phosphor (`$phosphor-*`) on a
+warm charcoal ground, with identity accents borrowed from the DEC PDP-11/70
+front panel (`$pdp-crimson/berry/purple-*`, used by the `AddressLights`
+strip and never for interaction). Light mode keeps the cream ground and
+cool blue header gradient; its resting primary is the deeper
+`$orange-700` (the old resting `$orange-600` failed AA on white).
 
 Established in [#198](https://github.com/DEGoodman/mongado/issues/198) /
-[PR #199](https://github.com/DEGoodman/mongado/pull/199).
+[PR #199](https://github.com/DEGoodman/mongado/pull/199); Phosphor Console
+direction chosen in [#278](https://github.com/DEGoodman/mongado/issues/278).
 
 ## Token architecture
 
@@ -51,10 +58,12 @@ neutrals is automatically correct in both themes.
 
 | Role | Token | Rule |
 |---|---|---|
-| Interactive accent | `$color-interactive-primary` (orange) | Orange means "interact here" — one primary CTA per view, everything else is a ghost |
-| Links | `$color-link-default` / `-hover` | Orange; never blue |
+| Interactive accent | `$color-interactive-primary` (orange light / phosphor amber dark) | The accent means "interact here" — one primary *fill* per view |
+| Secondary actions | ghost buttons | Outlined, and may carry a quiet semantic hue: slate-blue for informational (View in Graph), error-crimson for destructive (Delete), teal for technical (AI). Fills stay reserved for the primary |
+| Links | `$color-link-default` / `-hover` | Orange/amber; never blue |
 | Cool accent | slate-blue | Informational surfaces only (KB headers, info panels) |
-| States | sage = success, mustard = warning, red = error, dusty-blue = info | Semantic only, never decorative |
+| States | sage = success, mustard = warning, crimson = error, dusty-blue = info | Semantic only, never decorative |
+| Identity accents | `--color-lights-*` (PDP crimson/berry/purple) | Decorative only — the `AddressLights` strip, never interactive |
 | Category identity | typography, not hue | See mono labels below |
 
 Selected/active chips use `$orange-700` background with `#fff` text (≥4.5:1

--- a/frontend/src/app/knowledge-base/notes/[id]/page.module.scss
+++ b/frontend/src/app/knowledge-base/notes/[id]/page.module.scss
@@ -136,23 +136,21 @@
     }
 
     .editButton {
-      background-color: $orange-600; // Warm primary action
-      color: white;
+      background-color: $color-interactive-primary; // Warm primary action
+      color: $color-interactive-primary-text;
 
       &:hover:not(:disabled) {
-        background-color: $orange-700;
+        background-color: $color-interactive-primary-hover;
       }
     }
 
     .deleteButton {
       background-color: transparent;
-      color: $red-600; // Red destructive action
-      border: 1px solid $red-600;
+      color: $color-error-text; // Destructive action, theme-aware
+      border: 1px solid $color-error-border;
 
       &:hover:not(:disabled) {
-        background-color: $red-50;
-        border-color: $red-700;
-        color: $red-700;
+        background-color: $color-error-bg;
       }
     }
 
@@ -217,12 +215,12 @@
   .backLink {
     display: inline-flex;
     margin-top: $spacing-4;
-    color: $orange-600; // Warm orange link
+    color: $color-link-default;
     text-decoration: none;
     @include text-secondary;
 
     &:hover {
-      color: $orange-700;
+      color: $color-link-hover;
       text-decoration: underline;
     }
   }

--- a/frontend/src/app/knowledge-base/page.module.scss
+++ b/frontend/src/app/knowledge-base/page.module.scss
@@ -34,7 +34,7 @@
 
     .title {
       @include heading-h1;
-      margin: 0;
+      margin: 0 0 $spacing-3;
     }
   }
 }

--- a/frontend/src/app/knowledge-base/page.tsx
+++ b/frontend/src/app/knowledge-base/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 
 import { useState, useEffect, useRef } from "react";
 import AIAssistant from "@/components/AIAssistant";
+import AddressLights from "@/components/AddressLights";
 import Badge from "@/components/Badge";
 import { logger } from "@/lib/logger";
 import { useFeatureFlags } from "@/hooks/useFeatureFlags";
@@ -135,6 +136,7 @@ export default function KnowledgeBasePage() {
       <header className={styles.header}>
         <div className={styles.headerContent}>
           <h1 className={styles.title}>Knowledge Base</h1>
+          <AddressLights />
         </div>
       </header>
 

--- a/frontend/src/app/page.module.scss
+++ b/frontend/src/app/page.module.scss
@@ -183,9 +183,22 @@
   border-top: 1px solid $color-border-default;
 
   .copyright {
+    display: flex;
+    align-items: center;
+    gap: $spacing-2;
     font-family: $font-family-mono;
     font-size: $font-size-xs;
     color: $color-text-tertiary;
     margin: 0;
+  }
+
+  // The PDP-11/70 nod: a tiny front-panel outline beside the copyright
+  .pdpGlyph {
+    display: inline-flex;
+    color: $color-text-tertiary;
+
+    svg {
+      display: block;
+    }
   }
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -49,7 +49,24 @@ export default function Home() {
 
         {/* Footer note */}
         <footer className={styles.footer}>
-          <p className={styles.copyright}>© 2025 {siteConfig.author.name}</p>
+          <p className={styles.copyright}>
+            <span className={styles.pdpGlyph} title="PDP-11/70">
+              <svg
+                viewBox="0 0 44 18"
+                width="34"
+                height="14"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.25"
+                aria-hidden="true"
+              >
+                <rect x="0.75" y="0.75" width="42.5" height="16.5" rx="2" />
+                <rect x="3.5" y="3.5" width="37" height="6" rx="1" />
+                <path d="M7 12.5v3.5M12 13.5v2.5M17 12.5v3.5M22 13.5v2.5M27 13.5v2.5M32 12.5v3.5M37 13.5v2.5" />
+              </svg>
+            </span>
+            © 2025 {siteConfig.author.name}
+          </p>
         </footer>
       </main>
     </div>

--- a/frontend/src/components/AddressLights.module.scss
+++ b/frontend/src/components/AddressLights.module.scss
@@ -1,0 +1,39 @@
+/**
+ * AddressLights - PDP-11/70 console strip (decorative, theme-aware).
+ */
+
+.lights {
+  display: flex;
+  gap: 5px;
+
+  @media (max-width: 480px) {
+    gap: 4px;
+  }
+}
+
+.segment {
+  flex: none;
+  width: 26px;
+  height: 6px;
+  border-radius: 2px;
+
+  @media (max-width: 480px) {
+    width: 16px;
+  }
+}
+
+.crimson {
+  background-color: var(--color-lights-crimson);
+}
+
+.berry {
+  background-color: var(--color-lights-berry);
+}
+
+.purple {
+  background-color: var(--color-lights-purple);
+}
+
+.off {
+  background-color: var(--color-lights-off);
+}

--- a/frontend/src/components/AddressLights.tsx
+++ b/frontend/src/components/AddressLights.tsx
@@ -1,0 +1,23 @@
+/**
+ * AddressLights - decorative strip of PDP-11/70 console "address lights".
+ *
+ * The site's nod to the DEC front panel (#278): lit segments in the
+ * console's crimson / berry / purple against unlit ground. Purely
+ * decorative; colors come from the theme's --color-lights-* tokens.
+ */
+
+import styles from "./AddressLights.module.scss";
+
+// Fixed pattern (deterministic for SSR): 0 = off, 1 = crimson, 2 = berry, 3 = purple
+const PATTERN = [1, 0, 2, 1, 0, 0, 3, 2, 0, 1, 0, 3, 0, 0, 2, 1] as const;
+const SEGMENT_CLASS = ["off", "crimson", "berry", "purple"] as const;
+
+export default function AddressLights() {
+  return (
+    <div className={styles.lights} aria-hidden="true">
+      {PATTERN.map((value, index) => (
+        <span key={index} className={`${styles.segment} ${styles[SEGMENT_CLASS[value]]}`} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/TopNavigation.module.scss
+++ b/frontend/src/components/TopNavigation.module.scss
@@ -73,8 +73,8 @@
   }
 
   &.active {
-    background-color: $orange-50;
-    color: $orange-700;
+    background-color: $color-interactive-primary-bg-subtle;
+    color: $color-interactive-ghost-text;
     font-weight: 600;
   }
 }

--- a/frontend/src/styles/design-tokens/_colors.scss
+++ b/frontend/src/styles/design-tokens/_colors.scss
@@ -57,6 +57,30 @@ $orange-700: #c2532a; // Hover state
 $orange-800: #9a4222; // Active state
 $orange-900: #73311a; // Darkest orange
 
+// === PHOSPHOR (Dark-mode Primary - CRT Amber) ===
+// The dark theme's interactive voice: amber phosphor on warm charcoal,
+// per the "Phosphor Console" direction (#278). Light mode keeps orange.
+$phosphor-50: #fbf4e6;
+$phosphor-100: #f5e6c6;
+$phosphor-200: #eed3a0;
+$phosphor-300: #e6bc7d;
+$phosphor-400: #e0a458; // Links / hover in dark mode
+$phosphor-500: #d9983f; // PRIMARY CTA fill in dark mode
+$phosphor-600: #c08432;
+$phosphor-700: #9c6a26;
+$phosphor-800: #7a521d;
+$phosphor-900: #573a14;
+
+// === PDP CONSOLE ACCENTS (Identity - address-lights strip) ===
+// From the PDP-11/70 front panel: crimson / berry / purple switch rows.
+// Decorative-identity only; never interactive.
+$pdp-crimson-400: #c25c66; // light theme lit segment
+$pdp-crimson-600: #a84a52; // dark theme lit segment
+$pdp-berry-400: #b05c8a;
+$pdp-berry-600: #a04a78;
+$pdp-purple-400: #8a6b9c;
+$pdp-purple-600: #6d4a78;
+
 // === TERRACOTTA (Secondary - Warm) ===
 // Earthy, sophisticated
 $terracotta-50: #fff5f2; // Very light terracotta

--- a/frontend/src/styles/themes.scss
+++ b/frontend/src/styles/themes.scss
@@ -34,12 +34,14 @@
   --color-border-strong: #{$neutral-cool-400};
   --color-border-hover: #{$neutral-cool-400};
   --color-border-cool: #{$slate-blue-200};
-  --color-interactive-primary: #{$orange-600};
-  --color-interactive-primary-hover: #{$orange-700};
-  --color-interactive-primary-active: #{$orange-800};
+  // Resting primary is the deeper orange (AA on white; the old resting
+  // $orange-600 measured 3.4:1) - approved in the #278 theme review
+  --color-interactive-primary: #{$orange-700};
+  --color-interactive-primary-hover: #{$orange-800};
+  --color-interactive-primary-active: #{$orange-900};
   --color-interactive-primary-text: #{$white};
   --color-interactive-primary-bg-subtle: #{$orange-50};
-  --color-interactive-primary-focus: #{$orange-600};
+  --color-interactive-primary-focus: #{$orange-700};
   --color-interactive-secondary: #{$terracotta-600};
   --color-interactive-secondary-hover: #{$terracotta-700};
   --color-interactive-secondary-active: #{$terracotta-800};
@@ -57,12 +59,12 @@
   --color-interactive-tertiary-bg: #{$neutral-100};
   --color-interactive-ghost: #{transparent};
   --color-interactive-ghost-hover: #{$orange-50};
-  --color-interactive-ghost-text: #{$orange-600};
-  --color-interactive-ghost-text-hover: #{$orange-700};
-  --color-link-default: #{$orange-600};
-  --color-link-hover: #{$orange-700};
+  --color-interactive-ghost-text: #{$orange-700};
+  --color-interactive-ghost-text-hover: #{$orange-800};
+  --color-link-default: #{$orange-700};
+  --color-link-hover: #{$orange-800};
   --color-link-visited: #{$terracotta-700};
-  --color-link-active: #{$orange-800};
+  --color-link-active: #{$orange-900};
   --color-link-cool: #{$teal-600};
   --color-link-cool-hover: #{$teal-700};
   --color-link-cool-visited: #{$slate-blue-700};
@@ -181,88 +183,94 @@
   --color-header-bg-mid: #{$slate-blue-100};
   --color-header-bg-end: #{rgba($slate-blue-50, 0.7)};
   --color-header-border: #{$slate-blue-300};
+
+  // === PDP ADDRESS LIGHTS ===
+  --color-lights-crimson: #{$pdp-crimson-400};
+  --color-lights-berry: #{$pdp-berry-400};
+  --color-lights-purple: #{$pdp-purple-400};
+  --color-lights-off: #{$slate-blue-100};
 }
 
 // Dark theme: explicit user choice via the toggle
 :root[data-theme="dark"] {
   color-scheme: dark;
 
-  // === PAGE STRUCTURE ===
-  --color-page-bg: #1b1d22;
-  --color-page-bg-gradient-start: #1b1d22;
-  --color-page-bg-gradient-end: #1e2127;
-  --color-page-bg-alt: #22252b;
+  // === PAGE STRUCTURE (warm charcoal, faint warm-to-cool wash) ===
+  --color-page-bg: #201c17;
+  --color-page-bg-gradient-start: #201c17;
+  --color-page-bg-gradient-end: #1b1c22;
+  --color-page-bg-alt: #242019;
 
   // === SURFACES ===
-  --color-surface-default: #24272e;
-  --color-surface-secondary: #22252b;
-  --color-surface-tertiary: #2a2d34;
-  --color-surface-elevated: #282c34;
-  --color-surface-hover: #2c3038;
-  --color-surface-cool: #262b33;
-  --color-surface-hover-cool: #2a313a;
+  --color-surface-default: #262320;
+  --color-surface-secondary: #242019;
+  --color-surface-tertiary: #2b2721;
+  --color-surface-elevated: #2a2621;
+  --color-surface-hover: #2f2a24;
+  --color-surface-cool: #252830;
+  --color-surface-hover-cool: #2a2d36;
 
-  // === TEXT ===
-  --color-text-primary: #e8e9ec;
-  --color-text-secondary: #b4b7be;
-  --color-text-tertiary: #8f929a;
-  --color-text-heading: #dddee2;
-  --color-text-disabled: #6e7178;
-  --color-text-inverse: #1b1d22;
-  --color-text-warm: #48453d;
+  // === TEXT (warm off-whites) ===
+  --color-text-primary: #eae7e1;
+  --color-text-secondary: #b8b2a8;
+  --color-text-tertiary: #a29a8c;
+  --color-text-heading: #e6e2da;
+  --color-text-disabled: #6e675c;
+  --color-text-inverse: #201c17;
+  --color-text-warm: #4a443a;
 
   // === BORDERS ===
-  --color-border-default: #34373f;
-  --color-border-subtle: #2e3138;
-  --color-border-strong: #565a64;
-  --color-border-hover: #6b7078;
+  --color-border-default: #38332d;
+  --color-border-subtle: #322d27;
+  --color-border-strong: #5c554a;
+  --color-border-hover: #6e6659;
   --color-border-cool: #3a4250;
 
-  // === INTERACTIVE: PRIMARY (phosphor orange) ===
-  --color-interactive-primary: #{$orange-500};
-  --color-interactive-primary-hover: #{$orange-400};
-  --color-interactive-primary-active: #{$orange-300};
-  --color-interactive-primary-text: #1b1d22;
-  --color-interactive-primary-bg-subtle: #3a2a1e;
-  --color-interactive-primary-focus: #{$orange-400};
+  // === INTERACTIVE: PRIMARY (phosphor amber) ===
+  --color-interactive-primary: #{$phosphor-500};
+  --color-interactive-primary-hover: #{$phosphor-400};
+  --color-interactive-primary-active: #{$phosphor-300};
+  --color-interactive-primary-text: #201a10;
+  --color-interactive-primary-bg-subtle: #352a18;
+  --color-interactive-primary-focus: #{$phosphor-400};
 
   // === INTERACTIVE: SECONDARY ===
   --color-interactive-secondary: #{$terracotta-500};
   --color-interactive-secondary-hover: #{$terracotta-400};
   --color-interactive-secondary-active: #{$terracotta-300};
-  --color-interactive-secondary-text: #1b1d22;
+  --color-interactive-secondary-text: #201c17;
   --color-interactive-secondary-bg: #362420;
 
   --color-interactive-secondary-cool: #{$teal-500};
   --color-interactive-secondary-cool-hover: #{$teal-400};
   --color-interactive-secondary-cool-active: #{$teal-300};
-  --color-interactive-secondary-cool-text: #1b1d22;
+  --color-interactive-secondary-cool-text: #201c17;
   --color-interactive-secondary-cool-bg: #1e2e2b;
 
   // === INTERACTIVE: TERTIARY / GHOST ===
-  --color-interactive-tertiary: #2a2d34;
-  --color-interactive-tertiary-hover: #34373f;
-  --color-interactive-tertiary-active: #3e424b;
-  --color-interactive-tertiary-text: #d5d6da;
-  --color-interactive-tertiary-bg: #2a2d34;
+  --color-interactive-tertiary: #2b2721;
+  --color-interactive-tertiary-hover: #38332d;
+  --color-interactive-tertiary-active: #453f36;
+  --color-interactive-tertiary-text: #d6d0c7;
+  --color-interactive-tertiary-bg: #2b2721;
 
   --color-interactive-ghost: transparent;
-  --color-interactive-ghost-hover: #3a2a1e;
-  --color-interactive-ghost-text: #{$orange-400};
-  --color-interactive-ghost-text-hover: #{$orange-300};
+  --color-interactive-ghost-hover: #352a18;
+  --color-interactive-ghost-text: #{$phosphor-400};
+  --color-interactive-ghost-text-hover: #{$phosphor-300};
 
   // === LINKS (phosphor amber) ===
-  --color-link-default: #{$orange-400};
-  --color-link-hover: #{$orange-300};
+  --color-link-default: #{$phosphor-400};
+  --color-link-hover: #{$phosphor-300};
   --color-link-visited: #{$terracotta-400};
-  --color-link-active: #{$orange-200};
+  --color-link-active: #{$phosphor-200};
 
   --color-link-cool: #{$teal-400};
   --color-link-cool-hover: #{$teal-300};
   --color-link-cool-visited: #{$slate-blue-400};
 
-  // === SEMANTIC STATES ===
-  --color-success-bg: #24312a;
+  // === SEMANTIC STATES (console indicator lamps) ===
+  --color-success-bg: #252e23;
   --color-success-border: #{$sage-600};
   --color-success-text: #{$sage-400};
 
@@ -270,26 +278,26 @@
   --color-warning-border: #{$mustard-600};
   --color-warning-text: #{$mustard-400};
 
-  --color-error-bg: #33211f;
-  --color-error-border: #{$red-600};
-  --color-error-text: #e89b94;
+  --color-error-bg: #33201f;
+  --color-error-border: #7a3d44;
+  --color-error-text: #e0949c;
 
-  --color-info-bg: #22303c;
-  --color-info-border: #{$dusty-blue-700};
-  --color-info-text: #{$dusty-blue-300};
+  --color-info-bg: #242a35;
+  --color-info-border: #3d4b63;
+  --color-info-text: #a9bad6;
 
   --color-info-cool-bg: #262e3a;
   --color-info-cool-border: #{$slate-blue-700};
   --color-info-cool-text: #{$slate-blue-300};
 
   // === BADGES ===
-  --color-badge-article-bg: #3a2a1e;
-  --color-badge-article-text: #{$orange-300};
-  --color-badge-article-border: #{$orange-800};
+  --color-badge-article-bg: #352a18;
+  --color-badge-article-text: #{$phosphor-300};
+  --color-badge-article-border: #8b6a2d;
 
-  --color-badge-note-bg: #2a2d34;
-  --color-badge-note-text: #b4b7be;
-  --color-badge-note-border: #565a64;
+  --color-badge-note-bg: #2b2721;
+  --color-badge-note-text: #b8b2a8;
+  --color-badge-note-border: #5c554a;
 
   --color-badge-note-cool-bg: #1e2e2b;
   --color-badge-note-cool-text: #{$teal-300};
@@ -311,14 +319,14 @@
   --color-tag-note-hover-border: #{$teal-600};
 
   // === FORM ELEMENTS ===
-  --color-input-bg: #22252b;
-  --color-input-border: #34373f;
-  --color-input-border-hover: #565a64;
-  --color-input-border-focus: #{$orange-400};
-  --color-input-text: #e8e9ec;
-  --color-input-placeholder: #8f929a;
-  --color-input-disabled-bg: #2a2d34;
-  --color-input-disabled-text: #6e7178;
+  --color-input-bg: #242019;
+  --color-input-border: #38332d;
+  --color-input-border-hover: #5c554a;
+  --color-input-border-focus: #{$phosphor-400};
+  --color-input-text: #eae7e1;
+  --color-input-placeholder: #a29a8c;
+  --color-input-disabled-bg: #2b2721;
+  --color-input-disabled-text: #6e675c;
 
   // === QUICK LISTS ===
   --color-orphan-bg: #322b1c;
@@ -340,53 +348,59 @@
   --color-central-hover: #3e2a25;
 
   // === SOCIAL ===
-  --color-social-github-bg: #2a2d34;
-  --color-social-github-bg-hover: #34373f;
-  --color-social-github-text: #e8e9ec;
+  --color-social-github-bg: #2b2721;
+  --color-social-github-bg-hover: #38332d;
+  --color-social-github-text: #eae7e1;
   --color-social-linkedin-bg: #{$slate-blue-700};
   --color-social-linkedin-bg-hover: #{$slate-blue-600};
-  --color-social-linkedin-text: #e8e9ec;
-  --color-social-email-bg: #2a2d34;
-  --color-social-email-bg-hover: #34373f;
-  --color-social-email-text: #e8e9ec;
-  --color-social-email-border: #454952;
+  --color-social-linkedin-text: #eae7e1;
+  --color-social-email-bg: #2b2721;
+  --color-social-email-bg-hover: #38332d;
+  --color-social-email-text: #eae7e1;
+  --color-social-email-border: #4a443a;
 
   // === DISABLED ===
-  --color-disabled-bg: #3e424b;
-  --color-disabled-text: #6e7178;
+  --color-disabled-bg: #453f36;
+  --color-disabled-text: #6e675c;
 
-  // === NEUTRAL RAMP (flipped) ===
-  --neutral-50: #22252b;
-  --neutral-100: #262a31;
-  --neutral-200: #34373f;
-  --neutral-300: #454952;
-  --neutral-400: #8a8e98;
-  --neutral-500: #a5a8b0;
-  --neutral-600: #c0c2c8;
-  --neutral-700: #d5d6da;
-  --neutral-800: #e8e9ec;
-  --neutral-900: #f4f4f6;
-  --white: #24272e;
-  --gray-50: #22252b;
-  --gray-100: #262a31;
+  // === NEUTRAL RAMP (flipped, warm) ===
+  --neutral-50: #242019;
+  --neutral-100: #282420;
+  --neutral-200: #38332d;
+  --neutral-300: #4a443a;
+  --neutral-400: #948c7e;
+  --neutral-500: #a89f90;
+  --neutral-600: #c2bab0;
+  --neutral-700: #d6d0c7;
+  --neutral-800: #eae7e1;
+  --neutral-900: #f5f3ef;
+  --white: #262320;
+  --gray-50: #242019;
+  --gray-100: #282420;
+
+  // === PDP ADDRESS LIGHTS ===
+  --color-lights-crimson: #{$pdp-crimson-600};
+  --color-lights-berry: #{$pdp-berry-600};
+  --color-lights-purple: #{$pdp-purple-600};
+  --color-lights-off: #2a2622;
 
   // === BACKWARD-COMPAT ALIASES ===
-  --color-bg-canvas: #1b1d22;
-  --color-bg-secondary: #2a2d34;
-  --color-bg-card: #24272e;
-  --color-bg-cool: #1b1d22;
-  --color-border: #34373f;
-  --color-primary: #{$orange-500};
-  --color-primary-hover: #{$orange-400};
-  --color-primary-active: #{$orange-300};
-  --color-primary-light: #3a2a1e;
-  --color-primary-dark: #{$orange-300};
+  --color-bg-canvas: #201c17;
+  --color-bg-secondary: #2b2721;
+  --color-bg-card: #262320;
+  --color-bg-cool: #201c17;
+  --color-border: #38332d;
+  --color-primary: #{$phosphor-500};
+  --color-primary-hover: #{$phosphor-400};
+  --color-primary-active: #{$phosphor-300};
+  --color-primary-light: #352a18;
+  --color-primary-dark: #{$phosphor-300};
   --color-secondary: #{$terracotta-400};
   --color-secondary-hover: #{$terracotta-300};
   --color-secondary-light: #362420;
   --color-accent-blue: #{$dusty-blue-400};
-  --color-accent-blue-light: #22303c;
-  --color-accent-blue-border: #2e4152;
+  --color-accent-blue-light: #242a35;
+  --color-accent-blue-border: #3d4b63;
   --color-accent-blue-dark: #{$dusty-blue-300};
   --color-accent-purple: #{$terracotta-400};
   --color-accent-purple-light: #362420;
@@ -394,13 +408,13 @@
   --color-accent-purple-dark: #{$terracotta-300};
   --color-success: #{$sage-400};
   --color-warning: #{$mustard-400};
-  --color-info: #{$dusty-blue-300};
+  --color-info: #a9bad6;
 
-  // === KB HEADER ZONE ===
-  --color-header-bg-start: #262b33;
-  --color-header-bg-mid: #22262d;
-  --color-header-bg-end: #1e2127;
-  --color-header-border: #34373f;
+  // === KB HEADER ZONE (warm console panel) ===
+  --color-header-bg-start: #2b2620;
+  --color-header-bg-mid: #252220;
+  --color-header-bg-end: #1f1e20;
+  --color-header-border: #4a4128;
 }
 
 // Dark theme: OS preference, when the user has not chosen explicitly
@@ -408,82 +422,82 @@
   :root:not([data-theme="light"]) {
     color-scheme: dark;
 
-    // === PAGE STRUCTURE ===
-    --color-page-bg: #1b1d22;
-    --color-page-bg-gradient-start: #1b1d22;
-    --color-page-bg-gradient-end: #1e2127;
-    --color-page-bg-alt: #22252b;
+    // === PAGE STRUCTURE (warm charcoal, faint warm-to-cool wash) ===
+    --color-page-bg: #201c17;
+    --color-page-bg-gradient-start: #201c17;
+    --color-page-bg-gradient-end: #1b1c22;
+    --color-page-bg-alt: #242019;
 
     // === SURFACES ===
-    --color-surface-default: #24272e;
-    --color-surface-secondary: #22252b;
-    --color-surface-tertiary: #2a2d34;
-    --color-surface-elevated: #282c34;
-    --color-surface-hover: #2c3038;
-    --color-surface-cool: #262b33;
-    --color-surface-hover-cool: #2a313a;
+    --color-surface-default: #262320;
+    --color-surface-secondary: #242019;
+    --color-surface-tertiary: #2b2721;
+    --color-surface-elevated: #2a2621;
+    --color-surface-hover: #2f2a24;
+    --color-surface-cool: #252830;
+    --color-surface-hover-cool: #2a2d36;
 
-    // === TEXT ===
-    --color-text-primary: #e8e9ec;
-    --color-text-secondary: #b4b7be;
-    --color-text-tertiary: #8f929a;
-    --color-text-heading: #dddee2;
-    --color-text-disabled: #6e7178;
-    --color-text-inverse: #1b1d22;
-    --color-text-warm: #48453d;
+    // === TEXT (warm off-whites) ===
+    --color-text-primary: #eae7e1;
+    --color-text-secondary: #b8b2a8;
+    --color-text-tertiary: #a29a8c;
+    --color-text-heading: #e6e2da;
+    --color-text-disabled: #6e675c;
+    --color-text-inverse: #201c17;
+    --color-text-warm: #4a443a;
 
     // === BORDERS ===
-    --color-border-default: #34373f;
-    --color-border-subtle: #2e3138;
-    --color-border-strong: #565a64;
-    --color-border-hover: #6b7078;
+    --color-border-default: #38332d;
+    --color-border-subtle: #322d27;
+    --color-border-strong: #5c554a;
+    --color-border-hover: #6e6659;
     --color-border-cool: #3a4250;
 
-    // === INTERACTIVE: PRIMARY (phosphor orange) ===
-    --color-interactive-primary: #{$orange-500};
-    --color-interactive-primary-hover: #{$orange-400};
-    --color-interactive-primary-active: #{$orange-300};
-    --color-interactive-primary-text: #1b1d22;
-    --color-interactive-primary-bg-subtle: #3a2a1e;
-    --color-interactive-primary-focus: #{$orange-400};
+    // === INTERACTIVE: PRIMARY (phosphor amber) ===
+    --color-interactive-primary: #{$phosphor-500};
+    --color-interactive-primary-hover: #{$phosphor-400};
+    --color-interactive-primary-active: #{$phosphor-300};
+    --color-interactive-primary-text: #201a10;
+    --color-interactive-primary-bg-subtle: #352a18;
+    --color-interactive-primary-focus: #{$phosphor-400};
 
     // === INTERACTIVE: SECONDARY ===
     --color-interactive-secondary: #{$terracotta-500};
     --color-interactive-secondary-hover: #{$terracotta-400};
     --color-interactive-secondary-active: #{$terracotta-300};
-    --color-interactive-secondary-text: #1b1d22;
+    --color-interactive-secondary-text: #201c17;
     --color-interactive-secondary-bg: #362420;
 
     --color-interactive-secondary-cool: #{$teal-500};
     --color-interactive-secondary-cool-hover: #{$teal-400};
     --color-interactive-secondary-cool-active: #{$teal-300};
-    --color-interactive-secondary-cool-text: #1b1d22;
+    --color-interactive-secondary-cool-text: #201c17;
     --color-interactive-secondary-cool-bg: #1e2e2b;
 
     // === INTERACTIVE: TERTIARY / GHOST ===
-    --color-interactive-tertiary: #2a2d34;
-    --color-interactive-tertiary-hover: #34373f;
-    --color-interactive-tertiary-active: #3e424b;
-    --color-interactive-tertiary-text: #d5d6da;
-    --color-interactive-tertiary-bg: #2a2d34;
+    --color-interactive-tertiary: #2b2721;
+    --color-interactive-tertiary-hover: #38332d;
+    --color-interactive-tertiary-active: #453f36;
+    --color-interactive-tertiary-text: #d6d0c7;
+    --color-interactive-tertiary-bg: #2b2721;
 
     --color-interactive-ghost: transparent;
-    --color-interactive-ghost-hover: #3a2a1e;
-    --color-interactive-ghost-text: #{$orange-400};
-    --color-interactive-ghost-text-hover: #{$orange-300};
+    --color-interactive-ghost-hover: #352a18;
+    --color-interactive-ghost-text: #{$phosphor-400};
+    --color-interactive-ghost-text-hover: #{$phosphor-300};
 
     // === LINKS (phosphor amber) ===
-    --color-link-default: #{$orange-400};
-    --color-link-hover: #{$orange-300};
+    --color-link-default: #{$phosphor-400};
+    --color-link-hover: #{$phosphor-300};
     --color-link-visited: #{$terracotta-400};
-    --color-link-active: #{$orange-200};
+    --color-link-active: #{$phosphor-200};
 
     --color-link-cool: #{$teal-400};
     --color-link-cool-hover: #{$teal-300};
     --color-link-cool-visited: #{$slate-blue-400};
 
-    // === SEMANTIC STATES ===
-    --color-success-bg: #24312a;
+    // === SEMANTIC STATES (console indicator lamps) ===
+    --color-success-bg: #252e23;
     --color-success-border: #{$sage-600};
     --color-success-text: #{$sage-400};
 
@@ -491,26 +505,26 @@
     --color-warning-border: #{$mustard-600};
     --color-warning-text: #{$mustard-400};
 
-    --color-error-bg: #33211f;
-    --color-error-border: #{$red-600};
-    --color-error-text: #e89b94;
+    --color-error-bg: #33201f;
+    --color-error-border: #7a3d44;
+    --color-error-text: #e0949c;
 
-    --color-info-bg: #22303c;
-    --color-info-border: #{$dusty-blue-700};
-    --color-info-text: #{$dusty-blue-300};
+    --color-info-bg: #242a35;
+    --color-info-border: #3d4b63;
+    --color-info-text: #a9bad6;
 
     --color-info-cool-bg: #262e3a;
     --color-info-cool-border: #{$slate-blue-700};
     --color-info-cool-text: #{$slate-blue-300};
 
     // === BADGES ===
-    --color-badge-article-bg: #3a2a1e;
-    --color-badge-article-text: #{$orange-300};
-    --color-badge-article-border: #{$orange-800};
+    --color-badge-article-bg: #352a18;
+    --color-badge-article-text: #{$phosphor-300};
+    --color-badge-article-border: #8b6a2d;
 
-    --color-badge-note-bg: #2a2d34;
-    --color-badge-note-text: #b4b7be;
-    --color-badge-note-border: #565a64;
+    --color-badge-note-bg: #2b2721;
+    --color-badge-note-text: #b8b2a8;
+    --color-badge-note-border: #5c554a;
 
     --color-badge-note-cool-bg: #1e2e2b;
     --color-badge-note-cool-text: #{$teal-300};
@@ -532,14 +546,14 @@
     --color-tag-note-hover-border: #{$teal-600};
 
     // === FORM ELEMENTS ===
-    --color-input-bg: #22252b;
-    --color-input-border: #34373f;
-    --color-input-border-hover: #565a64;
-    --color-input-border-focus: #{$orange-400};
-    --color-input-text: #e8e9ec;
-    --color-input-placeholder: #8f929a;
-    --color-input-disabled-bg: #2a2d34;
-    --color-input-disabled-text: #6e7178;
+    --color-input-bg: #242019;
+    --color-input-border: #38332d;
+    --color-input-border-hover: #5c554a;
+    --color-input-border-focus: #{$phosphor-400};
+    --color-input-text: #eae7e1;
+    --color-input-placeholder: #a29a8c;
+    --color-input-disabled-bg: #2b2721;
+    --color-input-disabled-text: #6e675c;
 
     // === QUICK LISTS ===
     --color-orphan-bg: #322b1c;
@@ -561,53 +575,59 @@
     --color-central-hover: #3e2a25;
 
     // === SOCIAL ===
-    --color-social-github-bg: #2a2d34;
-    --color-social-github-bg-hover: #34373f;
-    --color-social-github-text: #e8e9ec;
+    --color-social-github-bg: #2b2721;
+    --color-social-github-bg-hover: #38332d;
+    --color-social-github-text: #eae7e1;
     --color-social-linkedin-bg: #{$slate-blue-700};
     --color-social-linkedin-bg-hover: #{$slate-blue-600};
-    --color-social-linkedin-text: #e8e9ec;
-    --color-social-email-bg: #2a2d34;
-    --color-social-email-bg-hover: #34373f;
-    --color-social-email-text: #e8e9ec;
-    --color-social-email-border: #454952;
+    --color-social-linkedin-text: #eae7e1;
+    --color-social-email-bg: #2b2721;
+    --color-social-email-bg-hover: #38332d;
+    --color-social-email-text: #eae7e1;
+    --color-social-email-border: #4a443a;
 
     // === DISABLED ===
-    --color-disabled-bg: #3e424b;
-    --color-disabled-text: #6e7178;
+    --color-disabled-bg: #453f36;
+    --color-disabled-text: #6e675c;
 
-    // === NEUTRAL RAMP (flipped) ===
-    --neutral-50: #22252b;
-    --neutral-100: #262a31;
-    --neutral-200: #34373f;
-    --neutral-300: #454952;
-    --neutral-400: #8a8e98;
-    --neutral-500: #a5a8b0;
-    --neutral-600: #c0c2c8;
-    --neutral-700: #d5d6da;
-    --neutral-800: #e8e9ec;
-    --neutral-900: #f4f4f6;
-    --white: #24272e;
-    --gray-50: #22252b;
-    --gray-100: #262a31;
+    // === NEUTRAL RAMP (flipped, warm) ===
+    --neutral-50: #242019;
+    --neutral-100: #282420;
+    --neutral-200: #38332d;
+    --neutral-300: #4a443a;
+    --neutral-400: #948c7e;
+    --neutral-500: #a89f90;
+    --neutral-600: #c2bab0;
+    --neutral-700: #d6d0c7;
+    --neutral-800: #eae7e1;
+    --neutral-900: #f5f3ef;
+    --white: #262320;
+    --gray-50: #242019;
+    --gray-100: #282420;
+
+    // === PDP ADDRESS LIGHTS ===
+    --color-lights-crimson: #{$pdp-crimson-600};
+    --color-lights-berry: #{$pdp-berry-600};
+    --color-lights-purple: #{$pdp-purple-600};
+    --color-lights-off: #2a2622;
 
     // === BACKWARD-COMPAT ALIASES ===
-    --color-bg-canvas: #1b1d22;
-    --color-bg-secondary: #2a2d34;
-    --color-bg-card: #24272e;
-    --color-bg-cool: #1b1d22;
-    --color-border: #34373f;
-    --color-primary: #{$orange-500};
-    --color-primary-hover: #{$orange-400};
-    --color-primary-active: #{$orange-300};
-    --color-primary-light: #3a2a1e;
-    --color-primary-dark: #{$orange-300};
+    --color-bg-canvas: #201c17;
+    --color-bg-secondary: #2b2721;
+    --color-bg-card: #262320;
+    --color-bg-cool: #201c17;
+    --color-border: #38332d;
+    --color-primary: #{$phosphor-500};
+    --color-primary-hover: #{$phosphor-400};
+    --color-primary-active: #{$phosphor-300};
+    --color-primary-light: #352a18;
+    --color-primary-dark: #{$phosphor-300};
     --color-secondary: #{$terracotta-400};
     --color-secondary-hover: #{$terracotta-300};
     --color-secondary-light: #362420;
     --color-accent-blue: #{$dusty-blue-400};
-    --color-accent-blue-light: #22303c;
-    --color-accent-blue-border: #2e4152;
+    --color-accent-blue-light: #242a35;
+    --color-accent-blue-border: #3d4b63;
     --color-accent-blue-dark: #{$dusty-blue-300};
     --color-accent-purple: #{$terracotta-400};
     --color-accent-purple-light: #362420;
@@ -615,12 +635,12 @@
     --color-accent-purple-dark: #{$terracotta-300};
     --color-success: #{$sage-400};
     --color-warning: #{$mustard-400};
-    --color-info: #{$dusty-blue-300};
+    --color-info: #a9bad6;
 
-    // === KB HEADER ZONE ===
-    --color-header-bg-start: #262b33;
-    --color-header-bg-mid: #22262d;
-    --color-header-bg-end: #1e2127;
-    --color-header-border: #34373f;
+    // === KB HEADER ZONE (warm console panel) ===
+    --color-header-bg-start: #2b2620;
+    --color-header-bg-mid: #252220;
+    --color-header-bg-end: #1f1e20;
+    --color-header-border: #4a4128;
   }
 }


### PR DESCRIPTION
## Summary

Implements the **Phosphor Console** theme direction chosen in the #278 design review: CRT-amber interactive accent on a warm charcoal ground for dark mode, PDP-11/70 identity accents, and the approved light-mode AA fix.

### Dark mode — Phosphor Console
- New `$phosphor-*` Tier-1 scale; dark `interactive-primary`, links, ghosts, and focus move from `$orange-500` to phosphor amber
- All grounds/surfaces/borders/text/neutral-ramp values warmed from cool grey (`#1b1d22` family) to charcoal (`#201c17` family); faint warm→cool page gradient
- Semantic states restyled as console indicator lamps; error goes dusty crimson; badges + inputs warmed to match
- Both dark blocks in `themes.scss` (`data-theme` + `prefers-color-scheme`) updated in lockstep

### PDP-11/70 nods
- `$pdp-crimson/berry/purple-*` accents + `--color-lights-*` tokens (light + dark variants)
- New `AddressLights` component (decorative, deterministic pattern) under the Knowledge Base hub header
- Front-panel outline glyph (inline SVG, `title="PDP-11/70"`) beside the homepage copyright

### Light mode
- Resting primary + links promoted `$orange-600` → `$orange-700` (old resting orange measured 3.4:1 on white — AA fail; the new shade passes at 4.6:1), hover `$orange-800`
- Everything else unchanged

### Coherence
- Hardcoded `$orange-*`/`$red-*` converted to semantic tokens in the nav active pill and note-detail Edit/Delete/back-link so both themes stay coherent
- `docs/DESIGN.md` rewritten: Phosphor Console description, identity-accent row, and the loosened color rule (one primary *fill* per view; ghost buttons may carry quiet semantic hue)

## Testing
- `make lint-frontend` ✓, `make typecheck-frontend` ✓, `make test-frontend` ✓ (118 tests), prettier ✓
- Visual verification in Chrome at 1440×900 and 390×844, both themes: homepage, KB hub, note detail, AI panel

Refs #278
