### PR TITLE
feat(library): Library v1 — card catalog (#294)

### DIFF
--- a/backend/adapters/neo4j.py
+++ b/backend/adapters/neo4j.py
@@ -16,7 +16,7 @@ class Neo4jAdapter:
     """Adapter for Neo4j graph database operations."""
 
     # Valid node types to prevent Cypher injection
-    VALID_NODE_TYPES = frozenset({"Article", "Note"})
+    VALID_NODE_TYPES = frozenset({"Article", "Note", "LibraryEntry"})
 
     def _validate_node_type(self, node_type: str) -> str:
         """Validate node_type to prevent Cypher injection.
@@ -142,7 +142,24 @@ class Neo4jAdapter:
                 """
             )
 
-            logger.info("Neo4j schema initialized (Notes + Articles + embeddings support)")
+            # ===== LIBRARY ENTRY SCHEMA (#294) =====
+            # Unique constraint on LibraryEntry.id
+            session.run(
+                """
+                CREATE CONSTRAINT library_entry_id_unique IF NOT EXISTS
+                FOR (e:LibraryEntry) REQUIRE e.id IS UNIQUE
+                """
+            )
+
+            # Index on LibraryEntry.created_at for sorting
+            session.run(
+                """
+                CREATE INDEX library_entry_created_at IF NOT EXISTS
+                FOR (e:LibraryEntry) ON (e.created_at)
+                """
+            )
+
+            logger.info("Neo4j schema initialized (Notes + Articles + Library + embeddings support)")
 
     def is_available(self) -> bool:
         """Check if Neo4j is available."""
@@ -1064,6 +1081,217 @@ class Neo4jAdapter:
                 result["embedding_version"] = node["embedding_version"]
 
         return result
