### PR TITLE
feat(frontend): shared compact KB header + randomized address lights (#282, #283, #284)

### DIFF
--- a/frontend/src/app/knowledge-base/articles/ArticlesClient.tsx
+++ b/frontend/src/app/knowledge-base/articles/ArticlesClient.tsx
@@ -7,6 +7,7 @@ import AIAssistant from "@/components/AIAssistant";
 import { EmptyState } from "@/components/PageState";
 import { useRouter, useSearchParams } from "next/navigation";
 import Breadcrumb from "@/components/Breadcrumb";
+import PageHeader from "@/components/PageHeader";
 import { TagPillList } from "@/components/TagPill";
 import { apiGet, isAuthenticated } from "@/lib/api/client";
 import { logger } from "@/lib/logger";
@@ -167,15 +168,7 @@ export default function ArticlesClient({ resources }: { resources: ArticleMetada
       {/* AI panel + button island (only shown when LLM features enabled) */}
       <AIAssistant />
 
-      {/* Header */}
-      <header className={styles.header}>
-        <div className={styles.headerContent}>
-          <div className={styles.breadcrumb}>
-            <Breadcrumb section="articles" toHub />
-          </div>
-          <h1 className={styles.title}>Articles</h1>
-        </div>
-      </header>
+      <PageHeader title="Articles" breadcrumb={<Breadcrumb section="articles" toHub />} />
 
       <main className={styles.main}>
         <div className={styles.contentGrid}>

--- a/frontend/src/app/knowledge-base/articles/page.module.scss
+++ b/frontend/src/app/knowledge-base/articles/page.module.scss
@@ -15,34 +15,6 @@
   );
 }
 
-// ===== HEADER =====
-.header {
-  // Cool slate blue header zone (consistent across KB)
-  background: linear-gradient(
-    to bottom,
-    var(--color-header-bg-start) 0%,
-    var(--color-header-bg-mid) 50%,
-    var(--color-header-bg-end) 100%
-  );
-  border-bottom: 1px solid var(--color-header-border);
-  box-shadow: $shadow-card-sm;
-
-  .headerContent {
-    @include container;
-    padding-top: $spacing-6;
-    padding-bottom: $spacing-6;
-
-    .breadcrumb {
-      margin-bottom: $spacing-4;
-    }
-
-    .title {
-      @include heading-h1;
-      margin: 0;
-    }
-  }
-}
-
 // ===== MAIN =====
 .main {
   @include container;
@@ -180,15 +152,16 @@
       }
 
       &.tagBadgeActive {
-        // Selected = interactive, so it takes the orange accent.
-        // orange-700 keeps white text at >4.5:1 contrast.
-        background-color: $orange-700;
-        border-color: $orange-800;
-        color: $white;
+        // Selected = interactive, so it takes the accent (theme-aware:
+        // orange in light, phosphor amber in dark). The text token flips
+        // to dark on amber, keeping >4.5:1 contrast in both themes.
+        background-color: $color-interactive-primary;
+        border-color: $color-interactive-primary-hover;
+        color: $color-interactive-primary-text;
 
         &:hover {
-          background-color: $orange-800;
-          border-color: $orange-900;
+          background-color: $color-interactive-primary-hover;
+          border-color: $color-interactive-primary-active;
         }
       }
 
@@ -231,7 +204,7 @@
   width: 100%;
   padding: $spacing-3 $spacing-4;
   background-color: $white;
-  border: $border-width-thin solid $orange-300;
+  border: $border-width-thin solid $color-link-default;
   border-radius: $border-radius-button;
   @include text-secondary;
   color: $color-link-default;
@@ -240,8 +213,8 @@
   transition: all 0.2s ease;
 
   &:hover {
-    background-color: $orange-50;
-    border-color: $orange-400;
+    background-color: $color-interactive-primary-bg-subtle;
+    border-color: $color-link-hover;
     color: $color-link-hover;
   }
 }

--- a/frontend/src/app/knowledge-base/inspire/page.module.scss
+++ b/frontend/src/app/knowledge-base/inspire/page.module.scss
@@ -17,93 +17,26 @@
 
 // ===== LOADING STATE =====
 // ===== ERROR STATE =====
