### PR TITLE
fix(frontend): keep highlighted dropdown item centered while navigating (#285)

### DIFF
--- a/frontend/src/components/EditorDropdown.tsx
+++ b/frontend/src/components/EditorDropdown.tsx
@@ -6,9 +6,14 @@
  * the same absolutely-positioned-list-of-buttons shape and keyboard-nav
  * styling; NoteEditor.tsx owns the keyboard handling (Arrow/Enter/Escape)
  * and guarantees only one of the two is ever open at a time.
+ *
+ * As the caller moves `selectedIndex`, we scroll the highlighted item to the
+ * center of the visible window so it's always in view while navigating with
+ * the keyboard (#285). Centering (clamped by the browser) naturally pins the
+ * first item to the top and the last item to the bottom.
  */
 
-import { ReactNode } from "react";
+import { ReactNode, useEffect, useRef } from "react";
 import styles from "./NoteEditor.module.scss";
 
 export interface EditorDropdownItem {
@@ -25,16 +30,34 @@ interface EditorDropdownProps {
 }
 
 export default function EditorDropdown({ position, items, selectedIndex }: EditorDropdownProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  // Keep the highlighted item centered within the scroll window (#285).
+  useEffect(() => {
+    const container = containerRef.current;
+    const item = itemRefs.current[selectedIndex];
+    if (!container || !item) return;
+
+    // Center the item; the browser clamps scrollTop so the first item stays
+    // at the top and the last item stays at the bottom.
+    container.scrollTop = item.offsetTop - (container.clientHeight - item.offsetHeight) / 2;
+  }, [selectedIndex, items.length]);
+
   if (items.length === 0) return null;
 
   return (
     <div
+      ref={containerRef}
       className={styles.autocomplete}
       style={{ top: `${position.top}px`, left: `${position.left}px` }}
     >
       {items.map((item, index) => (
         <button
           key={item.key}
+          ref={(el) => {
+            itemRefs.current[index] = el;
+          }}
           type="button"
           onClick={item.onSelect}
           disabled={item.disabled}


### PR DESCRIPTION
Fixes #285.

## Problem
In the note editor, arrow keys moved the highlight in the `/` slash palette (and the `[[` wikilink autocomplete / AI-suggested links) but the dropdown didn't scroll to follow it — you had to take your hands off the keyboard to see what was selected.

## Change
One file: `frontend/src/components/EditorDropdown.tsx`, the shared component behind all three popups, so the fix applies everywhere at once.

- Added a container ref + per-item refs.
- On each `selectedIndex` change, set the container's `scrollTop` to **center** the highlighted item in the visible window. The browser clamps `scrollTop`, so this naturally pins the first item to the top and the last item to the bottom — making it clear whether there are more options above/below.

## Note
Item heights vary with content (wikilink items carry title + tags; slash items are name + description), so the existing `15rem` `max-height` shows ~3 of the taller items and a few more of the shorter ones. The centering behavior is correct regardless; if a hard three-item window is wanted, item heights would need to be uniform.

## Validation
- `tsc --noEmit` clean
- `next lint` clean
- 118 frontend tests pass