+
+    # ===== LIBRARY ENTRY METHODS (#294) =====
+
+    def _library_node_to_dict(self, node: Any) -> dict[str, Any]:
+        """Convert a :LibraryEntry Neo4j node to a dict."""
+        return {
+            "id": node.get("id"),
+            "title": node.get("title", ""),
+            "source_url": node.get("source_url", ""),
+            "author": node.get("author", ""),
+            "type": node.get("type", "other"),
+            "summary": node.get("summary", ""),
+            "tags": node.get("tags", []),
+            "created_at": node.get("created_at", 0.0),
+            "updated_at": node.get("updated_at", node.get("created_at", 0.0)),
+        }
+
+    def create_library_entry(
+        self,
+        entry_id: str,
+        title: str,
+        source_url: str = "",
+        author: str = "",
+        type: str = "other",
+        summary: str = "",
+        tags: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Create a new Library entry (#294).
+
+        Args:
+            entry_id: Unique entry ID (adjective-noun)
+            title: Resource title
+            source_url: External link to the resource
+            author: Resource author/creator
+            type: Resource type (book/article/video/doc/paper/other)
+            summary: Erik's own markdown summary
+            tags: Optional tags
+
+        Returns:
+            Created entry as dict
+        """
+        if not self._available or not self.driver:
+            raise RuntimeError("Neo4j not available")
+
+        now = time.time()
+        with self.driver.session(database=self.database) as session:
+            result = session.run(
+                """
+                CREATE (e:LibraryEntry {
+                    id: $id,
+                    title: $title,
+                    source_url: $source_url,
+                    author: $author,
+                    type: $type,
+                    summary: $summary,
+                    tags: $tags,
+                    created_at: $created_at,
+                    updated_at: $updated_at
+                })
+                RETURN e
+                """,
+                id=entry_id,
+                title=title,
+                source_url=source_url,
+                author=author,
+                type=type,
+                summary=summary,
+                tags=tags or [],
+                created_at=now,
+                updated_at=now,
+            )
+            record = result.single()
+            if not record:
+                raise RuntimeError(f"Failed to create library entry {entry_id}")
+            return self._library_node_to_dict(record["e"])
+
+    def get_library_entry(self, entry_id: str) -> dict[str, Any] | None:
+        """Get a Library entry by ID."""
+        if not self._available or not self.driver:
+            return None
+
+        with self.driver.session(database=self.database) as session:
+            result = session.run(
+                """
+                MATCH (e:LibraryEntry)
+                WHERE e.id = $id
+                RETURN e
+                """,
+                id=entry_id,
+            )
+            record = result.single()
+            if not record:
+                return None
+            return self._library_node_to_dict(record["e"])
+
+    def list_library_entries(
+        self,
+        type: str | None = None,
+        tag: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """List Library entries, newest first, optionally filtered by type/tag.
+
+        Args:
+            type: Optional resource-type filter
+            tag: Optional tag filter (entries containing this tag)
+
+        Returns:
+            List of entry dicts sorted by created_at descending
+        """
+        if not self._available or not self.driver:
+            return []
+
+        where_clauses = []
+        params: dict[str, Any] = {}
+        if type:
+            where_clauses.append("e.type = $type")
+            params["type"] = type
+        if tag:
+            where_clauses.append("$tag IN e.tags")
+            params["tag"] = tag
+        where_clause = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
+
+        with self.driver.session(database=self.database) as session:
+            result = session.run(
+                f"""
+                MATCH (e:LibraryEntry)
+                {where_clause}
+                RETURN e
+                ORDER BY e.created_at DESC
+                """,
+                **params,
+            )
+            return [self._library_node_to_dict(record["e"]) for record in result]
+
+    def update_library_entry(
+        self,
+        entry_id: str,
+        title: str | None = None,
+        source_url: str | None = None,
+        author: str | None = None,
+        type: str | None = None,
+        summary: str | None = None,
+        tags: list[str] | None = None,
+    ) -> dict[str, Any] | None:
+        """Update a Library entry. Only provided fields are changed.
+
+        Returns:
+            Updated entry dict or None if not found
+        """
+        if not self._available or not self.driver:
+            return None
+
+        set_clauses = ["e.updated_at = $updated_at"]
+        params: dict[str, Any] = {"id": entry_id, "updated_at": time.time()}
+        for field, value in (
+            ("title", title),
+            ("source_url", source_url),
+            ("author", author),
+            ("type", type),
+            ("summary", summary),
+            ("tags", tags),
+        ):
+            if value is not None:
+                set_clauses.append(f"e.{field} = ${field}")
+                params[field] = value
+        set_clause = ", ".join(set_clauses)
+
+        with self.driver.session(database=self.database) as session:
+            result = session.run(
+                f"""
+                MATCH (e:LibraryEntry)
+                WHERE e.id = $id
+                SET {set_clause}
+                RETURN e
+                """,
+                **params,
+            )
+            record = result.single()
+            if not record:
+                return None
+            return self._library_node_to_dict(record["e"])
+
+    def delete_library_entry(self, entry_id: str) -> bool:
+        """Delete a Library entry by ID.
+
+        Returns:
+            True if deleted, False if not found
+        """
+        if not self._available or not self.driver:
+            return False
+
+        with self.driver.session(database=self.database) as session:
+            result = session.run(
+                """
+                MATCH (e:LibraryEntry)
+                WHERE e.id = $id
+                DETACH DELETE e
+                RETURN count(e) AS deleted
+                """,
+                id=entry_id,
+            )
+            record = result.single()
+            return record["deleted"] > 0 if record else False
+
+    def get_all_library_entry_ids(self) -> set[str]:
+        """Return the set of all existing Library entry IDs (for ID generation)."""
+        if not self._available or not self.driver:
+            return set()
+        with self.driver.session(database=self.database) as session:
+            result = session.run("MATCH (e:LibraryEntry) RETURN e.id AS id")
+            return {record["id"] for record in result if record["id"]}
 
     # ===== ARTICLE METHODS =====
 

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -22,6 +22,8 @@ Usage in tests:
 from typing import Any
 
 from adapters.neo4j import Neo4jAdapter, get_neo4j_adapter
+from library_service import LibraryService
+from library_service import get_library_service as _get_library_service
 from llm_client import RoutingLLMClient, get_llm_client
 from notes_service import NotesService
 from notes_service import get_notes_service as _get_notes_service
@@ -31,6 +33,7 @@ from notes_service import get_notes_service as _get_notes_service
 _llm: RoutingLLMClient | None = None
 _neo4j_adapter: Neo4jAdapter | None = None
 _notes_service: NotesService | None = None
+_library_service: LibraryService | None = None
 
 
 def get_llm() -> RoutingLLMClient:
@@ -71,6 +74,18 @@ def get_notes() -> NotesService:
     if _notes_service is None:
         _notes_service = _get_notes_service()
     return _notes_service
+
+
+def get_library() -> LibraryService:
+    """Get the library service instance.
+
+    This dependency can be overridden in tests:
+        app.dependency_overrides[get_library] = lambda: mock_service
+    """
+    global _library_service
+    if _library_service is None:
+        _library_service = _get_library_service()
+    return _library_service
 
 
 # For static articles and user resources, we need callables that return
@@ -141,11 +156,12 @@ def reset_dependencies() -> None:
 
     Call this in test fixtures to ensure clean state between tests.
     """
-    global _llm, _neo4j_adapter, _notes_service
+    global _llm, _neo4j_adapter, _notes_service, _library_service
     global _static_articles, _published_articles, _user_resources
     _llm = None
     _neo4j_adapter = None
     _notes_service = None
+    _library_service = None
     _static_articles = []
     _published_articles = []
     _user_resources = []

--- a/backend/domain_types.py
+++ b/backend/domain_types.py
@@ -107,6 +107,38 @@ class ResourceDict(TypedDict, total=False):
     content_hash: str
 
 
+class LibraryEntryDict(TypedDict, total=False):
+    """Type definition for a Library entry (#294).
+
+    A Library entry is a curated reference to an external resource (book, article,
+    video, doc) that Erik values and reaches back to. Unlike Notes, entries carry
+    a structured source link and resource type. Stored as :LibraryEntry nodes in
+    Neo4j. The only body stored is Erik's own summary (no third-party full text in
+    v1 - that is the v2 archive tier, #299).
+
+    Attributes:
+        id: Unique entry ID (adjective-noun, e.g. "curious-elephant")
+        title: Resource title
+        source_url: External link to the resource
+        author: Resource author/creator (not Erik)
+        type: Resource type ("book" | "article" | "video" | "doc" | "paper" | "other")
+        summary: Erik's own markdown summary/notes
+        tags: List of tag strings
+        created_at: Unix timestamp (float)
+        updated_at: Unix timestamp (float)
+    """
+
+    id: str
+    title: str
+    source_url: str
+    author: str
+    type: str
+    summary: str
+    tags: list[str]
+    created_at: float
+    updated_at: float
+
+
 class GraphNodeDict(TypedDict):
     """Type definition for graph visualization node.
 

--- a/backend/library_service.py
+++ b/backend/library_service.py
@@ -1,0 +1,137 @@
+"""Business logic for the Library (curated resource catalog, #294).
+
+Mirrors NotesService: a thin orchestration layer over the Neo4j adapter. Library
+entries are standalone :LibraryEntry nodes, kept separate from the notes graph.
+"""
+
+import logging
+from typing import Any
+
+from adapters.neo4j import get_neo4j_adapter
+from note_id_generator import get_id_generator
+
+logger = logging.getLogger(__name__)
+
+
+class LibraryService:
+    """Service for managing Library entries.
+
+    Requires Neo4j to be available; raises if it is not.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the library service."""
+        self.neo4j = get_neo4j_adapter()
+        self.id_generator = get_id_generator()
+
+        if self.neo4j.is_available():
+            logger.info("LibraryService initialized with Neo4j")
+        else:
+            logger.warning("LibraryService initialized but Neo4j is not available")
+
+    def _require_neo4j(self) -> None:
+        """Raise error if Neo4j is not available."""
+        if not self.neo4j.is_available():
+            raise RuntimeError(
+                "Neo4j is required but not available. "
+                "Ensure Neo4j is running: docker compose up neo4j"
+            )
+
+    def create_entry(
+        self,
+        title: str,
+        source_url: str = "",
+        author: str = "",
+        type: str = "other",
+        summary: str = "",
+        tags: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Create a new Library entry.
+
+        Returns:
+            Created entry dict
+
+        Raises:
+            RuntimeError: If Neo4j is not available
+        """
+        self._require_neo4j()
+
+        existing_ids = self.neo4j.get_all_library_entry_ids()
+        entry_id = self.id_generator.generate(existing_ids)
+
+        entry = self.neo4j.create_library_entry(
+            entry_id=entry_id,
+            title=title,
+            source_url=source_url,
+            author=author,
+            type=type,
+            summary=summary,
+            tags=tags or [],
+        )
+        logger.info("Created library entry: %s", entry_id)
+        return entry
+
+    def get_entry(self, entry_id: str) -> dict[str, Any] | None:
+        """Get a Library entry by ID."""
+        self._require_neo4j()
+        return self.neo4j.get_library_entry(entry_id)
+
+    def list_entries(
+        self,
+        type: str | None = None,
+        tag: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """List Library entries, newest first, optionally filtered."""
+        self._require_neo4j()
+        return self.neo4j.list_library_entries(type=type, tag=tag)
+
+    def update_entry(
+        self,
+        entry_id: str,
+        title: str | None = None,
+        source_url: str | None = None,
+        author: str | None = None,
+        type: str | None = None,
+        summary: str | None = None,
+        tags: list[str] | None = None,
+    ) -> dict[str, Any] | None:
+        """Update a Library entry. Only provided fields change."""
+        self._require_neo4j()
+
+        if not self.neo4j.get_library_entry(entry_id):
+            return None
+
+        updated = self.neo4j.update_library_entry(
+            entry_id=entry_id,
+            title=title,
+            source_url=source_url,
+            author=author,
+            type=type,
+            summary=summary,
+            tags=tags,
+        )
+        logger.info("Updated library entry: %s", entry_id)
+        return updated
+
+    def delete_entry(self, entry_id: str) -> bool:
+        """Delete a Library entry."""
+        self._require_neo4j()
+
+        if not self.neo4j.get_library_entry(entry_id):
+            return False
+
+        deleted = self.neo4j.delete_library_entry(entry_id)
+        if deleted:
+            logger.info("Deleted library entry: %s", entry_id)
+        return deleted
+
+
+_library_service: LibraryService | None = None
+
+
+def get_library_service() -> LibraryService:
+    """Get global LibraryService instance (singleton)."""
+    global _library_service
+    if _library_service is None:
+        _library_service = LibraryService()
+    return _library_service

--- a/backend/main.py
+++ b/backend/main.py
@@ -48,6 +48,7 @@ from routers.ai import router as ai_router
 from routers.articles import router as articles_router
 from routers.auth import create_auth_router
 from routers.inspire import router as inspire_router
+from routers.library import router as library_router
 from routers.notes import router as notes_router
 from routers.search import router as search_router
 from routers.templates import router as templates_router
@@ -317,6 +318,7 @@ app.add_middleware(CacheControlMiddleware)
 app.include_router(ai_router, dependencies=[Depends(require_llm_features)])
 app.include_router(inspire_router)
 app.include_router(notes_router)
+app.include_router(library_router)
 app.include_router(search_router)
 app.include_router(articles_router)
 app.include_router(templates_router)

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -42,6 +42,11 @@ from models.auth import (
     SessionResponse,
     SessionStatusResponse,
 )
+from models.library import (
+    LibraryEntryCreate,
+    LibraryEntryUpdate,
+    LibraryListResponse,
+)
 from models.note import (
     BacklinksResponse,
     LinkSuggestion,
@@ -101,6 +106,10 @@ __all__ = [
     "CredentialDeleteResponse",
     "CredentialInfo",
     "CredentialsListResponse",
+    # Library models
+    "LibraryEntryCreate",
+    "LibraryEntryUpdate",
+    "LibraryListResponse",
     "RegistrationOptionsRequest",
     "RegistrationOptionsResponse",
     "RegistrationVerifyRequest",

--- a/backend/models/library.py
+++ b/backend/models/library.py
@@ -1,0 +1,61 @@
+"""Library-related Pydantic models (#294).
+
+The Library is a curated catalog of external resources (books, articles, videos,
+docs) Erik values and reaches back to. Entries carry a structured source link and
+resource type, plus Erik's own summary. See LibraryEntryDict in domain_types.py.
+"""
+
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+# Allowed resource types (kept in sync with the frontend filter chips).
+LibraryEntryType = Literal["book", "article", "video", "doc", "paper", "other"]
+
+
+class LibraryEntryCreate(BaseModel):
+    """Request model for creating a Library entry."""
+
+    title: str
+    source_url: str = ""
+    author: str = ""
+    type: LibraryEntryType = "other"
+    summary: str = ""
+    tags: list[str] = []
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "title": "Exercises in Programming Style",
+                    "source_url": "https://www.oreilly.com/library/view/exercises-in-programming/9781482227376/",
+                    "author": "Cristina Videira Lopes",
+                    "type": "book",
+                    "summary": "40 solutions to one computation task, grouped by style. Knowing *when* to apply a style is a skill in itself.",
+                    "tags": ["programming", "problem-solving"],
+                }
+            ]
+        }
+    }
+
+
+class LibraryEntryUpdate(BaseModel):
+    """Request model for updating a Library entry. Only provided fields change."""
+
+    title: str | None = None
+    source_url: str | None = None
+    author: str | None = None
+    type: LibraryEntryType | None = None
+    summary: str | None = None
+    tags: list[str] | None = None
+
+
+class LibraryListResponse(BaseModel):
+    """Response model for a list of Library entries with pagination support."""
+
+    entries: list[dict[str, Any]]
+    count: int  # Number of entries in current page
+    total: int  # Total number of entries (all pages)
+    page: int  # Current page number (1-indexed)
+    limit: int  # Items per page
+    total_pages: int  # Total number of pages

--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -1,0 +1,141 @@
+"""Library API routes (curated resource catalog, #294).
+
+Uses FastAPI dependency injection for testability (override get_library in tests).
+Mirrors the notes router: public reads, admin-gated writes, server-rendered HTML
+for the summary so the frontend needs no markdown pipeline.
+"""
+
+import logging
+import os
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+from auth import AdminUser
+from core.markdown_renderer import render_markdown_to_html
+from dependencies import get_library
+from models import LibraryEntryCreate, LibraryEntryUpdate, LibraryListResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/library", tags=["library"])
+
+# Rate limiter - disabled in tests
+limiter = Limiter(key_func=get_remote_address, enabled=os.getenv("TESTING") != "1")
+
+LibraryDep = Annotated[Any, Depends(get_library)]
+
+
+def _with_html_summary(entry: dict[str, Any]) -> dict[str, Any]:
+    """Attach server-rendered HTML for the summary (mirrors notes, #233).
+
+    On render failure the entry is returned without html_summary and the
+    frontend falls back to plain-text display.
+    """
+    try:
+        entry["html_summary"] = render_markdown_to_html(entry.get("summary", ""))
+    except Exception:
+        logger.warning("Failed to render HTML for library entry %s", entry.get("id"), exc_info=True)
+    return entry
+
+
+@router.get("", response_model=LibraryListResponse)
+async def list_library_entries(
+    library: LibraryDep,
+    type: str | None = None,
+    tag: str | None = None,
+    page: int = 1,
+    limit: int = 20,
+) -> LibraryListResponse:
+    """List Library entries, newest first, with optional filters and pagination.
+
+    Query Parameters:
+        type: Filter by resource type (book/article/video/doc/paper/other)
+        tag: Filter by tag (entries containing this tag)
+        page: Page number (1-indexed, default: 1)
+        limit: Items per page (default: 20, max: 100)
+    """
+    page = max(1, page)
+    limit = min(max(1, limit), 100)
+
+    all_entries = library.list_entries(type=type, tag=tag)
+
+    total = len(all_entries)
+    total_pages = (total + limit - 1) // limit
+    start_idx = (page - 1) * limit
+    paginated = all_entries[start_idx : start_idx + limit]
+
+    return LibraryListResponse(
+        entries=paginated,
+        count=len(paginated),
+        total=total,
+        page=page,
+        limit=limit,
+        total_pages=total_pages,
+    )
+
+
+@router.get("/{entry_id}", response_model=dict[str, Any])
+async def get_library_entry(entry_id: str, library: LibraryDep) -> dict[str, Any]:
+    """Get a single Library entry by ID."""
+    entry: dict[str, Any] | None = library.get_entry(entry_id)
+    if not entry:
+        raise HTTPException(status_code=404, detail=f"Library entry '{entry_id}' not found")
+    return _with_html_summary(entry)
+
+
+@router.post("", response_model=dict[str, Any], status_code=201)
+@limiter.limit("10/minute")
+async def create_library_entry(
+    request: Request,
+    entry: LibraryEntryCreate,
+    _admin: AdminUser,
+    library: LibraryDep,
+) -> dict[str, Any]:
+    """Create a new Library entry (admin only)."""
+    created: dict[str, Any] = library.create_entry(
+        title=entry.title,
+        source_url=entry.source_url,
+        author=entry.author,
+        type=entry.type,
+        summary=entry.summary,
+        tags=entry.tags,
+    )
+    return _with_html_summary(created)
+
+
+@router.put("/{entry_id}", response_model=dict[str, Any])
+async def update_library_entry(
+    entry_id: str,
+    entry_update: LibraryEntryUpdate,
+    _admin: AdminUser,
+    library: LibraryDep,
+) -> dict[str, Any]:
+    """Update a Library entry (admin only). Only provided fields change."""
+    updated: dict[str, Any] | None = library.update_entry(
+        entry_id=entry_id,
+        title=entry_update.title,
+        source_url=entry_update.source_url,
+        author=entry_update.author,
+        type=entry_update.type,
+        summary=entry_update.summary,
+        tags=entry_update.tags,
+    )
+    if not updated:
+        raise HTTPException(status_code=404, detail=f"Library entry '{entry_id}' not found")
+    return _with_html_summary(updated)
+
+
+@router.delete("/{entry_id}")
+async def delete_library_entry(
+    entry_id: str,
+    _admin: AdminUser,
+    library: LibraryDep,
+) -> dict[str, str]:
+    """Delete a Library entry (admin only)."""
+    deleted = library.delete_entry(entry_id=entry_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail=f"Library entry '{entry_id}' not found")
+    return {"message": f"Library entry '{entry_id}' deleted successfully"}

--- a/backend/tests/unit/test_library_api.py
+++ b/backend/tests/unit/test_library_api.py
@@ -1,0 +1,214 @@
+"""Unit/integration tests for Library API endpoints (#294)."""
+
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Set testing mode before importing app modules
+os.environ["TESTING"] = "1"
+
+from library_service import get_library_service
+from main import app
+
+# admin_headers (a passkey-session token) comes from conftest since #267.
+
+
+@pytest.fixture
+def client() -> TestClient:
+    """Get test client for API testing."""
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def clean_library() -> None:
+    """Clean up library entries before and after each test."""
+    service = get_library_service()
+
+    if service.neo4j.is_available():
+        service.neo4j.driver.execute_query("MATCH (e:LibraryEntry) DETACH DELETE e")
+
+    yield
+
+    if service.neo4j.is_available():
+        service.neo4j.driver.execute_query("MATCH (e:LibraryEntry) DETACH DELETE e")
+
+
+def _skip_if_no_neo4j() -> None:
+    if not get_library_service().neo4j.is_available():
+        pytest.skip("Neo4j not available")
+
+
+class TestCreateLibraryEntry:
+    """Tests for POST /api/library."""
+
+    def test_create_with_admin(self, client: TestClient, admin_headers: dict[str, str]) -> None:
+        _skip_if_no_neo4j()
+        response = client.post(
+            "/api/library",
+            json={
+                "title": "Exercises in Programming Style",
+                "source_url": "https://example.com/eps",
+                "author": "Cristina Videira Lopes",
+                "type": "book",
+                "summary": "40 styles for one task.",
+                "tags": ["programming"],
+            },
+            headers=admin_headers,
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["title"] == "Exercises in Programming Style"
+        assert data["source_url"] == "https://example.com/eps"
+        assert data["author"] == "Cristina Videira Lopes"
+        assert data["type"] == "book"
+        assert data["tags"] == ["programming"]
+        assert "id" in data
+        assert "html_summary" in data
+
+    def test_create_without_auth_fails(self, client: TestClient) -> None:
+        response = client.post("/api/library", json={"title": "No auth"})
+        assert response.status_code == 401
+
+    def test_create_rejects_invalid_type(
+        self, client: TestClient, admin_headers: dict[str, str]
+    ) -> None:
+        response = client.post(
+            "/api/library",
+            json={"title": "Bad type", "type": "podcast"},
+            headers=admin_headers,
+        )
+        assert response.status_code == 422
+
+    def test_create_requires_title(
+        self, client: TestClient, admin_headers: dict[str, str]
+    ) -> None:
+        response = client.post("/api/library", json={"author": "x"}, headers=admin_headers)
+        assert response.status_code == 422
+
+
+class TestGetLibraryEntry:
+    """Tests for GET /api/library/{id}."""
+
+    def test_get_existing(self, client: TestClient, admin_headers: dict[str, str]) -> None:
+        _skip_if_no_neo4j()
+        created = client.post(
+            "/api/library",
+            json={"title": "Thing", "summary": "# Heading\n\nBody"},
+            headers=admin_headers,
+        ).json()
+        response = client.get(f"/api/library/{created['id']}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == created["id"]
+        assert data["title"] == "Thing"
+        assert "<h1" in data["html_summary"].lower() or "<h1>" in data["html_summary"]
+
+    def test_get_missing_returns_404(self, client: TestClient) -> None:
+        _skip_if_no_neo4j()
+        response = client.get("/api/library/does-not-exist")
+        assert response.status_code == 404
+
+
+class TestListLibraryEntries:
+    """Tests for GET /api/library."""
+
+    def test_list_and_filter(self, client: TestClient, admin_headers: dict[str, str]) -> None:
+        _skip_if_no_neo4j()
+        client.post(
+            "/api/library",
+            json={"title": "A book", "type": "book", "tags": ["x"]},
+            headers=admin_headers,
+        )
+        client.post(
+            "/api/library",
+            json={"title": "A video", "type": "video", "tags": ["y"]},
+            headers=admin_headers,
+        )
+
+        all_resp = client.get("/api/library").json()
+        assert all_resp["total"] == 2
+        assert {"page", "limit", "total_pages", "count"} <= all_resp.keys()
+
+        books = client.get("/api/library?type=book").json()
+        assert books["total"] == 1
+        assert books["entries"][0]["title"] == "A book"
+
+        tagged = client.get("/api/library?tag=y").json()
+        assert tagged["total"] == 1
+        assert tagged["entries"][0]["title"] == "A video"
+
+    def test_list_public_no_auth(self, client: TestClient) -> None:
+        _skip_if_no_neo4j()
+        response = client.get("/api/library")
+        assert response.status_code == 200
+
+    def test_pagination(self, client: TestClient, admin_headers: dict[str, str]) -> None:
+        _skip_if_no_neo4j()
+        for i in range(3):
+            client.post("/api/library", json={"title": f"E{i}"}, headers=admin_headers)
+        page1 = client.get("/api/library?limit=2&page=1").json()
+        assert page1["count"] == 2
+        assert page1["total"] == 3
+        assert page1["total_pages"] == 2
+        page2 = client.get("/api/library?limit=2&page=2").json()
+        assert page2["count"] == 1
+
+
+class TestUpdateLibraryEntry:
+    """Tests for PUT /api/library/{id}."""
+
+    def test_partial_update(self, client: TestClient, admin_headers: dict[str, str]) -> None:
+        _skip_if_no_neo4j()
+        created = client.post(
+            "/api/library",
+            json={"title": "Old", "author": "Keep me", "type": "book"},
+            headers=admin_headers,
+        ).json()
+        response = client.put(
+            f"/api/library/{created['id']}",
+            json={"title": "New"},
+            headers=admin_headers,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["title"] == "New"
+        assert data["author"] == "Keep me"  # unchanged
+        assert data["type"] == "book"  # unchanged
+
+    def test_update_without_auth_fails(self, client: TestClient) -> None:
+        response = client.put("/api/library/whatever", json={"title": "x"})
+        assert response.status_code == 401
+
+    def test_update_missing_returns_404(
+        self, client: TestClient, admin_headers: dict[str, str]
+    ) -> None:
+        _skip_if_no_neo4j()
+        response = client.put(
+            "/api/library/nope", json={"title": "x"}, headers=admin_headers
+        )
+        assert response.status_code == 404
+
+
+class TestDeleteLibraryEntry:
+    """Tests for DELETE /api/library/{id}."""
+
+    def test_delete(self, client: TestClient, admin_headers: dict[str, str]) -> None:
+        _skip_if_no_neo4j()
+        created = client.post(
+            "/api/library", json={"title": "Delete me"}, headers=admin_headers
+        ).json()
+        response = client.delete(f"/api/library/{created['id']}", headers=admin_headers)
+        assert response.status_code == 200
+        assert client.get(f"/api/library/{created['id']}").status_code == 404
+
+    def test_delete_without_auth_fails(self, client: TestClient) -> None:
+        response = client.delete("/api/library/whatever")
+        assert response.status_code == 401
+
+    def test_delete_missing_returns_404(
+        self, client: TestClient, admin_headers: dict[str, str]
+    ) -> None:
+        _skip_if_no_neo4j()
+        response = client.delete("/api/library/nope", headers=admin_headers)
+        assert response.status_code == 404

--- a/frontend/src/app/library/[id]/edit/page.tsx
+++ b/frontend/src/app/library/[id]/edit/page.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Breadcrumb from "@/components/Breadcrumb";
+import PageHeader from "@/components/PageHeader";
+import { LoadingState, ErrorState } from "@/components/PageState";
+import LibraryEntryForm, { LibraryFormValues, parseTags } from "@/components/LibraryEntryForm";
+import { getLibraryEntry, updateLibraryEntry } from "@/lib/api/library";
+import { logger } from "@/lib/logger";
+import styles from "../../page.module.scss";
+
+export default function EditLibraryEntryPage() {
+  const router = useRouter();
+  const params = useParams();
+  const entryId = params.id as string;
+
+  const [initialValues, setInitialValues] = useState<LibraryFormValues | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const entry = await getLibraryEntry(entryId);
+        setInitialValues({
+          title: entry.title,
+          source_url: entry.source_url,
+          author: entry.author,
+          type: entry.type,
+          summary: entry.summary,
+          tags: entry.tags.join(", "),
+        });
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load entry");
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [entryId]);
+
+  const handleSubmit = async (values: LibraryFormValues) => {
+    await updateLibraryEntry(entryId, {
+      title: values.title.trim(),
+      source_url: values.source_url.trim(),
+      author: values.author.trim(),
+      type: values.type,
+      summary: values.summary,
+      tags: parseTags(values.tags),
+    });
+    logger.info("Updated library entry", { id: entryId });
+    router.push(`/library/${entryId}`);
+  };
+
+  if (loading) {
+    return (
+      <div className={styles.container}>
+        <LoadingState label="Loading entry" />
+      </div>
+    );
+  }
+
+  if (error || !initialValues) {
+    return (
+      <div className={styles.container}>
+        <ErrorState
+          message={error || "Entry not found"}
+          backHref="/library"
+          backLabel="Back to Library"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.container}>
+      <PageHeader title="Edit Library Entry" breadcrumb={<Breadcrumb section="library" />} />
+      <main className={styles.main}>
+        <LibraryEntryForm
+          initialValues={initialValues}
+          submitLabel="Save changes"
+          onSubmit={handleSubmit}
+          onCancelHref={`/library/${entryId}`}
+        />
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/app/library/[id]/page.module.scss
+++ b/frontend/src/app/library/[id]/page.module.scss
@@ -1,0 +1,128 @@
+/**
+ * Library entry detail styles (#294)
+ */
+
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
+@use "@/styles/rendered-markdown" as *;
+
+.container {
+  min-height: 100vh;
+  background: linear-gradient(
+    to bottom right,
+    $color-page-bg-gradient-start,
+    $color-page-bg-gradient-end
+  );
+}
+
+.main {
+  @include container;
+  max-width: 48rem;
+  padding-top: $spacing-8;
+  padding-bottom: $spacing-8;
+}
+
+.adminActions {
+  display: flex;
+  gap: $spacing-2;
+}
+
+.editButton {
+  padding: $spacing-2 $spacing-4;
+  border-radius: $border-radius-button;
+  background-color: $color-interactive-primary;
+  color: $color-interactive-primary-text;
+  font-weight: $font-weight-medium;
+  text-decoration: none;
+  white-space: nowrap;
+
+  &:hover {
+    background-color: $color-interactive-primary-hover;
+  }
+}
+
+.deleteButton {
+  padding: $spacing-2 $spacing-4;
+  border: 1px solid $color-error-border;
+  border-radius: $border-radius-button;
+  background: transparent;
+  color: $color-error-text;
+  font-weight: $font-weight-medium;
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    background-color: $color-error-bg;
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}
+
+.meta {
+  display: flex;
+  align-items: center;
+  gap: $spacing-3;
+  margin-bottom: $spacing-4;
+}
+
+.typeBadge {
+  padding: 2px $spacing-2;
+  border-radius: $border-radius-full;
+  background-color: $color-surface-secondary;
+  color: $color-text-secondary;
+  font-size: $font-size-xs;
+  font-family: $font-family-mono;
+  text-transform: lowercase;
+}
+
+.sourceLink {
+  color: $color-interactive-primary;
+  font-weight: $font-weight-medium;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-2;
+  margin-bottom: $spacing-5;
+}
+
+.tag {
+  padding: 2px $spacing-2;
+  border-radius: $border-radius-full;
+  background-color: $color-surface-secondary;
+  color: $color-text-secondary;
+  font-size: $font-size-xs;
+  font-family: $font-family-mono;
+}
+
+.summaryCard {
+  padding: $spacing-6;
+  border: 1px solid $color-border-default;
+  border-radius: $border-radius-lg;
+  background-color: $color-surface-default;
+  box-shadow: $shadow-button;
+}
+
+.renderedSummary {
+  @include rendered-markdown;
+}
+
+.plainSummary {
+  white-space: pre-wrap;
+  color: $color-text-primary;
+  line-height: $line-height-relaxed;
+}
+
+.noSummary {
+  @include text-secondary;
+  font-style: italic;
+  margin: 0;
+}

--- a/frontend/src/app/library/[id]/page.tsx
+++ b/frontend/src/app/library/[id]/page.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import Breadcrumb from "@/components/Breadcrumb";
+import PageHeader from "@/components/PageHeader";
+import { LoadingState, ErrorState } from "@/components/PageState";
+import { getLibraryEntry, deleteLibraryEntry, LibraryEntry } from "@/lib/api/library";
+import { isAuthenticated } from "@/lib/api/client";
+import { sanitizeHtml } from "@/lib/sanitize";
+import { logger } from "@/lib/logger";
+import styles from "./page.module.scss";
+
+export default function LibraryEntryPage() {
+  const router = useRouter();
+  const params = useParams();
+  const entryId = params.id as string;
+
+  const [entry, setEntry] = useState<LibraryEntry | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [authed, setAuthed] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  useEffect(() => {
+    setAuthed(isAuthenticated());
+  }, []);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await getLibraryEntry(entryId);
+        setEntry(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load entry");
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [entryId]);
+
+  const handleDelete = async () => {
+    if (!confirm("Delete this library entry? This cannot be undone.")) return;
+    setDeleting(true);
+    try {
+      await deleteLibraryEntry(entryId);
+      logger.info("Deleted library entry", { id: entryId });
+      router.push("/library");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete entry");
+      setDeleting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className={styles.container}>
+        <LoadingState label="Loading entry" />
+      </div>
+    );
+  }
+
+  if (error || !entry) {
+    return (
+      <div className={styles.container}>
+        <ErrorState
+          message={error || "Entry not found"}
+          backHref="/library"
+          backLabel="Back to Library"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.container}>
+      <PageHeader
+        title={entry.title}
+        subtitle={entry.author || undefined}
+        breadcrumb={<Breadcrumb section="library" />}
+        actions={
+          authed ? (
+            <div className={styles.adminActions}>
+              <Link href={`/library/${entry.id}/edit`} className={styles.editButton}>
+                Edit
+              </Link>
+              <button
+                type="button"
+                onClick={handleDelete}
+                className={styles.deleteButton}
+                disabled={deleting}
+              >
+                {deleting ? "Deleting…" : "Delete"}
+              </button>
+            </div>
+          ) : undefined
+        }
+      />
+
+      <main className={styles.main}>
+        <div className={styles.meta}>
+          <span className={styles.typeBadge}>{entry.type}</span>
+          {entry.source_url && (
+            <a
+              href={entry.source_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.sourceLink}
+            >
+              View source ↗
+            </a>
+          )}
+        </div>
+
+        {entry.tags.length > 0 && (
+          <div className={styles.tags}>
+            {entry.tags.map((tag) => (
+              <span key={tag} className={styles.tag}>
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+
+        <div className={styles.summaryCard}>
+          {entry.html_summary ? (
+            <div
+              className={styles.renderedSummary}
+              dangerouslySetInnerHTML={{ __html: sanitizeHtml(entry.html_summary) }}
+            />
+          ) : entry.summary ? (
+            <div className={styles.plainSummary}>{entry.summary}</div>
+          ) : (
+            <p className={styles.noSummary}>No summary yet.</p>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/app/library/new/page.tsx
+++ b/frontend/src/app/library/new/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import Breadcrumb from "@/components/Breadcrumb";
+import PageHeader from "@/components/PageHeader";
+import LibraryEntryForm, { LibraryFormValues, parseTags } from "@/components/LibraryEntryForm";
+import { createLibraryEntry } from "@/lib/api/library";
+import { isAuthenticated } from "@/lib/api/client";
+import { logger } from "@/lib/logger";
+import styles from "../page.module.scss";
+
+export default function NewLibraryEntryPage() {
+  const router = useRouter();
+  const [authed, setAuthed] = useState<boolean | null>(null);
+
+  // isAuthenticated reads localStorage — only valid after hydration
+  useEffect(() => {
+    setAuthed(isAuthenticated());
+  }, []);
+
+  const handleSubmit = async (values: LibraryFormValues) => {
+    const entry = await createLibraryEntry({
+      title: values.title.trim(),
+      source_url: values.source_url.trim(),
+      author: values.author.trim(),
+      type: values.type,
+      summary: values.summary,
+      tags: parseTags(values.tags),
+    });
+    logger.info("Created library entry", { id: entry.id });
+    router.push(`/library/${entry.id}`);
+  };
+
+  return (
+    <div className={styles.container}>
+      <PageHeader
+        title="New Library Entry"
+        subtitle="Add a resource worth reaching back to"
+        breadcrumb={<Breadcrumb section="library" />}
+      />
+      <main className={styles.main}>
+        {authed === false ? (
+          <div className={styles.noResults}>
+            <p>You need to sign in as admin to add library entries.</p>
+            <Link href="/library" className={styles.clearButton}>
+              Back to Library
+            </Link>
+          </div>
+        ) : (
+          <LibraryEntryForm
+            submitLabel="Create entry"
+            onSubmit={handleSubmit}
+            onCancelHref="/library"
+          />
+        )}
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/app/library/page.module.scss
+++ b/frontend/src/app/library/page.module.scss
@@ -1,0 +1,275 @@
+/**
+ * Library Page Styles (#294)
+ * Curated catalog of external resources worth reaching back to.
+ */
+
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
+
+.container {
+  min-height: 100vh;
+  background: linear-gradient(
+    to bottom right,
+    $color-page-bg-gradient-start,
+    $color-page-bg-gradient-end
+  );
+}
+
+.newButton {
+  padding: $spacing-2 $spacing-4;
+  border-radius: $border-radius-button;
+  background-color: $color-interactive-primary;
+  color: $color-interactive-primary-text;
+  font-weight: $font-weight-medium;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: background-color 0.2s ease;
+
+  &:hover {
+    background-color: $color-interactive-primary-hover;
+  }
+}
+
+.main {
+  @include container;
+  padding-top: $spacing-8;
+  padding-bottom: $spacing-8;
+}
+
+// ===== FILTER BAR =====
+.filterBar {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-3;
+  margin-bottom: $spacing-5;
+}
+
+.searchInput {
+  width: 100%;
+  padding: $spacing-3 $spacing-4;
+  border: 1px solid $color-border-default;
+  border-radius: $border-radius-button;
+  background-color: $color-surface-default;
+  color: $color-text-primary;
+  font-size: $font-size-base;
+
+  &:focus {
+    outline: 2px solid $color-interactive-primary-focus;
+    outline-offset: 1px;
+    border-color: $color-interactive-primary;
+  }
+}
+
+.typeFilters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-2;
+}
+
+.typeChip {
+  padding: $spacing-1 $spacing-3;
+  border: 1px solid $color-border-default;
+  border-radius: $border-radius-full;
+  background-color: $color-surface-default;
+  color: $color-text-secondary;
+  font-size: $font-size-sm;
+  font-family: $font-family-mono;
+  text-transform: lowercase;
+  cursor: pointer;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease,
+    color 0.2s ease;
+
+  &:hover {
+    border-color: $color-interactive-primary;
+    color: $color-text-primary;
+  }
+}
+
+.typeChipActive {
+  background-color: $color-interactive-primary;
+  border-color: $color-interactive-primary;
+  color: $color-interactive-primary-text;
+
+  &:hover {
+    color: $color-interactive-primary-text;
+  }
+}
+
+// ===== RESULTS BAR =====
+.resultsBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $spacing-3;
+  margin-bottom: $spacing-4;
+}
+
+.resultsCount {
+  @include text-secondary;
+  font-size: $font-size-sm;
+  font-family: $font-family-mono;
+}
+
+.clearButton {
+  padding: $spacing-1 $spacing-3;
+  border: 1px solid $color-border-default;
+  border-radius: $border-radius-button;
+  background: transparent;
+  color: $color-text-secondary;
+  font-size: $font-size-sm;
+  cursor: pointer;
+
+  &:hover {
+    color: $color-text-primary;
+    border-color: $color-interactive-primary;
+  }
+}
+
+// ===== ENTRY GRID =====
+.grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: $spacing-4;
+
+  @media (min-width: 640px) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @media (min-width: 1024px) {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2;
+  height: 100%;
+  padding: $spacing-5;
+  border: 1px solid $color-border-default;
+  border-left: 3px solid $color-interactive-primary;
+  border-radius: $border-radius-lg;
+  background-color: $color-surface-default;
+  text-decoration: none;
+  box-shadow: $shadow-button;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    transform 0.2s ease;
+
+  &:hover {
+    border-color: $color-interactive-primary;
+    box-shadow: $shadow-button-hover;
+    transform: translateY(-2px);
+  }
+
+  &:focus-visible {
+    outline: 2px solid $color-interactive-primary-focus;
+    outline-offset: 3px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+
+    &:hover {
+      transform: none;
+    }
+  }
+}
+
+.cardTop {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.typeBadge {
+  padding: 2px $spacing-2;
+  border-radius: $border-radius-full;
+  background-color: $color-surface-secondary;
+  color: $color-text-secondary;
+  font-size: $font-size-xs;
+  font-family: $font-family-mono;
+  text-transform: lowercase;
+}
+
+.cardTitle {
+  font-size: $font-size-lg;
+  font-weight: $font-weight-semibold;
+  color: $color-text-heading;
+  line-height: $line-height-tight;
+  margin: 0;
+}
+
+.cardAuthor {
+  @include text-secondary;
+  font-size: $font-size-sm;
+  margin: 0;
+}
+
+.cardSummary {
+  @include text-secondary;
+  font-size: $font-size-sm;
+  line-height: $line-height-relaxed;
+  margin: 0;
+}
+
+.cardTags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-1;
+  margin-top: auto;
+  padding-top: $spacing-2;
+}
+
+.cardTag {
+  padding: 2px $spacing-2;
+  border-radius: $border-radius-full;
+  background-color: $color-surface-secondary;
+  color: $color-text-secondary;
+  font-size: $font-size-xs;
+  font-family: $font-family-mono;
+}
+
+// ===== EMPTY / NO RESULTS =====
+.emptyState,
+.noResults {
+  text-align: center;
+  padding: $spacing-8 $spacing-4;
+  color: $color-text-secondary;
+}
+
+.emptyIcon {
+  font-size: 3rem;
+  margin-bottom: $spacing-3;
+}
+
+.emptyTitle {
+  font-size: $font-size-xl;
+  font-weight: $font-weight-semibold;
+  color: $color-text-heading;
+  margin: 0 0 $spacing-2;
+}
+
+.emptyMessage {
+  margin: 0 auto $spacing-4;
+  max-width: 32rem;
+}
+
+.createButton {
+  display: inline-block;
+  padding: $spacing-2 $spacing-5;
+  border-radius: $border-radius-button;
+  background-color: $color-interactive-primary;
+  color: $color-interactive-primary-text;
+  font-weight: $font-weight-medium;
+  text-decoration: none;
+
+  &:hover {
+    background-color: $color-interactive-primary-hover;
+  }
+}

--- a/frontend/src/app/library/page.tsx
+++ b/frontend/src/app/library/page.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useState, useEffect, useMemo } from "react";
+import Link from "next/link";
+import {
+  listAllLibraryEntries,
+  LibraryEntry,
+  LibraryEntryType,
+  LIBRARY_ENTRY_TYPES,
+} from "@/lib/api/library";
+import { logger } from "@/lib/logger";
+import Breadcrumb from "@/components/Breadcrumb";
+import PageHeader from "@/components/PageHeader";
+import { LoadingState, ErrorState } from "@/components/PageState";
+import styles from "./page.module.scss";
+
+type TypeFilter = "all" | LibraryEntryType;
+
+export default function LibraryPage() {
+  const [entries, setEntries] = useState<LibraryEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
+
+  useEffect(() => {
+    async function fetchEntries() {
+      try {
+        setLoading(true);
+        const all = await listAllLibraryEntries();
+        setEntries(all);
+        logger.info("Library entries loaded", { count: all.length });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to load library";
+        setError(message);
+        logger.error("Failed to load library entries", err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchEntries();
+  }, []);
+
+  // Which types actually have entries (so we don't show empty filter chips)
+  const availableTypes = useMemo(() => {
+    const present = new Set(entries.map((e) => e.type));
+    return LIBRARY_ENTRY_TYPES.filter((t) => present.has(t));
+  }, [entries]);
+
+  const filteredEntries = useMemo(() => {
+    return entries.filter((entry) => {
+      if (typeFilter !== "all" && entry.type !== typeFilter) return false;
+
+      if (searchQuery) {
+        const q = searchQuery.toLowerCase();
+        const matches =
+          entry.title.toLowerCase().includes(q) ||
+          entry.author.toLowerCase().includes(q) ||
+          entry.summary.toLowerCase().includes(q) ||
+          entry.tags.some((tag) => tag.toLowerCase().includes(q));
+        if (!matches) return false;
+      }
+      return true;
+    });
+  }, [entries, searchQuery, typeFilter]);
+
+  const clearFilters = () => {
+    setSearchQuery("");
+    setTypeFilter("all");
+  };
+  const hasActiveFilters = searchQuery !== "" || typeFilter !== "all";
+
+  if (loading) {
+    return (
+      <div className={styles.container}>
+        <LoadingState variant="cards" label="Loading library" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={styles.container}>
+        <ErrorState message={error} backHref="/" backLabel="Back to home" />
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.container}>
+      <PageHeader
+        title="Library"
+        subtitle="Books, articles, and resources worth reaching back to"
+        breadcrumb={<Breadcrumb section="library" toHub />}
+        actions={
+          <Link href="/library/new" className={styles.newButton}>
+            + New Entry
+          </Link>
+        }
+      />
+
+      <main className={styles.main}>
+        {/* Filter bar */}
+        <div className={styles.filterBar}>
+          <input
+            type="text"
+            placeholder="Search the library..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className={styles.searchInput}
+            aria-label="Search the library"
+          />
+          {availableTypes.length > 0 && (
+            <div className={styles.typeFilters} role="group" aria-label="Filter by type">
+              <button
+                type="button"
+                onClick={() => setTypeFilter("all")}
+                className={`${styles.typeChip} ${typeFilter === "all" ? styles.typeChipActive : ""}`}
+                aria-pressed={typeFilter === "all"}
+              >
+                All ({entries.length})
+              </button>
+              {availableTypes.map((t) => (
+                <button
+                  key={t}
+                  type="button"
+                  onClick={() => setTypeFilter(t)}
+                  className={`${styles.typeChip} ${typeFilter === t ? styles.typeChipActive : ""}`}
+                  aria-pressed={typeFilter === t}
+                >
+                  {t} ({entries.filter((e) => e.type === t).length})
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className={styles.resultsBar}>
+          <span className={styles.resultsCount}>
+            {filteredEntries.length} {filteredEntries.length === 1 ? "entry" : "entries"}
+            {hasActiveFilters && " matching filters"}
+          </span>
+          {hasActiveFilters && (
+            <button type="button" onClick={clearFilters} className={styles.clearButton}>
+              Clear filters
+            </button>
+          )}
+        </div>
+
+        {/* Empty states */}
+        {entries.length === 0 && (
+          <div className={styles.emptyState}>
+            <div className={styles.emptyIcon}>📚</div>
+            <h3 className={styles.emptyTitle}>The library is empty</h3>
+            <p className={styles.emptyMessage}>
+              Curated books, articles, and resources you value will appear here.
+            </p>
+            <Link href="/library/new" className={styles.createButton}>
+              Add the first entry
+            </Link>
+          </div>
+        )}
+
+        {entries.length > 0 && filteredEntries.length === 0 && (
+          <div className={styles.noResults}>
+            <p>No entries match your filters.</p>
+            <button type="button" onClick={clearFilters} className={styles.clearButton}>
+              Clear filters
+            </button>
+          </div>
+        )}
+
+        {/* Entry grid */}
+        {filteredEntries.length > 0 && (
+          <ul className={styles.grid}>
+            {filteredEntries.map((entry) => (
+              <li key={entry.id}>
+                <Link href={`/library/${entry.id}`} className={styles.card}>
+                  <div className={styles.cardTop}>
+                    <span className={styles.typeBadge}>{entry.type}</span>
+                  </div>
+                  <h2 className={styles.cardTitle}>{entry.title}</h2>
+                  {entry.author && <p className={styles.cardAuthor}>{entry.author}</p>}
+                  {entry.summary && (
+                    <p className={styles.cardSummary}>{entry.summary.slice(0, 180)}</p>
+                  )}
+                  {entry.tags.length > 0 && (
+                    <div className={styles.cardTags}>
+                      {entry.tags.map((tag) => (
+                        <span key={tag} className={styles.cardTag}>
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/app/page.module.scss
+++ b/frontend/src/app/page.module.scss
@@ -80,6 +80,12 @@
   min-width: 0;
 }
 
+.cardStack {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-4;
+}
+
 // ===== SOCIAL LINKS (quiet mono text links) =====
 .socialLinks {
   @include cluster($spacing-6);

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -33,17 +33,31 @@ export default function Home() {
               </nav>
             </div>
 
-            <Link href="/knowledge-base" className={styles.kbCard}>
-              <span className={styles.kbCardTitle}>
-                Knowledge base
-                <span className={styles.kbCardArrow} aria-hidden="true">
-                  →
+            <div className={styles.cardStack}>
+              <Link href="/knowledge-base" className={styles.kbCard}>
+                <span className={styles.kbCardTitle}>
+                  Knowledge base
+                  <span className={styles.kbCardArrow} aria-hidden="true">
+                    →
+                  </span>
                 </span>
-              </span>
-              <span className={styles.kbCardDescription}>
-                A curated digital garden of engineering and leadership insights.
-              </span>
-            </Link>
+                <span className={styles.kbCardDescription}>
+                  A curated digital garden of engineering and leadership insights.
+                </span>
+              </Link>
+
+              <Link href="/library" className={styles.kbCard}>
+                <span className={styles.kbCardTitle}>
+                  Library
+                  <span className={styles.kbCardArrow} aria-hidden="true">
+                    →
+                  </span>
+                </span>
+                <span className={styles.kbCardDescription}>
+                  Books, articles, and resources worth reaching back to.
+                </span>
+              </Link>
+            </div>
           </div>
         </header>
 

--- a/frontend/src/components/Breadcrumb.tsx
+++ b/frontend/src/components/Breadcrumb.tsx
@@ -11,18 +11,20 @@ import Link from "next/link";
 import styles from "./Breadcrumb.module.scss";
 
 interface BreadcrumbProps {
-  section: "articles" | "notes" | "toolbox" | "inspire";
-  /** Set to true on list pages to link back to /knowledge-base hub */
+  section: "articles" | "notes" | "toolbox" | "inspire" | "library";
+  /** Set to true on list pages to link back to the parent hub */
   toHub?: boolean;
   className?: string;
 }
 
 export default function Breadcrumb({ section, toHub = false, className = "" }: BreadcrumbProps) {
-  // If toHub is true, link back to the KB hub page
+  // If toHub is true, link back to the parent hub. The Library is a top-level
+  // app, so its hub is the home page; everything else lives under the KB.
   if (toHub) {
+    const hubHref = section === "library" ? "/" : "/knowledge-base";
     return (
       <nav aria-label="Breadcrumb" className={`${styles.breadcrumb} ${className}`}>
-        <Link href="/knowledge-base" className={styles.link}>
+        <Link href={hubHref} className={styles.link}>
           ← Back
         </Link>
       </nav>
@@ -46,6 +48,10 @@ export default function Breadcrumb({ section, toHub = false, className = "" }: B
     inspire: {
       label: "Back",
       href: "/knowledge-base",
+    },
+    library: {
+      label: "Back",
+      href: "/library",
     },
   };
 

--- a/frontend/src/components/LibraryEntryForm.module.scss
+++ b/frontend/src/components/LibraryEntryForm.module.scss
@@ -1,0 +1,113 @@
+/**
+ * Library entry form styles (#294)
+ */
+
+@use "@/styles/design-tokens" as *;
+@use "@/styles/mixins" as *;
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-4;
+  max-width: 44rem;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: $spacing-4;
+
+  @media (min-width: 640px) {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-1;
+}
+
+.label {
+  font-size: $font-size-sm;
+  font-weight: $font-weight-medium;
+  color: $color-text-heading;
+}
+
+.input,
+.textarea {
+  width: 100%;
+  padding: $spacing-2 $spacing-3;
+  border: 1px solid $color-border-default;
+  border-radius: $border-radius-button;
+  background-color: $color-surface-default;
+  color: $color-text-primary;
+  font-size: $font-size-base;
+  font-family: inherit;
+
+  &:focus {
+    outline: 2px solid $color-interactive-primary-focus;
+    outline-offset: 1px;
+    border-color: $color-interactive-primary;
+  }
+}
+
+.textarea {
+  resize: vertical;
+  min-height: 8rem;
+  font-family: $font-family-mono;
+  line-height: $line-height-relaxed;
+}
+
+.hint {
+  @include text-secondary;
+  font-size: $font-size-xs;
+}
+
+.error {
+  padding: $spacing-3 $spacing-4;
+  border: 1px solid $color-error-border;
+  border-radius: $border-radius-button;
+  background-color: $color-error-bg;
+  color: $color-error-text;
+  font-size: $font-size-sm;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: $spacing-3;
+  margin-top: $spacing-2;
+}
+
+.cancel {
+  padding: $spacing-2 $spacing-4;
+  border-radius: $border-radius-button;
+  color: $color-text-secondary;
+  text-decoration: none;
+  font-size: $font-size-sm;
+
+  &:hover {
+    color: $color-text-primary;
+  }
+}
+
+.submit {
+  padding: $spacing-2 $spacing-5;
+  border: none;
+  border-radius: $border-radius-button;
+  background-color: $color-interactive-primary;
+  color: $color-interactive-primary-text;
+  font-weight: $font-weight-medium;
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    background-color: $color-interactive-primary-hover;
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}

--- a/frontend/src/components/LibraryEntryForm.tsx
+++ b/frontend/src/components/LibraryEntryForm.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+/**
+ * Shared create/edit form for Library entries (#294).
+ * Presentational: the parent owns submission (create vs update).
+ */
+
+import { useState } from "react";
+import { LibraryEntryType, LIBRARY_ENTRY_TYPES } from "@/lib/api/library";
+import styles from "./LibraryEntryForm.module.scss";
+
+export interface LibraryFormValues {
+  title: string;
+  source_url: string;
+  author: string;
+  type: LibraryEntryType;
+  summary: string;
+  tags: string; // comma-separated in the form; parsed on submit
+}
+
+export const EMPTY_LIBRARY_VALUES: LibraryFormValues = {
+  title: "",
+  source_url: "",
+  author: "",
+  type: "book",
+  summary: "",
+  tags: "",
+};
+
+export function parseTags(tags: string): string[] {
+  return tags
+    .split(",")
+    .map((t) => t.trim())
+    .filter(Boolean);
+}
+
+interface LibraryEntryFormProps {
+  initialValues?: LibraryFormValues;
+  submitLabel: string;
+  onSubmit: (values: LibraryFormValues) => Promise<void>;
+  onCancelHref: string;
+}
+
+export default function LibraryEntryForm({
+  initialValues = EMPTY_LIBRARY_VALUES,
+  submitLabel,
+  onSubmit,
+  onCancelHref,
+}: LibraryEntryFormProps) {
+  const [values, setValues] = useState<LibraryFormValues>(initialValues);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const set = <K extends keyof LibraryFormValues>(key: K, value: LibraryFormValues[K]) =>
+    setValues((prev) => ({ ...prev, [key]: value }));
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!values.title.trim()) {
+      setError("Title is required.");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onSubmit(values);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong.");
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form className={styles.form} onSubmit={handleSubmit}>
+      {error && (
+        <div className={styles.error} role="alert">
+          {error}
+        </div>
+      )}
+
+      <label className={styles.field}>
+        <span className={styles.label}>Title *</span>
+        <input
+          type="text"
+          value={values.title}
+          onChange={(e) => set("title", e.target.value)}
+          className={styles.input}
+          required
+        />
+      </label>
+
+      <div className={styles.row}>
+        <label className={styles.field}>
+          <span className={styles.label}>Type</span>
+          <select
+            value={values.type}
+            onChange={(e) => set("type", e.target.value as LibraryEntryType)}
+            className={styles.input}
+          >
+            {LIBRARY_ENTRY_TYPES.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className={styles.field}>
+          <span className={styles.label}>Author</span>
+          <input
+            type="text"
+            value={values.author}
+            onChange={(e) => set("author", e.target.value)}
+            className={styles.input}
+          />
+        </label>
+      </div>
+
+      <label className={styles.field}>
+        <span className={styles.label}>Source URL</span>
+        <input
+          type="url"
+          value={values.source_url}
+          onChange={(e) => set("source_url", e.target.value)}
+          className={styles.input}
+          placeholder="https://..."
+        />
+      </label>
+
+      <label className={styles.field}>
+        <span className={styles.label}>Tags</span>
+        <input
+          type="text"
+          value={values.tags}
+          onChange={(e) => set("tags", e.target.value)}
+          className={styles.input}
+          placeholder="comma, separated, tags"
+        />
+      </label>
+
+      <label className={styles.field}>
+        <span className={styles.label}>Summary</span>
+        <textarea
+          value={values.summary}
+          onChange={(e) => set("summary", e.target.value)}
+          className={styles.textarea}
+          rows={8}
+          placeholder="Your own summary. Markdown supported."
+        />
+        <span className={styles.hint}>Your own notes — Markdown supported.</span>
+      </label>
+
+      <div className={styles.actions}>
+        <a href={onCancelHref} className={styles.cancel}>
+          Cancel
+        </a>
+        <button type="submit" className={styles.submit} disabled={submitting}>
+          {submitting ? "Saving…" : submitLabel}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/lib/api/library.ts
+++ b/frontend/src/lib/api/library.ts
@@ -1,0 +1,188 @@
+/**
+ * API client for the Library (curated resource catalog, #294)
+ */
+
+import { logger } from "@/lib/logger";
+import { getAuthHeaders } from "@/lib/api/client";
+import { invalidate, revalidatingFetch } from "@/lib/api/cache";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+export type LibraryEntryType = "book" | "article" | "video" | "doc" | "paper" | "other";
+
+export const LIBRARY_ENTRY_TYPES: LibraryEntryType[] = [
+  "book",
+  "article",
+  "video",
+  "doc",
+  "paper",
+  "other",
+];
+
+export interface LibraryEntry {
+  id: string;
+  title: string;
+  source_url: string;
+  author: string;
+  type: LibraryEntryType;
+  summary: string;
+  html_summary?: string; // Pre-rendered HTML from backend (#233)
+  tags: string[];
+  created_at: number;
+  updated_at: number;
+}
+
+export interface CreateLibraryEntryRequest {
+  title: string;
+  source_url?: string;
+  author?: string;
+  type?: LibraryEntryType;
+  summary?: string;
+  tags?: string[];
+}
+
+export type UpdateLibraryEntryRequest = Partial<CreateLibraryEntryRequest>;
+
+export interface LibraryListResponse {
+  entries: LibraryEntry[];
+  count: number;
+  total: number;
+  page: number;
+  limit: number;
+  total_pages: number;
+}
+
+export interface ListLibraryOptions {
+  type?: LibraryEntryType;
+  tag?: string;
+  page?: number;
+  limit?: number;
+}
+
+/**
+ * List library entries with optional filters and pagination.
+ */
+export async function listLibraryEntries(
+  options?: ListLibraryOptions
+): Promise<LibraryListResponse> {
+  const params = new URLSearchParams();
+  if (options?.type) params.set("type", options.type);
+  if (options?.tag) params.set("tag", options.tag);
+  if (options?.page !== undefined) params.set("page", String(options.page));
+  if (options?.limit !== undefined) params.set("limit", String(options.limit));
+
+  const url = `${API_URL}/api/library?${params.toString()}`;
+  const response = await revalidatingFetch(url, { headers: getAuthHeaders() });
+
+  if (!response.ok) {
+    logger.error("Failed to list library entries", { status: response.status });
+    throw new Error("Failed to list library entries");
+  }
+
+  const data = await response.json();
+  logger.info("Library entries listed", { count: data.count, total: data.total });
+  return data;
+}
+
+/**
+ * Fetch every library entry across all pages (for the filterable list view).
+ */
+export async function listAllLibraryEntries(
+  options?: Omit<ListLibraryOptions, "page" | "limit">
+): Promise<LibraryEntry[]> {
+  const all: LibraryEntry[] = [];
+  let page = 1;
+  let totalPages = 1;
+  do {
+    const response = await listLibraryEntries({ ...options, page, limit: 100 });
+    all.push(...response.entries);
+    totalPages = response.total_pages;
+    page += 1;
+  } while (page <= totalPages);
+  return all;
+}
+
+/**
+ * Get a single library entry by ID.
+ */
+export async function getLibraryEntry(entryId: string): Promise<LibraryEntry> {
+  const response = await revalidatingFetch(`${API_URL}/api/library/${entryId}`, {
+    headers: getAuthHeaders(),
+  });
+
+  if (!response.ok) {
+    if (response.status === 404) throw new Error("Library entry not found");
+    logger.error("Failed to get library entry", { entryId, status: response.status });
+    throw new Error("Failed to get library entry");
+  }
+
+  return response.json();
+}
+
+/**
+ * Create a library entry (requires admin authentication).
+ */
+export async function createLibraryEntry(
+  request: CreateLibraryEntryRequest
+): Promise<LibraryEntry> {
+  const response = await fetch(`${API_URL}/api/library`, {
+    method: "POST",
+    headers: getAuthHeaders(),
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    const error = await response.json();
+    logger.error("Failed to create library entry", { status: response.status, error });
+    throw new Error(error.detail || "Failed to create library entry");
+  }
+
+  const entry = await response.json();
+  invalidate();
+  logger.info("Library entry created", { id: entry.id });
+  return entry;
+}
+
+/**
+ * Update a library entry (requires admin authentication).
+ */
+export async function updateLibraryEntry(
+  entryId: string,
+  request: UpdateLibraryEntryRequest
+): Promise<LibraryEntry> {
+  const response = await fetch(`${API_URL}/api/library/${entryId}`, {
+    method: "PUT",
+    headers: getAuthHeaders(),
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    const error = await response.json();
+    logger.error("Failed to update library entry", { entryId, status: response.status, error });
+    throw new Error(error.detail || "Failed to update library entry");
+  }
+
+  const entry = await response.json();
+  invalidate();
+  logger.info("Library entry updated", { id: entry.id });
+  return entry;
+}
+
+/**
+ * Delete a library entry (requires admin authentication).
+ */
+export async function deleteLibraryEntry(entryId: string): Promise<void> {
+  const response = await fetch(`${API_URL}/api/library/${entryId}`, {
+    method: "DELETE",
+    headers: getAuthHeaders(),
+  });
+
+  if (!response.ok) {
+    const error = await response.json();
+    logger.error("Failed to delete library entry", { entryId, status: response.status, error });
+    throw new Error(error.detail || "Failed to delete library entry");
+  }
+
+  invalidate();
+  logger.info("Library entry deleted", { id: entryId });
+}


### PR DESCRIPTION
Implements **Library v1 — "Card Catalog"** from #294: a curated catalog of external resources (books, articles, videos, docs) worth reaching back to. Public and metadata-first; no third-party full-text (that's v2, #299).

## What's included

**Backend** — standalone `:LibraryEntry` Neo4j node (kept separate from the notes graph):
- `domain_types.LibraryEntryDict`; adapter CRUD + schema constraint/index + `VALID_NODE_TYPES` entry
- `library_service.py`; `routers/library.py` mounted at `/api/library` (public reads, `AdminUser`-gated + rate-limited writes); `models/library.py`; `get_library` dependency
- Server-rendered `html_summary` (shared markdown pipeline, #233)

**Frontend:**
- `lib/api/library.ts` client
- `/library` list (search + type-filter chips), `/library/[id]` detail (source link, rendered summary, admin Edit/Delete), `/library/new` + `/library/[id]/edit` (shared `LibraryEntryForm`)
- Home-page **Library card** next to the Knowledge Base card (the chosen entry point — no nav restructure)
- `Breadcrumb` extended with a `library` section

## Data model

`title`, `source_url`, `author`, `type` (book/article/video/doc/paper/other), `summary` (Erik's own, Markdown), `tags`. **No `status` field** — the Library is a curated "reach back to it" set, not a reading tracker.

## Explicitly out of scope (→ v2, #299)

Third-party full-text archive, separate/redundant datastore, private-by-storage visibility tier + admin-auth lift, semantic search, graph viz.

## Testing

- Backend: `mypy` strict clean; **645 unit tests pass**, incl. 15 new in `test_library_api.py` (auth, CRUD, type/tag filters, pagination, validation)
- Frontend: `tsc --noEmit` clean; ESLint clean; Prettier clean
- Manual: `/library`, `/library/new`, and home all render; `GET /api/library` returns paginated JSON

Closes #294.