-// ===== HEADER =====
-.header {
-  background: linear-gradient(
-    to bottom,
-    var(--color-header-bg-start) 0%,
-    var(--color-header-bg-mid) 50%,
-    var(--color-header-bg-end) 100%
-  );
-  border-bottom: 1px solid var(--color-header-border);
-  box-shadow: $shadow-card-sm;
+// ===== HEADER ACTION =====
+// Header shell lives in PageHeader; only the page-specific action remains.
+.refreshButton {
+  padding: $spacing-2 $spacing-4;
+  border: none;
+  border-radius: $border-radius-button;
+  background-color: $color-interactive-primary;
+  color: $color-interactive-primary-text;
+  font-weight: $font-weight-medium;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: all 0.2s ease;
 
-  .headerContent {
-    @include container;
-    padding-top: $spacing-6;
-    padding-bottom: $spacing-6;
+  &:hover:not(:disabled) {
+    background-color: $color-interactive-primary-hover;
   }
 
-  .headerTop {
-    margin-bottom: $spacing-4;
-  }
-
-  .titleRow {
-    @include flex-between;
-    align-items: flex-start;
-
-    @media (max-width: 640px) {
-      flex-direction: column;
-      gap: $spacing-4;
-    }
-
-    .titleSection {
-      .title {
-        @include heading-h1;
-        margin: 0;
-        color: $color-text-heading;
-
-        @media (max-width: 640px) {
-          font-size: $font-size-2xl;
-        }
-      }
-
-      .subtitle {
-        margin-top: $spacing-2;
-        color: $color-text-secondary;
-        font-size: $font-size-lg;
-
-        @media (max-width: 640px) {
-          font-size: $font-size-sm;
-        }
-      }
-    }
-
-    .actions {
-      @include flex-start;
-      gap: $spacing-3;
-      flex-shrink: 0;
-
-      @media (max-width: 640px) {
-        width: 100%;
-      }
-
-      .refreshButton {
-        padding: $spacing-2 $spacing-4;
-        border: none;
-        border-radius: $border-radius-button;
-        background-color: $color-interactive-primary;
-        color: $color-interactive-primary-text;
-        font-weight: $font-weight-medium;
-        cursor: pointer;
-        transition: all 0.2s ease;
-
-        @media (max-width: 640px) {
-          width: 100%;
-          padding: $spacing-3 $spacing-4;
-          font-size: $font-size-sm;
-        }
-
-        &:hover:not(:disabled) {
-          background-color: $color-interactive-primary-hover;
-        }
-
-        &:disabled {
-          opacity: 0.6;
-          cursor: not-allowed;
-        }
-      }
-    }
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
   }
 }
 

--- a/frontend/src/app/knowledge-base/inspire/page.tsx
+++ b/frontend/src/app/knowledge-base/inspire/page.tsx
@@ -16,6 +16,7 @@ import Link from "next/link";
 import { getSuggestions, Suggestion, SuggestionType } from "@/lib/api/inspire";
 import { logger } from "@/lib/logger";
 import Breadcrumb from "@/components/Breadcrumb";
+import PageHeader from "@/components/PageHeader";
 import { LoadingState, ErrorState } from "@/components/PageState";
 import styles from "./page.module.scss";
 
@@ -166,29 +167,16 @@ export default function InspirePage() {
 
   return (
     <div className={styles.container}>
-      {/* Header */}
-      <header className={styles.header}>
-        <div className={styles.headerContent}>
-          <div className={styles.headerTop}>
-            <Breadcrumb section="inspire" />
-          </div>
-          <div className={styles.titleRow}>
-            <div className={styles.titleSection}>
-              <h1 className={styles.title}>Inspire Me</h1>
-              <p className={styles.subtitle}>Suggestions to improve your knowledge base</p>
-            </div>
-            <div className={styles.actions}>
-              <button
-                onClick={handleRefresh}
-                disabled={refreshing}
-                className={styles.refreshButton}
-              >
-                {refreshing ? "Refreshing..." : "Refresh Suggestions"}
-              </button>
-            </div>
-          </div>
-        </div>
-      </header>
+      <PageHeader
+        title="Inspire Me"
+        subtitle="Suggestions to improve your knowledge base"
+        breadcrumb={<Breadcrumb section="inspire" />}
+        actions={
+          <button onClick={handleRefresh} disabled={refreshing} className={styles.refreshButton}>
+            {refreshing ? "Refreshing..." : "Refresh Suggestions"}
+          </button>
+        }
+      />
 
       <main className={styles.main}>
         {/* AI Status */}

--- a/frontend/src/app/knowledge-base/notes/page.module.scss
+++ b/frontend/src/app/knowledge-base/notes/page.module.scss
@@ -251,7 +251,7 @@
   width: 100%;
   padding: $spacing-3 $spacing-4;
   background-color: $white;
-  border: $border-width-thin solid $orange-300;
+  border: $border-width-thin solid $color-link-default;
   border-radius: $border-radius-button;
   @include text-secondary;
   color: $color-link-default;
@@ -261,7 +261,7 @@
 
   &:hover {
     background-color: $color-surface-tertiary;
-    border-color: $orange-400;
+    border-color: $color-link-hover;
     color: $color-text-secondary;
   }
 }
@@ -296,153 +296,48 @@
   }
 }
 
-// ===== HEADER =====
-.header {
-  // Cool slate blue header zone (consistent across KB)
-  background: linear-gradient(
-    to bottom,
-    var(--color-header-bg-start) 0%,
-    var(--color-header-bg-mid) 50%,
-    var(--color-header-bg-end) 100%
-  );
-  border-bottom: 1px solid var(--color-header-border);
-  box-shadow: $shadow-card-sm;
+// ===== HEADER ACTIONS =====
+// Header shell lives in PageHeader; only the page-specific actions remain.
+// Ghost buttons share one shape; the primary (+ New Note) carries the fill.
+.graphButton,
+.randomButton {
+  padding: $spacing-2 $spacing-4;
+  border-radius: $border-radius-button;
+  border: $border-width-thin solid $color-link-default;
+  background-color: transparent;
+  color: $color-link-default;
+  font-family: $font-family-primary;
+  font-weight: $font-weight-medium;
+  font-size: $font-size-sm;
+  text-decoration: none;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: all 0.2s ease;
 
-  .headerContent {
-    @include container;
-    max-width: 56rem;
-    padding-top: $spacing-6;
-    padding-bottom: $spacing-6;
+  &:hover:not(:disabled) {
+    background-color: $color-interactive-primary-bg-subtle;
+    border-color: $color-link-hover;
   }
+}
 
-  .headerTop {
-    margin-bottom: $spacing-6;
-    @include flex-between;
-  }
+.randomButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
 
-  .titleRow {
-    @include flex-between;
-    align-items: flex-start;
+.newNoteButton {
+  padding: $spacing-2 $spacing-4;
+  border-radius: $border-radius-button;
+  background-color: $color-interactive-primary;
+  color: $color-interactive-primary-text;
+  font-weight: $font-weight-medium;
+  font-size: $font-size-sm;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: all 0.2s ease;
 
-    @media (max-width: 640px) {
-      flex-direction: column;
-      gap: $spacing-4;
-    }
-
-    .titleSection {
-      .title {
-        @include heading-h1;
-        margin: 0;
-
-        @media (max-width: 640px) {
-          font-size: $font-size-2xl;
-        }
-      }
-
-      .subtitle {
-        margin-top: $spacing-1;
-        color: $color-text-secondary;
-
-        @media (max-width: 640px) {
-          font-size: $font-size-sm;
-        }
-
-        .toolboxLink {
-          color: $color-link-default;
-          text-decoration: none;
-          transition: color 0.2s ease;
-
-          &:hover {
-            color: $color-link-hover;
-            text-decoration: underline;
-          }
-        }
-      }
-    }
-
-    .actions {
-      @include flex-start;
-      gap: $spacing-3;
-      flex-shrink: 0;
-
-      @media (max-width: 640px) {
-        width: 100%;
-        flex-direction: column;
-        gap: $spacing-2;
-      }
-
-      .graphButton {
-        padding: $spacing-2 $spacing-4;
-        border-radius: $border-radius-button;
-        border: $border-width-thin solid $orange-300;
-        background-color: transparent;
-        color: $color-link-default;
-        font-family: $font-family-primary;
-        font-weight: $font-weight-medium;
-        text-decoration: none;
-        transition: all 0.2s ease;
-        display: inline-block;
-
-        @media (max-width: 640px) {
-          width: 100%;
-          padding: $spacing-3 $spacing-4;
-          font-size: $font-size-sm;
-          text-align: center;
-        }
-
-        &:hover {
-          background-color: $color-interactive-primary-bg-subtle;
-        }
-      }
-
-      .randomButton {
-        padding: $spacing-2 $spacing-4;
-        border-radius: $border-radius-button;
-        border: $border-width-thin solid $orange-300;
-        background-color: transparent;
-        color: $color-link-default;
-        font-family: $font-family-primary;
-        font-weight: $font-weight-medium;
-        cursor: pointer;
-        transition: all 0.2s ease;
-
-        @media (max-width: 640px) {
-          width: 100%;
-          padding: $spacing-3 $spacing-4;
-          font-size: $font-size-sm;
-        }
-
-        &:hover:not(:disabled) {
-          background-color: $color-surface-tertiary;
-        }
-
-        &:disabled {
-          cursor: not-allowed;
-          opacity: 0.5;
-        }
-      }
-
-      .newNoteButton {
-        padding: $spacing-2 $spacing-4;
-        border-radius: $border-radius-button;
-        background-color: $color-interactive-primary;
-        color: $color-interactive-primary-text;
-        font-weight: $font-weight-medium;
-        text-decoration: none;
-        transition: all 0.2s ease;
-
-        @media (max-width: 640px) {
-          width: 100%;
-          padding: $spacing-3 $spacing-4;
-          font-size: $font-size-sm;
-          text-align: center;
-        }
-
-        &:hover {
-          background-color: $color-interactive-primary-hover;
-        }
-      }
-    }
+  &:hover {
+    background-color: $color-interactive-primary-hover;
   }
 }
 

--- a/frontend/src/app/knowledge-base/notes/page.tsx
+++ b/frontend/src/app/knowledge-base/notes/page.tsx
@@ -23,6 +23,7 @@ import { logger } from "@/lib/logger";
 import AIAssistant from "@/components/AIAssistant";
 import { LoadingState, ErrorState, EmptyState } from "@/components/PageState";
 import Breadcrumb from "@/components/Breadcrumb";
+import PageHeader from "@/components/PageHeader";
 import { TagPillList } from "@/components/TagPill";
 import QuickLists from "@/components/QuickLists/QuickLists";
 import NoteOfDay from "@/components/NoteOfDay/NoteOfDay";
@@ -217,46 +218,39 @@ function NotesContent() {
     <div className={styles.container}>
       <AIAssistant />
 
-      {/* Header */}
-      <div className={styles.header}>
-        <div className={styles.headerContent}>
-          <div className={styles.headerTop}>
-            <Breadcrumb section="notes" toHub />
-          </div>
-          <div className={styles.titleRow}>
-            <div className={styles.titleSection}>
-              <h1 className={styles.title}>Notes</h1>
-              <p className={styles.subtitle}>
-                Atomic insights and knowledge building ({totalNotes} notes) &middot;{" "}
-                <Link href="/knowledge-base/toolbox" className={styles.toolboxLink}>
-                  Looking for frameworks and checklists? Check the Toolbox →
-                </Link>
-              </p>
-            </div>
-            <div className={styles.actions}>
-              <Link href="/knowledge-base/notes/graph" className={styles.graphButton}>
-                View Graph
-              </Link>
-              <button
-                onClick={handleRandomNote}
-                disabled={randomNoteLoading || notes.length === 0}
-                className={styles.randomButton}
-                title="Open a random note for serendipitous discovery"
-              >
-                {randomNoteLoading ? "Loading..." : "Random Note"}
-              </button>
-              <Link
-                href="/knowledge-base/notes/new"
-                className={styles.newNoteButton}
-                onMouseEnter={prefetchEditorChunk}
-                onFocus={prefetchEditorChunk}
-              >
-                + New Note
-              </Link>
-            </div>
-          </div>
-        </div>
-      </div>
+      <PageHeader
+        title="Notes"
+        breadcrumb={<Breadcrumb section="notes" toHub />}
+        subtitle={
+          <>
+            {totalNotes} notes &middot;{" "}
+            <Link href="/knowledge-base/toolbox">Frameworks and checklists? Toolbox →</Link>
+          </>
+        }
+        actions={
+          <>
+            <Link href="/knowledge-base/notes/graph" className={styles.graphButton}>
+              View Graph
+            </Link>
+            <button
+              onClick={handleRandomNote}
+              disabled={randomNoteLoading || notes.length === 0}
+              className={styles.randomButton}
+              title="Open a random note for serendipitous discovery"
+            >
+              {randomNoteLoading ? "Loading..." : "Random Note"}
+            </button>
+            <Link
+              href="/knowledge-base/notes/new"
+              className={styles.newNoteButton}
+              onMouseEnter={prefetchEditorChunk}
+              onFocus={prefetchEditorChunk}
+            >
+              + New Note
+            </Link>
+          </>
+        }
+      />
 
       <div className={styles.main}>
         <div className={styles.contentGrid}>

--- a/frontend/src/app/knowledge-base/page.module.scss
+++ b/frontend/src/app/knowledge-base/page.module.scss
@@ -289,7 +289,7 @@
     &.toolboxSecondary {
       background-color: transparent;
       color: $color-primary-dark;
-      border: $border-width-thin solid $orange-300;
+      border: $border-width-thin solid $color-link-default;
 
       &:hover {
         background-color: $color-primary-light;

--- a/frontend/src/app/knowledge-base/toolbox/page.module.scss
+++ b/frontend/src/app/knowledge-base/toolbox/page.module.scss
@@ -17,90 +17,20 @@
 
 // ===== LOADING STATE =====
 // ===== ERROR STATE =====
-// ===== HEADER =====
-.header {
-  background: linear-gradient(
-    to bottom,
-    var(--color-header-bg-start) 0%,
-    var(--color-header-bg-mid) 50%,
-    var(--color-header-bg-end) 100%
-  );
-  border-bottom: 1px solid var(--color-header-border);
-  box-shadow: $shadow-card-sm;
+// ===== HEADER ACTION =====
+// Header shell lives in PageHeader; only the page-specific action remains.
+.newReferenceButton {
+  padding: $spacing-2 $spacing-4;
+  border-radius: $border-radius-button;
+  background-color: $color-interactive-primary;
+  color: $color-interactive-primary-text;
+  font-weight: $font-weight-medium;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: all 0.2s ease;
 
-  .headerContent {
-    @include container;
-    padding-top: $spacing-6;
-    padding-bottom: $spacing-6;
-  }
-
-  .headerTop {
-    margin-bottom: $spacing-4;
-  }
-
-  .titleRow {
-    @include flex-between;
-    align-items: flex-start;
-
-    @media (max-width: 640px) {
-      flex-direction: column;
-      gap: $spacing-4;
-    }
-
-    .titleSection {
-      .title {
-        @include heading-h1;
-        margin: 0;
-        color: $color-text-heading;
-
-        @media (max-width: 640px) {
-          font-size: $font-size-2xl;
-        }
-      }
-
-      .subtitle {
-        margin-top: $spacing-2;
-        color: $color-text-secondary;
-        font-size: $font-size-lg;
-
-        @media (max-width: 640px) {
-          font-size: $font-size-sm;
-        }
-      }
-    }
-
-    .actions {
-      @include flex-start;
-      gap: $spacing-3;
-      flex-shrink: 0;
-
-      @media (max-width: 640px) {
-        width: 100%;
-        flex-direction: column;
-        gap: $spacing-2;
-      }
-
-      .newReferenceButton {
-        padding: $spacing-2 $spacing-4;
-        border-radius: $border-radius-button;
-        background-color: $color-link-default;
-        color: white;
-        font-weight: $font-weight-medium;
-        text-decoration: none;
-        transition: all 0.2s ease;
-
-        @media (max-width: 640px) {
-          width: 100%;
-          padding: $spacing-3 $spacing-4;
-          font-size: $font-size-sm;
-          text-align: center;
-        }
-
-        &:hover {
-          background-color: $color-text-secondary;
-        }
-      }
-    }
+  &:hover {
+    background-color: $color-interactive-primary-hover;
   }
 }
 
@@ -206,13 +136,13 @@
       }
 
       &.categoryBadgeActive {
-        background-color: $orange-700;
-        border-color: $orange-800;
-        color: #fff;
+        background-color: $color-interactive-primary;
+        border-color: $color-interactive-primary-hover;
+        color: $color-interactive-primary-text;
 
         &:hover {
-          background-color: $orange-800;
-          border-color: $orange-900;
+          background-color: $color-interactive-primary-hover;
+          border-color: $color-interactive-primary-active;
         }
       }
     }
@@ -224,7 +154,7 @@
   width: 100%;
   padding: $spacing-3 $spacing-4;
   background-color: $white;
-  border: $border-width-thin solid $orange-300;
+  border: $border-width-thin solid $color-link-default;
   border-radius: $border-radius-button;
   @include text-secondary;
   color: $color-link-default;
@@ -234,7 +164,7 @@
 
   &:hover {
     background-color: $color-surface-tertiary;
-    border-color: $orange-400;
+    border-color: $color-link-hover;
     color: $color-text-secondary;
   }
 }

--- a/frontend/src/app/knowledge-base/toolbox/page.tsx
+++ b/frontend/src/app/knowledge-base/toolbox/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { listAllNotes, Note } from "@/lib/api/notes";
 import { logger } from "@/lib/logger";
 import Breadcrumb from "@/components/Breadcrumb";
+import PageHeader from "@/components/PageHeader";
 import { LoadingState, ErrorState } from "@/components/PageState";
 import styles from "./page.module.scss";
 
@@ -127,27 +128,16 @@ export default function ToolboxPage() {
 
   return (
     <div className={styles.container}>
-      {/* Header */}
-      <header className={styles.header}>
-        <div className={styles.headerContent}>
-          <div className={styles.headerTop}>
-            <Breadcrumb section="toolbox" />
-          </div>
-          <div className={styles.titleRow}>
-            <div className={styles.titleSection}>
-              <h1 className={styles.title}>Toolbox</h1>
-              <p className={styles.subtitle}>
-                Frameworks, checklists, and mental models at your fingertips
-              </p>
-            </div>
-            <div className={styles.actions}>
-              <Link href="/knowledge-base/notes/new?ref=true" className={styles.newReferenceButton}>
-                + New Reference
-              </Link>
-            </div>
-          </div>
-        </div>
-      </header>
+      <PageHeader
+        title="Toolbox"
+        subtitle="Frameworks, checklists, and mental models at your fingertips"
+        breadcrumb={<Breadcrumb section="toolbox" />}
+        actions={
+          <Link href="/knowledge-base/notes/new?ref=true" className={styles.newReferenceButton}>
+            + New Reference
+          </Link>
+        }
+      />
 
       <main className={styles.main}>
         <div className={styles.contentGrid}>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -63,7 +63,7 @@ export default function RootLayout({
         {/* Apply the stored theme choice before first paint (no flash). */}
         <script
           dangerouslySetInnerHTML={{
-            __html: `try{var t=localStorage.getItem("theme");if(t==="dark"||t==="light"){document.documentElement.dataset.theme=t;}var d=localStorage.getItem("delight");if(d==="on"){document.documentElement.dataset.delight="on";}}catch(e){}`,
+            __html: `try{var t=localStorage.getItem("theme");if(t==="dark"||t==="light"){document.documentElement.dataset.theme=t;}var d=localStorage.getItem("delight");if(d!=="off"){document.documentElement.dataset.delight="on";}}catch(e){}`,
           }}
         />
       </head>

--- a/frontend/src/app/login/page.module.scss
+++ b/frontend/src/app/login/page.module.scss
@@ -199,7 +199,7 @@
     flex-shrink: 0;
     width: 1.25rem;
     height: 1.25rem;
-    color: $red-500;
+    color: $color-error-text;
   }
 
   .errorMessage {

--- a/frontend/src/app/page.module.scss
+++ b/frontend/src/app/page.module.scss
@@ -90,7 +90,7 @@
     letter-spacing: $letter-spacing-wide;
     color: $color-link-hover;
     text-decoration: none;
-    border-bottom: 1px solid $orange-300;
+    border-bottom: 1px solid $color-link-default;
     padding-bottom: 2px;
     transition:
       color 0.2s ease,

--- a/frontend/src/components/AIPanel.module.scss
+++ b/frontend/src/components/AIPanel.module.scss
@@ -307,7 +307,7 @@
   letter-spacing: $letter-spacing-wide;
 
   &[data-type="article"] {
-    color: $orange-700;
+    color: $color-badge-article-text;
   }
 
   &[data-type="note"] {

--- a/frontend/src/components/AddressLights.module.scss
+++ b/frontend/src/components/AddressLights.module.scss
@@ -5,8 +5,13 @@
 .lights {
   display: flex;
   gap: 5px;
+  // Decorative strip: never let its fixed-width segments push the page
+  // wider than the viewport. Trailing segments clip cleanly off-edge,
+  // like a console panel continuing past the frame.
+  max-width: 100%;
+  overflow: hidden;
 
-  @media (max-width: 480px) {
+  @media (max-width: 640px) {
     gap: 4px;
   }
 }
@@ -17,7 +22,7 @@
   height: 6px;
   border-radius: 2px;
 
-  @media (max-width: 480px) {
+  @media (max-width: 640px) {
     width: 16px;
   }
 }

--- a/frontend/src/components/AddressLights.tsx
+++ b/frontend/src/components/AddressLights.tsx
@@ -4,18 +4,45 @@
  * The site's nod to the DEC front panel (#278): lit segments in the
  * console's crimson / berry / purple against unlit ground. Purely
  * decorative; colors come from the theme's --color-lights-* tokens.
+ *
+ * The fixed PATTERN renders on the server and on the first client render
+ * (no hydration mismatch). After mount, if Delight mode is on, the strip
+ * randomizes per page-view (#283) - like a console mid-computation. Because
+ * DelightEffects re-keys the tree by pathname, this remounts on navigation,
+ * so both refresh and navigation produce a fresh arrangement. With Delight
+ * off, the calm fixed pattern stands.
  */
 
+"use client";
+
+import { useEffect, useState } from "react";
+import { isDelightOn } from "@/hooks/useDelight";
 import styles from "./AddressLights.module.scss";
 
 // Fixed pattern (deterministic for SSR): 0 = off, 1 = crimson, 2 = berry, 3 = purple
 const PATTERN = [1, 0, 2, 1, 0, 0, 3, 2, 0, 1, 0, 3, 0, 0, 2, 1] as const;
 const SEGMENT_CLASS = ["off", "crimson", "berry", "purple"] as const;
 
+// Weighted toward unlit ground so a randomized strip reads like a console
+// panel (roughly half lit) rather than a solid wall of color.
+const WEIGHTS = [0, 0, 0, 0, 1, 1, 2, 2, 3] as const;
+
+function randomPattern(length: number): number[] {
+  return Array.from({ length }, () => WEIGHTS[Math.floor(Math.random() * WEIGHTS.length)]);
+}
+
 export default function AddressLights() {
+  const [pattern, setPattern] = useState<readonly number[]>(PATTERN);
+
+  useEffect(() => {
+    if (isDelightOn()) {
+      setPattern(randomPattern(PATTERN.length));
+    }
+  }, []);
+
   return (
     <div className={styles.lights} aria-hidden="true">
-      {PATTERN.map((value, index) => (
+      {pattern.map((value, index) => (
         <span key={index} className={`${styles.segment} ${styles[SEGMENT_CLASS[value]]}`} />
       ))}
     </div>

--- a/frontend/src/components/Badge.module.scss
+++ b/frontend/src/components/Badge.module.scss
@@ -21,8 +21,8 @@
 
   // Article badge - orange accent
   &[data-type="article"] {
-    color: $orange-700;
-    border-color: $orange-300;
+    color: $color-badge-article-text;
+    border-color: $color-badge-article-border;
   }
 
   // Note badge - quiet grey

--- a/frontend/src/components/HeaderMenu.module.scss
+++ b/frontend/src/components/HeaderMenu.module.scss
@@ -124,14 +124,14 @@
   background: none;
   border: none;
   border-radius: $border-radius-md;
-  color: $red-600;
+  color: $color-error-text;
   text-align: left;
   cursor: pointer;
   @include transition-colors;
 
   &:hover {
-    background-color: $red-50;
-    color: $red-700;
+    background-color: $color-error-bg;
+    color: $color-error-text;
   }
 }
 

--- a/frontend/src/components/NoteEditorForm.module.scss
+++ b/frontend/src/components/NoteEditorForm.module.scss
@@ -160,7 +160,7 @@
     }
 
     &.error {
-      color: $orange-600;
+      color: $color-error-text;
     }
   }
 

--- a/frontend/src/components/PageHeader.module.scss
+++ b/frontend/src/components/PageHeader.module.scss
@@ -1,0 +1,93 @@
+/**
+ * PageHeader - shared compact header zone for KB list pages (#282).
+ *
+ * Slate-blue gradient zone, dense vertical rhythm, a Space Grotesk title,
+ * a mono "terminal readout" subtitle, a wrapping actions row, and the
+ * AddressLights strip as the one signature flourish (DESIGN.md).
+ */
+
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
+
+.header {
+  background: linear-gradient(
+    to bottom,
+    var(--color-header-bg-start) 0%,
+    var(--color-header-bg-mid) 50%,
+    var(--color-header-bg-end) 100%
+  );
+  border-bottom: 1px solid var(--color-header-border);
+  box-shadow: $shadow-card-sm;
+}
+
+.headerContent {
+  @include container;
+  padding-top: $spacing-4;
+  padding-bottom: $spacing-4;
+}
+
+.breadcrumb {
+  margin-bottom: $spacing-3;
+}
+
+.titleRow {
+  @include flex-between;
+  align-items: flex-start;
+  gap: $spacing-3;
+  flex-wrap: wrap;
+}
+
+.titleSection {
+  min-width: 0;
+}
+
+.title {
+  font-family: $font-family-primary;
+  font-size: $font-size-2xl;
+  font-weight: $font-weight-semibold;
+  line-height: $line-height-tight;
+  letter-spacing: $letter-spacing-wide;
+  color: $color-text-heading;
+  margin: 0;
+
+  @media (max-width: 640px) {
+    font-size: $font-size-xl;
+  }
+}
+
+.subtitle {
+  margin-top: $spacing-1;
+  font-family: $font-family-mono;
+  font-size: $font-size-sm;
+  letter-spacing: $letter-spacing-wide;
+  color: $color-text-secondary;
+
+  @media (max-width: 640px) {
+    font-size: $font-size-xs;
+  }
+
+  a {
+    color: $color-link-default;
+    text-decoration: none;
+    transition: color 0.2s ease;
+
+    &:hover {
+      color: $color-link-hover;
+      text-decoration: underline;
+    }
+  }
+}
+
+// Compact wrapping row - actions stay pill-sized and wrap under the title
+// on narrow screens instead of stacking into full-width bars.
+.actions {
+  @include flex-start;
+  align-items: center;
+  gap: $spacing-2;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+.lightsRow {
+  margin-top: $spacing-3;
+}

--- a/frontend/src/components/PageHeader.tsx
+++ b/frontend/src/components/PageHeader.tsx
@@ -1,0 +1,56 @@
+/**
+ * PageHeader - shared header zone for Knowledge Base list pages (#282).
+ *
+ * One compact header pattern across Articles / Notes / Toolbox / Inspire:
+ * the slate-blue gradient zone, a Space Grotesk title, an optional mono
+ * "terminal readout" subtitle, an inline actions slot, and the decorative
+ * AddressLights strip (#283). Per DESIGN.md the strip is the header's one
+ * signature flourish, so everything around it stays quiet and dense.
+ *
+ * The Graph page keeps its own ultra-compact header but shares the same
+ * --color-header-bg-* tokens, so it isn't built on this component.
+ */
+
+import AddressLights from "./AddressLights";
+import styles from "./PageHeader.module.scss";
+
+interface PageHeaderProps {
+  /** Page title, rendered as the h1. */
+  title: string;
+  /** Optional mono metadata line (counts, cross-links). */
+  subtitle?: React.ReactNode;
+  /** Breadcrumb element, e.g. <Breadcrumb section="notes" toHub />. */
+  breadcrumb?: React.ReactNode;
+  /** Right-aligned action controls (buttons/links). */
+  actions?: React.ReactNode;
+  /** Show the decorative AddressLights strip. Default true. */
+  showLights?: boolean;
+}
+
+export default function PageHeader({
+  title,
+  subtitle,
+  breadcrumb,
+  actions,
+  showLights = true,
+}: PageHeaderProps) {
+  return (
+    <header className={styles.header}>
+      <div className={styles.headerContent}>
+        {breadcrumb && <div className={styles.breadcrumb}>{breadcrumb}</div>}
+        <div className={styles.titleRow}>
+          <div className={styles.titleSection}>
+            <h1 className={styles.title}>{title}</h1>
+            {subtitle && <div className={styles.subtitle}>{subtitle}</div>}
+          </div>
+          {actions && <div className={styles.actions}>{actions}</div>}
+        </div>
+        {showLights && (
+          <div className={styles.lightsRow}>
+            <AddressLights />
+          </div>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/components/SearchModal.module.scss
+++ b/frontend/src/components/SearchModal.module.scss
@@ -105,7 +105,7 @@
 }
 
 .error {
-  color: $red-600;
+  color: $color-error-text;
 }
 
 // Results List
@@ -142,7 +142,7 @@
     letter-spacing: $letter-spacing-wide;
 
     &[data-type="article"] {
-      color: $orange-700;
+      color: $color-badge-article-text;
     }
 
     &[data-type="note"] {


### PR DESCRIPTION
Unifies the Articles / Notes / Toolbox / Inspire list headers behind one shared `PageHeader` component and rolls the AddressLights strip out to all of them with per-view randomization. Closes #282, #283, #284.

## What changed

### #282 — shared compact header
- New `PageHeader.tsx` + `PageHeader.module.scss`: slate-blue gradient zone, ~24px Space Grotesk title, mono "terminal readout" subtitle, a wrapping actions row, and the AddressLights strip.
- Articles / Notes / Toolbox / Inspire refactored onto it; ~200 lines of duplicated per-page header SCSS removed (net **−123 lines**).
- Tighter vertical rhythm (`spacing-4`) so content reaches the first screen sooner. On mobile the Notes actions now **wrap as a compact row** instead of three full-width stacked bars (the worst offender in #282).
- Graph keeps its own ultra-compact header but shares the same `--color-header-bg-*` tokens.

### #283 — AddressLights rollout + randomization
- Strip now on Articles / Notes / Toolbox headers (KB hub already had it).
- Randomizes the lit-segment pattern **per page-view when Delight is on** (fixed pattern for SSR + first paint → no hydration mismatch; calm fixed pattern when Delight is off). Remounts per navigation via the pathname-keyed Delight wrapper, so both refresh and navigation produce a fresh pattern.
- Fixed a horizontal-overflow bug: the fixed-width segments could push the page wider than the viewport on narrow screens; the strip now clips to its container.

### #284 — token sweep
- All 29 hardcoded `$orange-*` / `$red-*` uses in `.module.scss` converted to semantic tokens (`interactive` / `link` / `error` / `badge`).
- Active tag & category chips now go phosphor-amber in dark mode, and their text flips to the dark on-amber token — fixing a latent white-on-amber contrast bug.
- `NoteEditorForm` `.error` moved from `$orange-600` to `$color-error-text` (now red, matching the semantic; previously near-identical to its amber warning state).

### Delight default
- Delight mode now defaults **ON** unless explicitly disabled (one-line change to the `layout.tsx` inline script).

## Verification
- `make ci` clean (lint, typecheck, security, format) via the pre-push hook.
- 117 frontend unit tests pass.
- All four list pages eyeballed on desktop dark; Notes verified on mobile (390px) dark — no horizontal overflow, actions wrap compactly, lights re-randomize on reload.

## Follow-up
Mobile density on the list pages still needs a real rethink (condensed headers, filters behind a menu, much smaller cards) — tracked separately.