### PR TITLE
feat(auth): scoped revocable API tokens (#300, #291, #292)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -463,11 +463,32 @@ In `backend/main.py`:
 - `GET /api/auth/session` - Report auth state (200 whether or not signed in)
 - `GET|DELETE /api/auth/credentials` - List / revoke enrolled passkeys
 
-Admin endpoints require a passkey session token. The static `ADMIN_TOKEN` is
-scoped to passkey enrollment only (`/api/auth/register/*`, #267) - it bootstraps
-the first passkey and is the break-glass path, but is rejected (403) everywhere
-else. Deploy-time backups run over SSH (`backend/scripts/backup_export.py`), so
-CI no longer uses the token.
+*Scoped API tokens (#300):*
+- `GET /api/admin/tokens/scopes` - List assignable scopes (full admin)
+- `GET|POST /api/admin/tokens` - List / mint tokens (full admin; plaintext shown once)
+- `DELETE /api/admin/tokens/{token_id}` - Revoke a token (full admin)
+
+Three credentials share the `Authorization: Bearer` transport (see `backend/auth.py`):
+
+1. **Passkey session tokens** - full admin, the human login path.
+2. **Scoped API tokens** - `mgd_`-prefixed random secrets (hashed in Neo4j), each
+   carrying scopes for programmatic use. Endpoints declare a required scope via
+   `require_scope("...")`; a passkey session satisfies every scope, an API token
+   satisfies a granted scope (`admin:*` is a wildcard). Scopes: `notes:write`,
+   `library:write`, `feature_flags:write`, `ai:use`, `admin:*`. Managing tokens
+   themselves always requires full admin, so a narrow token can't self-escalate.
+3. **The static `ADMIN_TOKEN`** - scoped to passkey enrollment only
+   (`/api/auth/register/*`, #267); rejected (403) elsewhere, **except** in local
+   dev (`ENVIRONMENT=development` + `ALLOW_TOKEN_AUTH=true`, #291) where it acts as
+   full admin so a fresh dev box needs no passkey ceremony. `ENVIRONMENT` defaults
+   to `production` (fail-secure), so this can never activate in prod.
+
+**Bootstrap & rotation:** a fresh/migrated prod bootstraps via the static token
+(enroll first passkey -> session -> mint API tokens). API tokens are independent
+of `ADMIN_TOKEN`, and prod sets `SESSION_SECRET` explicitly (#268), so rotating
+`ADMIN_TOKEN` in prod is consequence-free (doesn't invalidate sessions, passkeys,
+or API tokens). A GitHub "deploy token" is a minted scoped API token, not the
+static token. Deploy-time backups run over SSH (`backend/scripts/backup_export.py`).
 
 *AI Features:*
 - `POST /api/search` - Semantic search (articles + notes)

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,6 +3,15 @@ APP_NAME="Knowledge Base API"
 APP_VERSION="0.1.0"
 DEBUG=false
 
+# Deployment environment: "development" or "production" (fail-secure default).
+# Dedicated signal for dev-only conveniences; docker-compose sets this for you.
+ENVIRONMENT=development
+
+# Local dev only (#291): with ENVIRONMENT=development, accept the static admin
+# token as a full admin session (all scopes) so you can skip the passkey
+# ceremony on a fresh dev machine. Ignored unless ENVIRONMENT=development.
+ALLOW_TOKEN_AUTH=false
+
 # Server Configuration
 HOST=0.0.0.0
 PORT=8000

--- a/backend/adapters/neo4j.py
+++ b/backend/adapters/neo4j.py
@@ -142,6 +142,23 @@ class Neo4jAdapter:
                 """
             )
 
+            # ===== API TOKEN SCHEMA (#300) =====
+            # Unique constraint on ApiToken.token_id (public identifier)
+            session.run(
+                """
+                CREATE CONSTRAINT api_token_id_unique IF NOT EXISTS
+                FOR (t:ApiToken) REQUIRE t.token_id IS UNIQUE
+                """
+            )
+
+            # Index on ApiToken.token_hash for auth lookup on every authed request
+            session.run(
+                """
+                CREATE INDEX api_token_hash IF NOT EXISTS
+                FOR (t:ApiToken) ON (t.token_hash)
+                """
+            )
+
             # ===== LIBRARY ENTRY SCHEMA (#294) =====
             # Unique constraint on LibraryEntry.id
             session.run(
@@ -941,6 +958,175 @@ class Neo4jAdapter:
             )
             record = result.single()
             return bool(record and record["consumed"] > 0)
+
+    # ===== API TOKENS (scoped bearer tokens, #300) =====
+
+    def create_api_token(
+        self,
+        token_id: str,
+        token_hash: str,
+        name: str,
+        scopes: list[str],
+        created_at: float,
+        expires_at: float | None,
+    ) -> bool:
+        """Store a newly minted API token (only its hash, never the plaintext).
+
+        Args:
+            token_id: Public identifier used to reference the token (uuid hex)
+            token_hash: SHA-256 hex of the plaintext (auth lookup key)
+            name: Human label ("deploy job", "importer")
+            scopes: Granted scopes (validated by the caller)
+            created_at: Unix timestamp of creation
+            expires_at: Unix timestamp of expiry, or None for no expiry
+
+        Returns:
+            True if stored, False if Neo4j unavailable
+        """
+        if not self._available or not self.driver:
+            return False
+
+        with self.driver.session(database=self.database) as session:
+            session.run(
+                """
+                CREATE (t:ApiToken {
+                    token_id: $token_id,
+                    token_hash: $token_hash,
+                    name: $name,
+                    scopes: $scopes,
+                    created_at: $created_at,
+                    expires_at: $expires_at,
+                    last_used_at: null
+                })
+                """,
+                token_id=token_id,
+                token_hash=token_hash,
+                name=name,
+                scopes=scopes,
+                created_at=created_at,
+                expires_at=expires_at,
+            )
+            return True
+
+    def list_api_tokens(self) -> list[dict[str, Any]]:
+        """List API tokens as metadata (never the hash), newest first.
+
+        Returns:
+            Token records without secrets (empty if Neo4j unavailable)
+        """
+        if not self._available or not self.driver:
+            return []
+
+        with self.driver.session(database=self.database) as session:
+            result = session.run(
+                """
+                MATCH (t:ApiToken)
+                RETURN t.token_id AS token_id,
+                       t.name AS name,
+                       t.scopes AS scopes,
+                       t.created_at AS created_at,
+                       t.expires_at AS expires_at,
+                       t.last_used_at AS last_used_at
+                ORDER BY t.created_at DESC
+                """
+            )
+            return [
+                {
+                    "token_id": record["token_id"],
+                    "name": record["name"],
+                    "scopes": list(record["scopes"] or []),
+                    "created_at": record["created_at"],
+                    "expires_at": record["expires_at"],
+                    "last_used_at": record["last_used_at"],
+                }
+                for record in result
+            ]
+
+    def get_api_token_by_hash(self, token_hash: str) -> dict[str, Any] | None:
+        """Look up an API token by its hash, for request authentication.
+
+        Args:
+            token_hash: SHA-256 hex of the presented plaintext token
+
+        Returns:
+            Token record (including scopes and expiry), or None if not found
+            / Neo4j unavailable
+        """
+        if not self._available or not self.driver:
+            return None
+
+        with self.driver.session(database=self.database) as session:
+            result = session.run(
+                """
+                MATCH (t:ApiToken {token_hash: $token_hash})
+                RETURN t.token_id AS token_id,
+                       t.name AS name,
+                       t.scopes AS scopes,
+                       t.created_at AS created_at,
+                       t.expires_at AS expires_at,
+                       t.last_used_at AS last_used_at
+                """,
+                token_hash=token_hash,
+            )
+            record = result.single()
+            if not record:
+                return None
+            return {
+                "token_id": record["token_id"],
+                "name": record["name"],
+                "scopes": list(record["scopes"] or []),
+                "created_at": record["created_at"],
+                "expires_at": record["expires_at"],
+                "last_used_at": record["last_used_at"],
+            }
+
+    def record_api_token_use(self, token_id: str, now: float) -> bool:
+        """Stamp an API token's last-used time after a successful auth.
+
+        Args:
+            token_id: Public token identifier
+            now: Unix timestamp of use
+
+        Returns:
+            True if updated, False if Neo4j unavailable
+        """
+        if not self._available or not self.driver:
+            return False
+
+        with self.driver.session(database=self.database) as session:
+            session.run(
+                """
+                MATCH (t:ApiToken {token_id: $token_id})
+                SET t.last_used_at = $now
+                """,
+                token_id=token_id,
+                now=now,
+            )
+            return True
+
+    def delete_api_token(self, token_id: str) -> bool:
+        """Revoke (delete) an API token.
+
+        Args:
+            token_id: Public token identifier
+
+        Returns:
+            True if a token was deleted, False otherwise
+        """
+        if not self._available or not self.driver:
+            return False
+
+        with self.driver.session(database=self.database) as session:
+            result = session.run(
+                """
+                MATCH (t:ApiToken {token_id: $token_id})
+                DELETE t
+                RETURN count(t) AS deleted
+                """,
+                token_id=token_id,
+            )
+            record = result.single()
+            return bool(record and record["deleted"] > 0)
 
     def get_all_note_ids(self) -> set[str]:
         """Get all note IDs (for collision detection).

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,31 +1,52 @@
 """Authentication middleware for Zettelkasten notes system.
 
-Two credentials share the `Authorization: Bearer` transport (#229):
+Three credentials share the `Authorization: Bearer` transport:
 
-- **Passkey session tokens** - signed, 12-hour, minted by /api/auth/login/verify.
-  The primary path for humans, and the only one the frontend issues.
-- **The static admin token** - retained for machine callers (the deploy
-  workflow's pre/post-deploy backups) and to gate first-time passkey
-  enrollment. Long-lived and unrevokable, hence the #225 lockout below.
+- **Passkey session tokens** (#229) - signed, 12-hour, minted by
+  /api/auth/login/verify. The primary path for humans, full admin, and the
+  only one the frontend issues.
+- **Scoped API tokens** (#300) - `mgd_`-prefixed random secrets, stored as
+  hashes in Neo4j, each carrying a set of scopes for programmatic use. Created
+  and revoked from the admin panel; the safe way to script against prod.
+- **The static admin token** - scoped to first-time passkey enrollment (#267),
+  plus (in local dev only, #291) a full-admin session when ALLOW_TOKEN_AUTH is
+  set. Long-lived and unrevokable, hence the #225 lockout below.
 
-Session tokens are checked first and are exempt from the lockout: they are
-unguessable by construction, so failed attempts carry no signal about them.
+Endpoints declare a required scope via `require_scope(...)`. A passkey session
+satisfies every scope (full admin); an API token satisfies a scope it was
+granted (with `admin:*` a wildcard); the static token satisfies scopes only on
+the dev bootstrap path. Session tokens are checked first and are exempt from the
+lockout: they are unguessable by construction, so failed attempts carry no
+signal about them.
 """
 
 import hmac
 import logging
 import threading
 import time
+from collections.abc import Callable
 from typing import Annotated, Any
 
 from fastapi import Depends, HTTPException, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
+from adapters.neo4j import get_neo4j_adapter
 from config import get_settings
+from core.api_tokens import (
+    ADMIN_WILDCARD,
+    hash_token,
+    is_expired,
+    looks_like_api_token,
+    scopes_satisfy,
+)
 from core.sessions import derive_session_secret, looks_like_session_token, verify_session_token
 
 logger = logging.getLogger(__name__)
 settings = get_settings()
+
+# A resolved caller: always has 'kind' ('passkey' | 'api_token' | 'token'),
+# and for API tokens also 'scopes' (set[str]) and 'token_id'.
+Principal = dict[str, Any]
 
 # HTTPBearer security scheme - enables "Authorize" button in Swagger UI
 # auto_error=False so we can return custom 401 message for missing auth
@@ -134,32 +155,65 @@ def _check_session_token(token: str) -> dict[str, Any] | None:
     }
 
 
+def _check_api_token(token: str) -> tuple[str, Principal | None]:
+    """Try to authenticate a bearer token as a scoped API token (#300).
+
+    Args:
+        token: The bearer token from the Authorization header
+
+    Returns:
+        (status, principal) where status is:
+        - "valid": principal is the resolved caller (scopes recorded, use stamped)
+        - "expired": the token was ours but has expired (do not count as a
+          brute-force attempt - it is a genuine, if stale, secret)
+        - "miss": no such token (a wrong secret - the caller counts it toward
+          the #225 lockout, exactly like a wrong static token)
+    """
+    adapter = get_neo4j_adapter()
+    record = adapter.get_api_token_by_hash(hash_token(token))
+    if record is None:
+        return "miss", None
+
+    if is_expired(record["expires_at"], time.time()):
+        return "expired", None
+
+    adapter.record_api_token_use(record["token_id"], time.time())
+    return "valid", {
+        "authenticated": True,
+        "kind": "api_token",
+        "token_id": record["token_id"],
+        "scopes": set(record["scopes"]),
+        "name": record["name"],
+        "expires_at": record["expires_at"],
+    }
+
+
 def _authenticate(
     request: Request,
     credentials: HTTPAuthorizationCredentials | None,
 ) -> dict[str, Any]:
-    """Authenticate an admin request, returning the principal or raising.
+    """Resolve the caller's credential to a principal, or raise.
 
-    Shared by verify_admin (passkey sessions only) and verify_enrollment
-    (sessions or the static token). Returns a dict with 'kind' ('passkey' or
-    'token'); each caller decides whether that kind is allowed for its endpoint.
+    Establishes *who* is calling (passkey session, API token, or static token);
+    callers decide whether that principal is *allowed* via _authorize /
+    require_scope. Returns a dict with 'kind' ('passkey', 'api_token', or
+    'token') and, for API tokens, 'scopes'.
 
-    The #225 lockout lives here because this is where the static token is
-    checked: repeated invalid tokens from one IP trigger 429 for LOCKOUT_SECONDS,
-    even for a request that would otherwise carry the correct token. A passkey
-    session is HMAC-signed and unguessable, so an expired or malformed session is
-    reported as 401 and does not count toward that budget - counting it would let
-    a stale browser tab lock the admin out of signing back in.
+    The #225 lockout lives here because this is where guessable secrets (the
+    static token and API tokens) are checked: repeated wrong secrets from one IP
+    trigger 429 for LOCKOUT_SECONDS. A passkey session or a genuine-but-expired
+    API token is reported as 401 and does not count toward that budget - counting
+    it would let a stale credential lock the admin out of getting back in.
 
     Args:
         request: Incoming request (for the client IP)
         credentials: HTTPAuthorizationCredentials from HTTPBearer (None if missing)
 
     Returns:
-        Principal dict with 'kind' ('passkey' or 'token')
+        Principal dict with 'kind' (and 'scopes' for API tokens)
 
     Raises:
-        HTTPException: 401 if no auth header or an expired session, 403 if
+        HTTPException: 401 if no auth header or an expired credential, 403 if an
             invalid token, 429 if the client IP is locked out
     """
     ip = _client_ip(request)
@@ -194,7 +248,32 @@ def _authenticate(
             detail="Session expired. Sign in again with your passkey.",
         )
 
-    # Fall back to the static token (CI/automation, passkey enrollment)
+    # Scoped API token (#300): a mgd_-shaped secret looked up by hash in Neo4j
+    if looks_like_api_token(token):
+        status, principal = _check_api_token(token)
+        if status == "valid" and principal is not None:
+            auth_tracker.record_success(ip)
+            logger.debug("Authenticated via API token %s", principal["token_id"])
+            return principal
+        if status == "expired":
+            logger.info("Rejected expired API token from %s", ip)
+            raise HTTPException(
+                status_code=401,
+                detail="API token expired. Create a new one from the admin panel.",
+            )
+        # "miss": a wrong secret - count it, exactly like a wrong static token
+        failures = auth_tracker.record_failure(ip)
+        logger.warning("Invalid API token attempt from %s (failure %d)", ip, failures)
+        if failures >= MAX_FAILED_ATTEMPTS:
+            logger.warning(
+                "IP %s locked out for %ds after %d failed attempts",
+                ip,
+                LOCKOUT_SECONDS,
+                failures,
+            )
+        raise HTTPException(status_code=403, detail="Invalid API token.")
+
+    # Fall back to the static token (passkey enrollment, dev bootstrap)
     expected_token = settings.admin_token
 
     if not expected_token:
@@ -221,36 +300,113 @@ def _authenticate(
     return {"kind": "token"}
 
 
+def _authorize(principal: Principal, required_scopes: tuple[str, ...]) -> None:
+    """Enforce that a resolved principal may exercise the required scopes.
+
+    Authorization policy, kept separate from _authenticate (which only
+    establishes identity):
+    - passkey session -> full admin, satisfies everything.
+    - API token -> must have been granted every required scope (admin:* is a
+      wildcard, see core.api_tokens.scopes_satisfy).
+    - static token -> only the local-dev bootstrap (#291) treats it as full
+      admin, gated on is_development AND allow_token_auth so it can never
+      activate in production. Otherwise it is enrollment-only and rejected here.
+
+    Args:
+        principal: The resolved caller from _authenticate
+        required_scopes: Scopes the endpoint demands (all must be satisfied)
+
+    Raises:
+        HTTPException: 403 if the principal lacks a required scope
+    """
+    kind = principal["kind"]
+
+    if kind == "passkey":
+        return
+
+    if kind == "api_token":
+        granted: set[str] = principal["scopes"]
+        for required in required_scopes:
+            if not scopes_satisfy(granted, required):
+                logger.info(
+                    "API token %s lacks scope %s (has %s)",
+                    principal.get("token_id"),
+                    required,
+                    sorted(granted),
+                )
+                raise HTTPException(
+                    status_code=403,
+                    detail=f"This token lacks the required scope: {required}.",
+                )
+        return
+
+    # kind == "token": the static admin token
+    if settings.is_development and settings.allow_token_auth:
+        logger.warning("Static admin token accepted as full admin (dev ALLOW_TOKEN_AUTH, #291)")
+        return
+
+    raise HTTPException(
+        status_code=403,
+        detail="This operation requires a passkey session or a scoped API token.",
+    )
+
+
+def require_scope(
+    *required_scopes: str,
+) -> Callable[[Request, HTTPAuthorizationCredentials | None], Principal]:
+    """Build a dependency that authenticates and enforces the given scopes.
+
+    Use on any admin-gated endpoint in place of AdminUser to allow scoped API
+    tokens (#300) alongside passkey sessions. The returned dependency yields the
+    resolved principal, so a handler can inspect the caller if it needs to.
+
+    Example:
+        @router.post("/notes")
+        async def create(_admin: Annotated[Principal, Depends(require_scope("notes:write"))]):
+            ...
+
+    Args:
+        *required_scopes: One or more scopes the caller must satisfy
+
+    Returns:
+        A FastAPI dependency callable
+    """
+
+    def dependency(
+        request: Request,
+        credentials: HTTPAuthorizationCredentials | None = Depends(security),
+    ) -> Principal:
+        principal = _authenticate(request, credentials)
+        _authorize(principal, required_scopes)
+        return principal
+
+    return dependency
+
+
 def verify_admin(
     request: Request,
     credentials: HTTPAuthorizationCredentials | None = Depends(security),
 ) -> bool:
-    """Full admin access: a passkey session is required (#267).
+    """Full admin access: a passkey session, an `admin:*` API token, or (in
+    local dev) the static token.
 
-    The static token no longer grants general admin access - it is scoped to
-    passkey enrollment (see verify_enrollment). A correct static token still
-    authenticates, but is rejected here with 403 directing the caller to sign in
-    with a passkey. This is the dependency behind AdminUser, used by every admin
-    operation except enrollment.
+    The static token is otherwise scoped to passkey enrollment (#267). This is
+    the dependency behind AdminUser, used by the most sensitive operations
+    (backups, auth and token management) that map to no narrower scope.
 
     Args:
         request: Incoming request (for the client IP)
         credentials: HTTPAuthorizationCredentials from HTTPBearer (None if missing)
 
     Returns:
-        True if authenticated with a passkey session
+        True if authorized for full admin
 
     Raises:
-        HTTPException: 401 if no auth header or an expired session, 403 if the
-            credential is an invalid or enrollment-only static token, 429 if the
-            client IP is locked out
+        HTTPException: 401 if no auth header or an expired credential, 403 if the
+            credential is insufficient, 429 if the client IP is locked out
     """
     principal = _authenticate(request, credentials)
-    if principal["kind"] != "passkey":
-        raise HTTPException(
-            status_code=403,
-            detail="This operation requires a passkey session. Sign in with your passkey.",
-        )
+    _authorize(principal, (ADMIN_WILDCARD,))
     return True
 
 
@@ -289,8 +445,8 @@ def verify_admin_optional(
         credentials: HTTPAuthorizationCredentials from HTTPBearer (None if missing)
 
     Returns:
-        Dict with 'authenticated', 'kind' ('passkey'/'token'/'none'), and for
-        passkey sessions 'credential_id' and 'expires_at'
+        Dict with 'authenticated', 'kind' ('passkey'/'api_token'/'token'/'none'),
+        and for passkey sessions 'credential_id' and 'expires_at'
     """
     unauthenticated: dict[str, Any] = {"authenticated": False, "kind": "none", "expires_at": None}
 
@@ -303,6 +459,12 @@ def verify_admin_optional(
     if session:
         return session
 
+    if looks_like_api_token(token):
+        status, principal = _check_api_token(token)
+        if status == "valid" and principal is not None:
+            return principal
+        return unauthenticated
+
     if settings.admin_token and hmac.compare_digest(token, settings.admin_token):
         return {"authenticated": True, "kind": "token", "expires_at": None}
 
@@ -310,7 +472,8 @@ def verify_admin_optional(
 
 
 # Type aliases for dependency injection.
-# AdminUser gates full admin access (passkey session only). EnrollmentUser gates
-# passkey enrollment, which the static token may still authorize (#267).
+# AdminUser gates full admin (passkey, an admin:* API token, or the dev static
+# token). For narrower access, use require_scope("...") directly. EnrollmentUser
+# gates passkey enrollment, which the static token may still authorize (#267).
 AdminUser = Annotated[bool, Depends(verify_admin)]
 EnrollmentUser = Annotated[bool, Depends(verify_enrollment)]

--- a/backend/config.py
+++ b/backend/config.py
@@ -22,6 +22,23 @@ class Settings(BaseSettings):
     app_version: str = "0.1.0"
     debug: bool = False
 
+    # Deployment environment. A dedicated signal (not `debug`, which only
+    # controls logging verbosity) so security-sensitive dev conveniences can
+    # never activate in prod. Fail-secure: defaults to "production" so a
+    # misconfigured environment stays locked down. docker-compose.yml sets
+    # ENVIRONMENT=development; docker-compose.prod.yml sets it to production.
+    environment: str = "production"
+
+    @property
+    def is_development(self) -> bool:
+        """Whether we are running in a local/dev environment."""
+        return self.environment.strip().lower() == "development"
+
+    @property
+    def is_production(self) -> bool:
+        """Whether we are running in production (the fail-secure default)."""
+        return not self.is_development
+
     # Server settings
     host: str = "0.0.0.0"
     port: int = 8000
@@ -98,6 +115,12 @@ class Settings(BaseSettings):
 
     # Zettelkasten authentication
     admin_token: str = ""  # Admin bearer token for creating persistent notes
+
+    # Local-dev convenience (#291): when running in development, accept the
+    # static admin_token as a full admin session (all scopes), so a fresh dev
+    # machine can use admin features without a passkey ceremony. Double-gated
+    # with is_development, so it is unreachable in production by construction.
+    allow_token_auth: bool = False
 
     # Passkey (WebAuthn) admin authentication (#229). Passkeys are the primary
     # login for humans; admin_token remains valid for CI/automation callers

--- a/backend/core/api_tokens.py
+++ b/backend/core/api_tokens.py
@@ -1,0 +1,150 @@
+"""Pure logic for scoped API bearer tokens (Functional Core, #300).
+
+Programmatic callers (scripts, a GitHub deploy job) need to hit the API
+without the static admin token - which is unrevocable - or a browser passkey
+ceremony. This module is the pure half: token shape, hashing, scope matching,
+and expiry, all deterministic and unit-testable without I/O. The imperative
+half (random generation, Neo4j storage, request auth) lives in the shell.
+
+Token model:
+    - The plaintext is `mgd_<random>`; only its SHA-256 hash is ever stored,
+      so a database read cannot recover a usable token.
+    - Each token carries a set of scopes (see KNOWN_SCOPES). A request is
+      allowed when the token's scopes satisfy the endpoint's required scope,
+      with `admin:*` acting as a wildcard that satisfies everything.
+    - A passkey session (verified elsewhere) is full admin and bypasses this
+      check entirely; scopes only ever constrain API tokens.
+"""
+
+from hashlib import sha256
+
+TOKEN_PREFIX = "mgd_"  # nosec B105 - a public token prefix, not a secret
+"""Marks a bearer token as an API token, distinguishing it at a glance from a
+passkey session token (which is `<payload>.<sig>`) and letting auth route a
+mismatched `mgd_` token to the brute-force lockout instead of the session path."""
+
+ADMIN_WILDCARD = "admin:*"
+"""A scope that satisfies every required scope: full admin, but revocable."""
+
+KNOWN_SCOPES: frozenset[str] = frozenset(
+    {
+        "notes:write",
+        "library:write",
+        "feature_flags:write",
+        "ai:use",
+        ADMIN_WILDCARD,
+    }
+)
+"""The controlled vocabulary of assignable scopes. Reads (notes/library GETs)
+are currently public, so no read scopes exist yet; add them the day a read
+endpoint gets gated."""
+
+SCOPE_DESCRIPTIONS: dict[str, str] = {
+    "notes:write": "Create, update, and delete notes; upload images",
+    "library:write": "Create, update, and delete library entries",
+    "feature_flags:write": "Read and toggle feature flags (LLM break-glass)",
+    "ai:use": "Use AI editor and suggestion endpoints",
+    ADMIN_WILDCARD: "Full admin: everything above plus backups, auth, and token management",
+}
+"""Human-readable descriptions for the admin create-token form. Keys mirror
+KNOWN_SCOPES exactly."""
+
+
+def hash_token(token: str) -> str:
+    """Hash a plaintext token for storage and lookup.
+
+    SHA-256 (not a slow password hash) is deliberate: these are
+    high-entropy random secrets, not user-chosen passwords, so there is
+    nothing to brute-force and lookup happens on every authed request.
+
+    Args:
+        token: The plaintext bearer token
+
+    Returns:
+        Lowercase hex SHA-256 digest
+    """
+    return sha256(token.encode("utf-8")).hexdigest()
+
+
+def token_display_prefix(token: str, chars: int = 8) -> str:
+    """A safe, non-secret fragment of a token for display in the admin list.
+
+    Shows the `mgd_` marker plus a few characters so a human can tell two
+    tokens apart, without revealing enough to be usable.
+
+    Args:
+        token: The plaintext bearer token
+        chars: How many characters after the prefix to reveal
+
+    Returns:
+        e.g. "mgd_a1b2c3d4…"
+    """
+    head = token[: len(TOKEN_PREFIX) + chars]
+    return f"{head}…" if len(token) > len(head) else head
+
+
+def looks_like_api_token(token: str) -> bool:
+    """Whether a bearer token is shaped like an API token.
+
+    Decidable without any secret, so auth can tell an API-token attempt from
+    a passkey session or static-token attempt and route lockout accordingly.
+    """
+    return token.startswith(TOKEN_PREFIX)
+
+
+def scopes_satisfy(granted: set[str], required: str) -> bool:
+    """Whether a set of granted scopes satisfies a required scope.
+
+    `admin:*` is a wildcard that satisfies any requirement.
+
+    Args:
+        granted: Scopes attached to the presented token
+        required: The scope the endpoint demands
+
+    Returns:
+        True if the token may proceed
+    """
+    return ADMIN_WILDCARD in granted or required in granted
+
+
+def is_expired(expires_at: float | None, now: float) -> bool:
+    """Whether a token has expired.
+
+    Args:
+        expires_at: Unix timestamp of expiry, or None for a token that
+            never expires
+        now: Current unix timestamp
+
+    Returns:
+        True if the token is past its expiry
+    """
+    if expires_at is None:
+        return False
+    return now >= expires_at
+
+
+def validate_scopes(requested: list[str]) -> list[str]:
+    """Normalize and validate a requested scope list.
+
+    Deduplicates while preserving order and rejects anything outside the
+    controlled vocabulary, so an unknown scope cannot be silently stored and
+    then never match (a token that can do nothing).
+
+    Args:
+        requested: Scopes asked for at token creation
+
+    Returns:
+        The cleaned scope list
+
+    Raises:
+        ValueError: If the list is empty or contains an unknown scope
+    """
+    seen: dict[str, None] = {}
+    for scope in requested:
+        normalized = scope.strip()
+        if normalized not in KNOWN_SCOPES:
+            raise ValueError(f"Unknown scope: {scope!r}. Known scopes: {sorted(KNOWN_SCOPES)}")
+        seen[normalized] = None
+    if not seen:
+        raise ValueError("At least one scope is required.")
+    return list(seen)

--- a/backend/main.py
+++ b/backend/main.py
@@ -20,7 +20,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 
 from adapters.article_loader import load_static_articles
 from adapters.neo4j import get_neo4j_adapter
-from auth import verify_admin
+from auth import require_scope, verify_admin
 from config import SecretManager, Settings, get_secret_manager, get_settings
 from dependencies import (
     get_neo4j,
@@ -52,6 +52,7 @@ from routers.library import router as library_router
 from routers.notes import router as notes_router
 from routers.search import router as search_router
 from routers.templates import router as templates_router
+from routers.tokens import create_tokens_router
 
 # Configure logging
 setup_logging(level="INFO")
@@ -330,6 +331,10 @@ app.include_router(admin_router)
 auth_router = create_auth_router(neo4j_adapter=neo4j_adapter)
 app.include_router(auth_router)
 
+# Scoped API tokens (#300)
+tokens_router = create_tokens_router(neo4j_adapter=neo4j_adapter)
+app.include_router(tokens_router)
+
 # Create uploads directory for user-uploaded images (temporary storage)
 UPLOAD_DIR = Path("uploads")
 UPLOAD_DIR.mkdir(exist_ok=True)
@@ -464,7 +469,7 @@ def enforce_upload_body_size(request: Request) -> None:
 async def upload_image(
     request: Request,
     file: Annotated[UploadFile, File()],
-    _admin: Annotated[bool, Depends(verify_admin)],
+    _admin: Annotated[dict[str, Any], Depends(require_scope("notes:write"))],
 ) -> ImageUploadResponse:
     """Upload an image file, optimize to WebP, and return its URL.
 

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -31,6 +31,13 @@ from models.ai import (
     WarmupResponse,
 )
 from models.auth import (
+    ApiScopeInfo,
+    ApiScopesResponse,
+    ApiTokenCreateRequest,
+    ApiTokenCreateResponse,
+    ApiTokenDeleteResponse,
+    ApiTokenInfo,
+    ApiTokensListResponse,
     AuthenticationOptionsResponse,
     AuthenticationVerifyRequest,
     CredentialDeleteResponse,
@@ -106,6 +113,14 @@ __all__ = [
     "CredentialDeleteResponse",
     "CredentialInfo",
     "CredentialsListResponse",
+    # API token models (#300)
+    "ApiScopeInfo",
+    "ApiScopesResponse",
+    "ApiTokenCreateRequest",
+    "ApiTokenCreateResponse",
+    "ApiTokenDeleteResponse",
+    "ApiTokenInfo",
+    "ApiTokensListResponse",
     # Library models
     "LibraryEntryCreate",
     "LibraryEntryUpdate",

--- a/backend/models/auth.py
+++ b/backend/models/auth.py
@@ -1,4 +1,5 @@
-"""Pydantic models for passkey (WebAuthn) admin authentication (#229)."""
+"""Pydantic models for passkey (WebAuthn) admin authentication (#229) and
+scoped API tokens (#300)."""
 
 from typing import Any
 
@@ -77,3 +78,73 @@ class CredentialDeleteResponse(BaseModel):
 
     success: bool = Field(..., description="Whether the credential was deleted")
     message: str = Field(..., description="Human-readable outcome")
+
+
+# ===== Scoped API tokens (#300) =====
+
+
+class ApiTokenCreateRequest(BaseModel):
+    """Request to mint a new scoped API token."""
+
+    name: str = Field(
+        ...,
+        min_length=1,
+        max_length=64,
+        description="Human label for the token (e.g. 'deploy job', 'importer')",
+    )
+    scopes: list[str] = Field(
+        ...,
+        min_length=1,
+        description="Granted scopes (e.g. ['notes:write', 'library:write'] or ['admin:*'])",
+    )
+    expires_in_days: int | None = Field(
+        None,
+        ge=1,
+        le=365,
+        description="Days until the token expires; omit for a token that never expires",
+    )
+
+
+class ApiTokenInfo(BaseModel):
+    """A stored API token as shown in the admin UI (never the secret)."""
+
+    token_id: str = Field(..., description="Public identifier used to revoke the token")
+    name: str = Field(..., description="Human label")
+    scopes: list[str] = Field(..., description="Granted scopes")
+    created_at: float = Field(..., description="Unix timestamp of creation")
+    expires_at: float | None = Field(None, description="Unix timestamp of expiry, if any")
+    last_used_at: float | None = Field(None, description="Unix timestamp of last successful use")
+
+
+class ApiTokenCreateResponse(BaseModel):
+    """A freshly minted token. The plaintext is returned exactly once."""
+
+    token: str = Field(..., description="The plaintext bearer token - shown only now")
+    info: ApiTokenInfo = Field(..., description="Stored metadata for the new token")
+
+
+class ApiTokensListResponse(BaseModel):
+    """All stored API tokens."""
+
+    tokens: list[ApiTokenInfo] = Field(..., description="Stored tokens, newest first")
+    count: int = Field(..., description="Number of stored tokens")
+
+
+class ApiTokenDeleteResponse(BaseModel):
+    """Result of revoking an API token."""
+
+    success: bool = Field(..., description="Whether the token was deleted")
+    message: str = Field(..., description="Human-readable outcome")
+
+
+class ApiScopeInfo(BaseModel):
+    """A selectable scope, for populating the admin create form."""
+
+    name: str = Field(..., description="Scope identifier (e.g. 'notes:write')")
+    description: str = Field(..., description="What the scope grants")
+
+
+class ApiScopesResponse(BaseModel):
+    """The controlled vocabulary of assignable scopes."""
+
+    scopes: list[ApiScopeInfo] = Field(..., description="Known scopes")

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Response
 
-from auth import AdminUser
+from auth import AdminUser, require_scope
 from feature_flags import FeatureFlagService, get_feature_flags
 from models import (
     BackupCreateResponse,
@@ -28,6 +28,10 @@ from models import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/admin", tags=["admin"])
+
+# Feature-flag access: a passkey session, an admin:* token, or a
+# feature_flags:write token - the break-glass LLM kill-switch path (#292, #300)
+FeatureFlagUser = Annotated[dict[str, Any], Depends(require_scope("feature_flags:write"))]
 
 
 def create_admin_router(neo4j_adapter: Any) -> APIRouter:
@@ -329,7 +333,7 @@ def create_admin_router(neo4j_adapter: Any) -> APIRouter:
 
     @router.get("/feature-flags", response_model=FeatureFlagsResponse)
     async def list_feature_flags(
-        _admin: AdminUser,
+        _admin: FeatureFlagUser,
         response: Response,
         service: Annotated[FeatureFlagService, Depends(get_feature_flags)],
     ) -> FeatureFlagsResponse:
@@ -354,7 +358,7 @@ def create_admin_router(neo4j_adapter: Any) -> APIRouter:
     async def update_feature_flag(
         flag_name: str,
         update: FeatureFlagUpdateRequest,
-        _admin: AdminUser,
+        _admin: FeatureFlagUser,
         service: Annotated[FeatureFlagService, Depends(get_feature_flags)],
     ) -> FeatureFlagUpdateResponse:
         """Enable or disable a feature flag at runtime.

--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -12,7 +12,7 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
-from auth import AdminUser
+from auth import require_scope
 from core import ai as ai_core
 from dependencies import get_llm, get_neo4j, get_notes, get_static_articles, get_user_resources
 from models import (
@@ -34,6 +34,9 @@ from rate_limiter import RATE_LIMITS, limiter
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api", tags=["ai"])
+
+# AI editor access: a passkey session, an admin:* token, or an ai:use token (#300)
+AiUser = Annotated[dict[str, Any], Depends(require_scope("ai:use"))]
 
 
 def _get_all_resources(
@@ -991,7 +994,7 @@ def editor_assist(
     neo4j: Neo4jDep,
     static_articles: ArticlesDep,
     user_resources: UserResourcesDep,
-    _admin: AdminUser,
+    _admin: AiUser,
 ) -> EditorAssistResponse:
     """Non-streaming counterpart to /api/editor/assist/stream, for fallback.
 
@@ -1094,7 +1097,7 @@ def editor_assist_stream(
     neo4j: Neo4jDep,
     static_articles: ArticlesDep,
     user_resources: UserResourcesDep,
-    _admin: AdminUser,
+    _admin: AiUser,
 ) -> StreamingResponse:
     """Stream an editor slash-command result via Server-Sent Events (#146).
 

--- a/backend/routers/library.py
+++ b/backend/routers/library.py
@@ -13,7 +13,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
-from auth import AdminUser
+from auth import require_scope
 from core.markdown_renderer import render_markdown_to_html
 from dependencies import get_library
 from models import LibraryEntryCreate, LibraryEntryUpdate, LibraryListResponse
@@ -26,6 +26,9 @@ router = APIRouter(prefix="/api/library", tags=["library"])
 limiter = Limiter(key_func=get_remote_address, enabled=os.getenv("TESTING") != "1")
 
 LibraryDep = Annotated[Any, Depends(get_library)]
+
+# Write access: a passkey session, an admin:* token, or a library:write token (#300)
+LibraryWriter = Annotated[dict[str, Any], Depends(require_scope("library:write"))]
 
 
 def _with_html_summary(entry: dict[str, Any]) -> dict[str, Any]:
@@ -91,7 +94,7 @@ async def get_library_entry(entry_id: str, library: LibraryDep) -> dict[str, Any
 async def create_library_entry(
     request: Request,
     entry: LibraryEntryCreate,
-    _admin: AdminUser,
+    _admin: LibraryWriter,
     library: LibraryDep,
 ) -> dict[str, Any]:
     """Create a new Library entry (admin only)."""
@@ -110,7 +113,7 @@ async def create_library_entry(
 async def update_library_entry(
     entry_id: str,
     entry_update: LibraryEntryUpdate,
-    _admin: AdminUser,
+    _admin: LibraryWriter,
     library: LibraryDep,
 ) -> dict[str, Any]:
     """Update a Library entry (admin only). Only provided fields change."""
@@ -131,7 +134,7 @@ async def update_library_entry(
 @router.delete("/{entry_id}")
 async def delete_library_entry(
     entry_id: str,
-    _admin: AdminUser,
+    _admin: LibraryWriter,
     library: LibraryDep,
 ) -> dict[str, str]:
     """Delete a Library entry (admin only)."""

--- a/backend/routers/notes.py
+++ b/backend/routers/notes.py
@@ -12,7 +12,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
-from auth import AdminUser
+from auth import require_scope
 from core import notes as notes_core
 from core.markdown_renderer import render_markdown_to_html
 from dependencies import get_notes, get_ollama
@@ -34,6 +34,9 @@ limiter = Limiter(key_func=get_remote_address, enabled=os.getenv("TESTING") != "
 # Type aliases for cleaner signatures
 OllamaDep = Annotated[Any, Depends(get_ollama)]
 NotesDep = Annotated[Any, Depends(get_notes)]
+
+# Write access: a passkey session, an admin:* token, or a notes:write token (#300)
+NotesWriter = Annotated[dict[str, Any], Depends(require_scope("notes:write"))]
 
 
 def _with_html_content(note: dict[str, Any]) -> dict[str, Any]:
@@ -80,7 +83,7 @@ semantic search and AI features within seconds.
 async def create_note(
     request: Request,
     note: NoteCreate,
-    _admin: AdminUser,
+    _admin: NotesWriter,
     notes_service: NotesDep,
     background_tasks: BackgroundTasks,
 ) -> dict[str, Any]:
@@ -304,7 +307,7 @@ async def get_note(note_id: str, notes_service: NotesDep) -> dict[str, Any]:
 async def update_note(
     note_id: str,
     note_update: NoteUpdate,
-    _admin: AdminUser,
+    _admin: NotesWriter,
     notes_service: NotesDep,
     background_tasks: BackgroundTasks,
 ) -> dict[str, Any]:
@@ -340,7 +343,7 @@ async def update_note(
 @router.delete("/{note_id}")
 async def delete_note(
     note_id: str,
-    _admin: AdminUser,
+    _admin: NotesWriter,
     notes_service: NotesDep,
 ) -> dict[str, str]:
     """Delete a note (admin only)."""

--- a/backend/routers/tokens.py
+++ b/backend/routers/tokens.py
@@ -1,0 +1,152 @@
+"""Scoped API token management endpoints (#300).
+
+Lets a full admin mint, list, and revoke `mgd_`-prefixed bearer tokens with
+assignable scopes - the safe way to script against the API without exposing the
+unrevocable static admin token. Managing tokens itself always requires full
+admin (a passkey session or an `admin:*` token), so a narrowly-scoped token
+cannot escalate by minting a broader one.
+
+The plaintext token is returned exactly once, at creation; only its SHA-256
+hash is stored. Pure token logic (hashing, scope validation) lives in
+core.api_tokens; this router is the imperative shell around Neo4j storage.
+"""
+
+import logging
+import secrets
+import time
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+
+from auth import AdminUser
+from core.api_tokens import (
+    KNOWN_SCOPES,
+    SCOPE_DESCRIPTIONS,
+    TOKEN_PREFIX,
+    hash_token,
+    validate_scopes,
+)
+from models import (
+    ApiScopeInfo,
+    ApiScopesResponse,
+    ApiTokenCreateRequest,
+    ApiTokenCreateResponse,
+    ApiTokenDeleteResponse,
+    ApiTokenInfo,
+    ApiTokensListResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def create_tokens_router(neo4j_adapter: Any) -> APIRouter:
+    """Create the API-token router with dependencies injected.
+
+    Args:
+        neo4j_adapter: Neo4j adapter for token storage
+
+    Returns:
+        Configured APIRouter with token endpoints
+    """
+    router = APIRouter(prefix="/api/admin/tokens", tags=["tokens"])
+
+    def _require_neo4j() -> None:
+        """Tokens need persistent storage; fail loudly rather than half-work."""
+        if not neo4j_adapter.is_available():
+            raise HTTPException(
+                status_code=503,
+                detail="API tokens unavailable: database not reachable.",
+            )
+
+    def _to_info(record: dict[str, Any]) -> ApiTokenInfo:
+        return ApiTokenInfo(
+            token_id=record["token_id"],
+            name=record["name"],
+            scopes=list(record["scopes"]),
+            created_at=record["created_at"],
+            expires_at=record["expires_at"],
+            last_used_at=record["last_used_at"],
+        )
+
+    @router.get("/scopes", response_model=ApiScopesResponse)
+    async def list_scopes(_admin: AdminUser) -> ApiScopesResponse:
+        """List the assignable scopes, for the admin create form."""
+        return ApiScopesResponse(
+            scopes=[
+                ApiScopeInfo(name=name, description=SCOPE_DESCRIPTIONS.get(name, ""))
+                for name in sorted(KNOWN_SCOPES)
+            ]
+        )
+
+    @router.get("", response_model=ApiTokensListResponse)
+    async def list_tokens(_admin: AdminUser) -> ApiTokensListResponse:
+        """List stored API tokens (metadata only, never the secret)."""
+        _require_neo4j()
+        records = neo4j_adapter.list_api_tokens()
+        return ApiTokensListResponse(
+            tokens=[_to_info(r) for r in records],
+            count=len(records),
+        )
+
+    @router.post("", response_model=ApiTokenCreateResponse)
+    async def create_token(
+        body: ApiTokenCreateRequest, _admin: AdminUser
+    ) -> ApiTokenCreateResponse:
+        """Mint a new scoped API token. Returns the plaintext exactly once."""
+        _require_neo4j()
+
+        try:
+            scopes = validate_scopes(body.scopes)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+
+        # High-entropy random secret; only its hash is ever stored.
+        plaintext = f"{TOKEN_PREFIX}{secrets.token_urlsafe(32)}"
+        token_id = uuid.uuid4().hex
+        now = time.time()
+        expires_at = (
+            now + body.expires_in_days * 86400 if body.expires_in_days is not None else None
+        )
+
+        stored = neo4j_adapter.create_api_token(
+            token_id=token_id,
+            token_hash=hash_token(plaintext),
+            name=body.name,
+            scopes=scopes,
+            created_at=now,
+            expires_at=expires_at,
+        )
+        if not stored:
+            raise HTTPException(status_code=503, detail="Failed to store token.")
+
+        # Log the id/scopes for the audit trail - never the plaintext.
+        logger.info(
+            "Minted API token %s ('%s') scopes=%s expires_at=%s",
+            token_id,
+            body.name,
+            scopes,
+            expires_at,
+        )
+        return ApiTokenCreateResponse(
+            token=plaintext,
+            info=ApiTokenInfo(
+                token_id=token_id,
+                name=body.name,
+                scopes=scopes,
+                created_at=now,
+                expires_at=expires_at,
+                last_used_at=None,
+            ),
+        )
+
+    @router.delete("/{token_id}", response_model=ApiTokenDeleteResponse)
+    async def delete_token(token_id: str, _admin: AdminUser) -> ApiTokenDeleteResponse:
+        """Revoke an API token immediately."""
+        _require_neo4j()
+        if not neo4j_adapter.delete_api_token(token_id):
+            raise HTTPException(status_code=404, detail="Token not found.")
+        logger.info("Revoked API token %s", token_id)
+        return ApiTokenDeleteResponse(success=True, message="Token revoked.")
+
+    return router

--- a/backend/tests/unit/test_core_api_tokens.py
+++ b/backend/tests/unit/test_core_api_tokens.py
@@ -1,0 +1,103 @@
+"""Unit tests for pure API-token logic (core/api_tokens.py, #300)."""
+
+import pytest
+
+from core.api_tokens import (
+    ADMIN_WILDCARD,
+    KNOWN_SCOPES,
+    TOKEN_PREFIX,
+    hash_token,
+    is_expired,
+    looks_like_api_token,
+    scopes_satisfy,
+    token_display_prefix,
+    validate_scopes,
+)
+
+
+class TestHashToken:
+    def test_deterministic(self) -> None:
+        assert hash_token("mgd_abc") == hash_token("mgd_abc")
+
+    def test_distinct_inputs_distinct_hashes(self) -> None:
+        assert hash_token("mgd_abc") != hash_token("mgd_abd")
+
+    def test_is_hex_sha256(self) -> None:
+        digest = hash_token("mgd_abc")
+        assert len(digest) == 64
+        assert all(c in "0123456789abcdef" for c in digest)
+
+
+class TestDisplayPrefix:
+    def test_reveals_prefix_and_a_few_chars(self) -> None:
+        prefix = token_display_prefix("mgd_abcdefghijklmnop", chars=4)
+        assert prefix == "mgd_abcd…"
+
+    def test_short_token_not_truncated(self) -> None:
+        assert token_display_prefix("mgd_ab", chars=8) == "mgd_ab"
+
+
+class TestLooksLikeApiToken:
+    def test_true_for_prefixed(self) -> None:
+        assert looks_like_api_token(f"{TOKEN_PREFIX}whatever")
+
+    def test_false_for_session_shaped(self) -> None:
+        assert not looks_like_api_token("payload.signature")
+
+    def test_false_for_static_token(self) -> None:
+        assert not looks_like_api_token("some-static-admin-token")
+
+
+class TestScopesSatisfy:
+    def test_exact_match(self) -> None:
+        assert scopes_satisfy({"notes:write"}, "notes:write")
+
+    def test_missing_scope(self) -> None:
+        assert not scopes_satisfy({"notes:write"}, "library:write")
+
+    def test_admin_wildcard_satisfies_anything(self) -> None:
+        assert scopes_satisfy({ADMIN_WILDCARD}, "library:write")
+        assert scopes_satisfy({ADMIN_WILDCARD}, "feature_flags:write")
+
+    def test_empty_grant_satisfies_nothing(self) -> None:
+        assert not scopes_satisfy(set(), "notes:write")
+
+
+class TestIsExpired:
+    def test_none_never_expires(self) -> None:
+        assert not is_expired(None, now=10_000_000_000.0)
+
+    def test_future_expiry_not_expired(self) -> None:
+        assert not is_expired(1000.0, now=999.0)
+
+    def test_past_expiry_expired(self) -> None:
+        assert is_expired(1000.0, now=1001.0)
+
+    def test_exact_boundary_is_expired(self) -> None:
+        assert is_expired(1000.0, now=1000.0)
+
+
+class TestValidateScopes:
+    def test_accepts_known_scopes(self) -> None:
+        assert validate_scopes(["notes:write", "library:write"]) == [
+            "notes:write",
+            "library:write",
+        ]
+
+    def test_deduplicates_preserving_order(self) -> None:
+        assert validate_scopes(["ai:use", "ai:use", "notes:write"]) == ["ai:use", "notes:write"]
+
+    def test_strips_whitespace(self) -> None:
+        assert validate_scopes([" notes:write "]) == ["notes:write"]
+
+    def test_rejects_unknown_scope(self) -> None:
+        with pytest.raises(ValueError, match="Unknown scope"):
+            validate_scopes(["notes:destroy"])
+
+    def test_rejects_empty(self) -> None:
+        with pytest.raises(ValueError, match="At least one scope"):
+            validate_scopes([])
+
+    def test_all_known_scopes_validate(self) -> None:
+        # Guards against KNOWN_SCOPES and validate_scopes drifting apart
+        assert set(validate_scopes(sorted(KNOWN_SCOPES))) == set(KNOWN_SCOPES)

--- a/backend/tests/unit/test_tokens_api.py
+++ b/backend/tests/unit/test_tokens_api.py
@@ -1,0 +1,337 @@
+"""Integration tests for scoped API tokens (#300).
+
+Covers the token-management router (create/list/revoke), and the end-to-end
+authorization path: a minted token authenticating a request and being allowed
+or rejected by require_scope. Auth's token lookup reads the global Neo4j
+adapter, so we point that at the same in-memory fake the router writes to.
+"""
+
+import os
+import time
+from typing import Annotated, Any
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+os.environ["TESTING"] = "1"
+
+import auth
+from auth import auth_tracker, require_scope
+from config import get_settings
+from core.sessions import create_session_token, derive_session_secret
+from routers.tokens import create_tokens_router
+
+TEST_ADMIN_TOKEN = "test-admin-token-for-ci"
+
+
+def _admin_token() -> str:
+    return get_settings().admin_token or TEST_ADMIN_TOKEN
+
+
+@pytest.fixture
+def session_headers() -> dict[str, str]:
+    """Full-admin headers via a valid passkey session token."""
+    settings = get_settings()
+    secret = derive_session_secret(_admin_token(), settings.session_secret)
+    token = create_session_token(secret, "test-credential", time.time())
+    return {"Authorization": f"Bearer {token}"}
+
+
+class FakeNeo4jAdapter:
+    """In-memory stand-in for the Neo4j adapter's API-token surface."""
+
+    def __init__(self, available: bool = True) -> None:
+        self._available = available
+        self.tokens: list[dict[str, Any]] = []
+
+    def is_available(self) -> bool:
+        return self._available
+
+    def create_api_token(
+        self,
+        token_id: str,
+        token_hash: str,
+        name: str,
+        scopes: list[str],
+        created_at: float,
+        expires_at: float | None,
+    ) -> bool:
+        self.tokens.append(
+            {
+                "token_id": token_id,
+                "token_hash": token_hash,
+                "name": name,
+                "scopes": list(scopes),
+                "created_at": created_at,
+                "expires_at": expires_at,
+                "last_used_at": None,
+            }
+        )
+        return True
+
+    def _public(self, record: dict[str, Any]) -> dict[str, Any]:
+        return {k: v for k, v in record.items() if k != "token_hash"}
+
+    def list_api_tokens(self) -> list[dict[str, Any]]:
+        return [self._public(t) for t in sorted(self.tokens, key=lambda t: -t["created_at"])]
+
+    def get_api_token_by_hash(self, token_hash: str) -> dict[str, Any] | None:
+        record = next((t for t in self.tokens if t["token_hash"] == token_hash), None)
+        return self._public(record) if record else None
+
+    def record_api_token_use(self, token_id: str, now: float) -> bool:
+        for t in self.tokens:
+            if t["token_id"] == token_id:
+                t["last_used_at"] = now
+                return True
+        return False
+
+    def delete_api_token(self, token_id: str) -> bool:
+        before = len(self.tokens)
+        self.tokens = [t for t in self.tokens if t["token_id"] != token_id]
+        return len(self.tokens) < before
+
+
+@pytest.fixture(autouse=True)
+def reset_lockout() -> None:
+    auth_tracker.reset()
+
+
+@pytest.fixture
+def adapter(monkeypatch: pytest.MonkeyPatch) -> FakeNeo4jAdapter:
+    fake = FakeNeo4jAdapter()
+    # Auth resolves API tokens against the *global* adapter; point it at the fake
+    # so the token the router stores is the one auth can look up.
+    monkeypatch.setattr(auth, "get_neo4j_adapter", lambda: fake)
+    return fake
+
+
+@pytest.fixture
+def client(adapter: FakeNeo4jAdapter) -> TestClient:
+    """Tokens router plus two scope-guarded probe endpoints."""
+    app = FastAPI()
+    app.include_router(create_tokens_router(neo4j_adapter=adapter))
+
+    @app.post("/probe/notes")
+    async def _notes(_p: Annotated[dict, Depends(require_scope("notes:write"))]) -> dict[str, bool]:
+        return {"ok": True}
+
+    @app.post("/probe/library")
+    async def _library(
+        _p: Annotated[dict, Depends(require_scope("library:write"))],
+    ) -> dict[str, bool]:
+        return {"ok": True}
+
+    return TestClient(app)
+
+
+def _bearer(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestTokenManagement:
+    def test_create_requires_full_admin(self, client: TestClient) -> None:
+        response = client.post(
+            "/api/admin/tokens",
+            json={"name": "x", "scopes": ["notes:write"]},
+        )
+        assert response.status_code == 401
+
+    def test_create_returns_plaintext_once(
+        self, client: TestClient, session_headers: dict[str, str]
+    ) -> None:
+        response = client.post(
+            "/api/admin/tokens",
+            json={"name": "importer", "scopes": ["library:write"], "expires_in_days": 30},
+            headers=session_headers,
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["token"].startswith("mgd_")
+        assert body["info"]["name"] == "importer"
+        assert body["info"]["scopes"] == ["library:write"]
+        assert body["info"]["expires_at"] is not None
+
+    def test_create_rejects_unknown_scope(
+        self, client: TestClient, session_headers: dict[str, str]
+    ) -> None:
+        response = client.post(
+            "/api/admin/tokens",
+            json={"name": "x", "scopes": ["notes:destroy"]},
+            headers=session_headers,
+        )
+        assert response.status_code == 400
+
+    def test_list_never_exposes_secret(
+        self, client: TestClient, session_headers: dict[str, str]
+    ) -> None:
+        client.post(
+            "/api/admin/tokens",
+            json={"name": "a", "scopes": ["ai:use"]},
+            headers=session_headers,
+        )
+        response = client.get("/api/admin/tokens", headers=session_headers)
+        assert response.status_code == 200
+        body = response.json()
+        assert body["count"] == 1
+        assert "token_hash" not in body["tokens"][0]
+        assert "token" not in body["tokens"][0]
+
+    def test_revoke(self, client: TestClient, session_headers: dict[str, str]) -> None:
+        created = client.post(
+            "/api/admin/tokens",
+            json={"name": "temp", "scopes": ["ai:use"]},
+            headers=session_headers,
+        ).json()
+        token_id = created["info"]["token_id"]
+
+        response = client.delete(f"/api/admin/tokens/{token_id}", headers=session_headers)
+        assert response.status_code == 200
+        assert client.get("/api/admin/tokens", headers=session_headers).json()["count"] == 0
+
+    def test_revoke_unknown_is_404(
+        self, client: TestClient, session_headers: dict[str, str]
+    ) -> None:
+        response = client.delete("/api/admin/tokens/nope", headers=session_headers)
+        assert response.status_code == 404
+
+    def test_scopes_endpoint_lists_vocabulary(
+        self, client: TestClient, session_headers: dict[str, str]
+    ) -> None:
+        response = client.get("/api/admin/tokens/scopes", headers=session_headers)
+        assert response.status_code == 200
+        names = {s["name"] for s in response.json()["scopes"]}
+        assert "notes:write" in names
+        assert "admin:*" in names
+
+
+class TestScopeEnforcement:
+    def _mint(
+        self, client: TestClient, session_headers: dict[str, str], scopes: list[str]
+    ) -> str:
+        body = client.post(
+            "/api/admin/tokens",
+            json={"name": "t", "scopes": scopes},
+            headers=session_headers,
+        ).json()
+        return body["token"]
+
+    def test_scoped_token_allowed_on_its_scope(
+        self, client: TestClient, session_headers: dict[str, str]
+    ) -> None:
+        token = self._mint(client, session_headers, ["notes:write"])
+        assert client.post("/probe/notes", headers=_bearer(token)).status_code == 200
+
+    def test_scoped_token_rejected_off_scope(
+        self, client: TestClient, session_headers: dict[str, str]
+    ) -> None:
+        token = self._mint(client, session_headers, ["notes:write"])
+        assert client.post("/probe/library", headers=_bearer(token)).status_code == 403
+
+    def test_admin_wildcard_satisfies_everything(
+        self, client: TestClient, session_headers: dict[str, str]
+    ) -> None:
+        token = self._mint(client, session_headers, ["admin:*"])
+        assert client.post("/probe/notes", headers=_bearer(token)).status_code == 200
+        assert client.post("/probe/library", headers=_bearer(token)).status_code == 200
+
+    def test_passkey_session_satisfies_scope(
+        self, client: TestClient, session_headers: dict[str, str]
+    ) -> None:
+        assert client.post("/probe/notes", headers=session_headers).status_code == 200
+
+    def test_expired_token_rejected(
+        self, client: TestClient, session_headers: dict[str, str], adapter: FakeNeo4jAdapter
+    ) -> None:
+        token = self._mint(client, session_headers, ["notes:write"])
+        # Force expiry in the store
+        adapter.tokens[0]["expires_at"] = time.time() - 1
+        response = client.post("/probe/notes", headers=_bearer(token))
+        assert response.status_code == 401
+
+    def test_unknown_mgd_token_is_403_and_counts(
+        self, client: TestClient, adapter: FakeNeo4jAdapter
+    ) -> None:
+        response = client.post("/probe/notes", headers=_bearer("mgd_not-a-real-token"))
+        assert response.status_code == 403
+
+    def test_revoked_token_stops_working(
+        self, client: TestClient, session_headers: dict[str, str]
+    ) -> None:
+        created = client.post(
+            "/api/admin/tokens",
+            json={"name": "t", "scopes": ["notes:write"]},
+            headers=session_headers,
+        ).json()
+        token = created["token"]
+        assert client.post("/probe/notes", headers=_bearer(token)).status_code == 200
+
+        client.delete(f"/api/admin/tokens/{created['info']['token_id']}", headers=session_headers)
+        assert client.post("/probe/notes", headers=_bearer(token)).status_code == 403
+
+
+class TestFullAdminGate:
+    """verify_admin (AdminUser) via the token-management endpoints."""
+
+    def test_admin_wildcard_token_can_manage_tokens(
+        self, client: TestClient, session_headers: dict[str, str]
+    ) -> None:
+        """An admin:* token is full admin - it may even mint/list other tokens."""
+        admin_token = client.post(
+            "/api/admin/tokens",
+            json={"name": "root", "scopes": ["admin:*"]},
+            headers=session_headers,
+        ).json()["token"]
+
+        response = client.get("/api/admin/tokens", headers=_bearer(admin_token))
+        assert response.status_code == 200
+
+    def test_narrow_token_cannot_manage_tokens(
+        self, client: TestClient, session_headers: dict[str, str]
+    ) -> None:
+        """A notes:write token cannot escalate by listing/minting tokens."""
+        narrow = client.post(
+            "/api/admin/tokens",
+            json={"name": "narrow", "scopes": ["notes:write"]},
+            headers=session_headers,
+        ).json()["token"]
+
+        assert client.get("/api/admin/tokens", headers=_bearer(narrow)).status_code == 403
+
+
+class TestDevTokenAuth:
+    """#291: the static token acts as full admin only in local dev."""
+
+    def test_static_token_full_admin_when_dev_enabled(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        settings = get_settings()
+        monkeypatch.setattr(settings, "admin_token", TEST_ADMIN_TOKEN)
+        monkeypatch.setattr(settings, "environment", "development")
+        monkeypatch.setattr(settings, "allow_token_auth", True)
+
+        response = client.get("/api/admin/tokens", headers=_bearer(TEST_ADMIN_TOKEN))
+        assert response.status_code == 200
+
+    def test_static_token_rejected_when_not_dev(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        settings = get_settings()
+        monkeypatch.setattr(settings, "admin_token", TEST_ADMIN_TOKEN)
+        monkeypatch.setattr(settings, "environment", "production")
+        monkeypatch.setattr(settings, "allow_token_auth", True)
+
+        response = client.get("/api/admin/tokens", headers=_bearer(TEST_ADMIN_TOKEN))
+        assert response.status_code == 403
+
+    def test_static_token_rejected_when_flag_off(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        settings = get_settings()
+        monkeypatch.setattr(settings, "admin_token", TEST_ADMIN_TOKEN)
+        monkeypatch.setattr(settings, "environment", "development")
+        monkeypatch.setattr(settings, "allow_token_auth", False)
+
+        response = client.get("/api/admin/tokens", headers=_bearer(TEST_ADMIN_TOKEN))
+        assert response.status_code == 403

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -48,6 +48,7 @@ services:
       - "127.0.0.1:8000:8000"
     environment:
       - DEBUG=false
+      - ENVIRONMENT=production
       - OP_MONGADO_SERVICE_ACCOUNT_TOKEN=${OP_MONGADO_SERVICE_ACCOUNT_TOKEN}
       - NEO4J_URI=bolt://neo4j:7687
       - NEO4J_USER=neo4j

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,7 @@ services:
       - /app/venv
     environment:
       - DEBUG=true
+      - ENVIRONMENT=development
       - NEO4J_URI=bolt://neo4j:7687
       - NEO4J_USER=neo4j
       - NEO4J_PASSWORD=mongado-dev-password

--- a/frontend/src/app/admin/page.module.scss
+++ b/frontend/src/app/admin/page.module.scss
@@ -322,3 +322,124 @@
     transform: translateX(1.25rem);
   }
 }
+
+// ===== API TOKENS (#300) =====
+.tokenForm {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-4;
+  margin-top: $spacing-4;
+  padding-top: $spacing-4;
+  border-top: $border-default;
+}
+
+.tokenField {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2;
+}
+
+.tokenLabel {
+  font-weight: $font-weight-medium;
+  color: $color-text-primary;
+  font-size: $font-size-sm;
+}
+
+.tokenSelect {
+  padding: $spacing-2 $spacing-3;
+  border: $border-default;
+  border-radius: $border-radius-button;
+  font-family: $font-family-primary;
+  background-color: $color-bg-canvas;
+
+  &:focus {
+    outline: none;
+    border-color: $color-input-border-focus;
+    box-shadow: $shadow-focus-primary;
+  }
+}
+
+.scopeList {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2;
+}
+
+.scopeItem {
+  display: flex;
+  align-items: flex-start;
+  gap: $spacing-2;
+  cursor: pointer;
+
+  input {
+    margin-top: 0.2rem;
+  }
+}
+
+.scopeName {
+  font-family: $font-family-mono;
+  font-size: $font-size-sm;
+  font-weight: $font-weight-medium;
+  color: $color-text-primary;
+}
+
+.scopeDescription {
+  @include text-secondary;
+  font-size: $font-size-sm;
+  color: $color-text-secondary;
+}
+
+.tokenReveal {
+  margin: 0 0 $spacing-5 0;
+  padding: $spacing-4;
+  background-color: rgba(254, 243, 199, 0.5);
+  border: $border-width-thin solid rgba(217, 119, 6, 0.4);
+  border-radius: $border-radius-md;
+}
+
+.tokenRevealWarning {
+  margin: 0 0 $spacing-3 0;
+  font-weight: $font-weight-medium;
+  color: $color-text-primary;
+}
+
+.tokenRevealCode {
+  display: flex;
+  align-items: center;
+  gap: $spacing-3;
+  flex-wrap: wrap;
+}
+
+.tokenValue {
+  flex: 1 1 16rem;
+  font-family: $font-family-mono;
+  font-size: $font-size-sm;
+  word-break: break-all;
+  padding: $spacing-2 $spacing-3;
+  background-color: $color-bg-canvas;
+  border: $border-default;
+  border-radius: $border-radius-button;
+}
+
+.copyButton {
+  @include button-secondary;
+  @include button-sm;
+  flex-shrink: 0;
+}
+
+.tokenScopes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-1;
+  margin-top: $spacing-1;
+}
+
+.scopeTag {
+  font-family: $font-family-mono;
+  font-size: $font-size-xs;
+  padding: 0 $spacing-2;
+  border-radius: $border-radius-md;
+  background-color: $color-bg-secondary;
+  color: $color-text-secondary;
+  border: $border-width-thin solid $color-border-subtle;
+}

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -19,6 +19,14 @@ import {
   registerPasskey,
   type PasskeyCredential,
 } from "@/lib/api/passkey";
+import {
+  createApiToken,
+  deleteApiToken,
+  getApiScopes,
+  listApiTokens,
+  type ApiScope,
+  type ApiTokenInfo,
+} from "@/lib/api/tokens";
 import { applyFeatureFlag } from "@/hooks/useFeatureFlags";
 import { logger } from "@/lib/logger";
 import styles from "./page.module.scss";
@@ -57,6 +65,28 @@ export default function AdminPage() {
   const [enrolling, setEnrolling] = useState(false);
   const [passkeySupported, setPasskeySupported] = useState(false);
 
+  const [scopes, setScopes] = useState<ApiScope[]>([]);
+  const [tokens, setTokens] = useState<ApiTokenInfo[]>([]);
+  const [tokenError, setTokenError] = useState<string | null>(null);
+  const [tokenMessage, setTokenMessage] = useState<string | null>(null);
+  const [tokenName, setTokenName] = useState("");
+  const [selectedScopes, setSelectedScopes] = useState<string[]>([]);
+  const [tokenExpiry, setTokenExpiry] = useState("30"); // days; "" = never
+  const [creatingToken, setCreatingToken] = useState(false);
+  const [newToken, setNewToken] = useState<string | null>(null);
+
+  const loadTokens = useCallback(() => {
+    listApiTokens()
+      .then(setTokens)
+      .catch((err) => {
+        adminLogger.error("Failed to load API tokens:", err);
+        setTokenError("Failed to load API tokens.");
+      });
+    getApiScopes()
+      .then(setScopes)
+      .catch((err) => adminLogger.error("Failed to load scopes:", err));
+  }, []);
+
   const loadPasskeys = useCallback(() => {
     listPasskeys()
       .then(setPasskeys)
@@ -92,7 +122,69 @@ export default function AdminPage() {
     loadHealth();
     setPasskeySupported(isPasskeySupported());
     loadPasskeys();
-  }, [router, loadHealth, loadPasskeys]);
+    loadTokens();
+  }, [router, loadHealth, loadPasskeys, loadTokens]);
+
+  const toggleScope = (name: string) => {
+    setSelectedScopes((current) =>
+      current.includes(name) ? current.filter((s) => s !== name) : [...current, name]
+    );
+  };
+
+  const handleCreateToken = async () => {
+    const name = tokenName.trim();
+    if (!name || selectedScopes.length === 0) {
+      setTokenError("A name and at least one scope are required.");
+      return;
+    }
+
+    setCreatingToken(true);
+    setTokenError(null);
+    setTokenMessage(null);
+    setNewToken(null);
+
+    const expiresInDays = tokenExpiry === "" ? null : parseInt(tokenExpiry, 10);
+    try {
+      const result = await createApiToken(name, selectedScopes, expiresInDays);
+      setNewToken(result.token);
+      setTokens((current) => [result.info, ...current]);
+      setTokenName("");
+      setSelectedScopes([]);
+      setTokenMessage(`Created "${name}".`);
+    } catch (err) {
+      adminLogger.error("Token creation failed:", err);
+      setTokenError(err instanceof Error ? err.message : "Failed to create token.");
+    } finally {
+      setCreatingToken(false);
+    }
+  };
+
+  const handleRevokeToken = async (token: ApiTokenInfo) => {
+    if (!window.confirm(`Revoke "${token.name}"? Any script using it will stop working.`)) {
+      return;
+    }
+
+    setTokenError(null);
+    setTokenMessage(null);
+    try {
+      await deleteApiToken(token.token_id);
+      setTokens((current) => current.filter((t) => t.token_id !== token.token_id));
+      setTokenMessage(`Revoked "${token.name}".`);
+    } catch (err) {
+      adminLogger.error("Token revocation failed:", err);
+      setTokenError("Failed to revoke token.");
+    }
+  };
+
+  const handleCopyToken = async () => {
+    if (!newToken) return;
+    try {
+      await navigator.clipboard.writeText(newToken);
+      setTokenMessage("Copied to clipboard.");
+    } catch {
+      setTokenMessage("Copy failed - select and copy the token manually.");
+    }
+  };
 
   const handleEnrollPasskey = async () => {
     setEnrolling(true);
@@ -289,6 +381,131 @@ export default function AdminPage() {
             ) : (
               <p className={styles.status}>This browser does not support passkeys.</p>
             )}
+          </div>
+
+          <div className={styles.card}>
+            <h2 className={styles.cardTitle}>API Tokens</h2>
+            <p className={styles.cardDescription}>
+              Scoped, revocable bearer tokens for programmatic API use - the safe way to script
+              against the site without exposing the admin token. Each token can do only what its
+              scopes allow.
+            </p>
+
+            {tokenError && <p className={styles.error}>{tokenError}</p>}
+            {tokenMessage && <p className={styles.success}>{tokenMessage}</p>}
+
+            {newToken && (
+              <div className={styles.tokenReveal}>
+                <p className={styles.tokenRevealWarning}>
+                  Copy this token now - it will not be shown again.
+                </p>
+                <div className={styles.tokenRevealCode}>
+                  <code className={styles.tokenValue}>{newToken}</code>
+                  <button type="button" className={styles.copyButton} onClick={handleCopyToken}>
+                    Copy
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {tokens.length === 0 ? (
+              <p className={styles.status}>No API tokens yet.</p>
+            ) : (
+              <ul className={styles.passkeyList}>
+                {tokens.map((token) => (
+                  <li key={token.token_id} className={styles.passkeyRow}>
+                    <div className={styles.passkeyInfo}>
+                      <span className={styles.passkeyName}>{token.name}</span>
+                      <span className={styles.tokenScopes}>
+                        {token.scopes.map((scope) => (
+                          <span key={scope} className={styles.scopeTag}>
+                            {scope}
+                          </span>
+                        ))}
+                      </span>
+                      <span className={styles.passkeyMeta}>
+                        Created {formatUnixTimestamp(token.created_at)} · Expires{" "}
+                        {token.expires_at ? formatUnixTimestamp(token.expires_at) : "never"} · Last
+                        used {formatUnixTimestamp(token.last_used_at)}
+                      </span>
+                    </div>
+                    <button
+                      type="button"
+                      className={styles.revokeButton}
+                      onClick={() => handleRevokeToken(token)}
+                    >
+                      Revoke
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            <div className={styles.tokenForm}>
+              <div className={styles.tokenField}>
+                <label htmlFor="token-name" className={styles.tokenLabel}>
+                  Name
+                </label>
+                <input
+                  id="token-name"
+                  type="text"
+                  className={styles.passkeyInput}
+                  placeholder="e.g. deploy job, importer"
+                  maxLength={64}
+                  value={tokenName}
+                  onChange={(e) => setTokenName(e.target.value)}
+                  disabled={creatingToken}
+                />
+              </div>
+
+              <div className={styles.tokenField}>
+                <span className={styles.tokenLabel}>Scopes</span>
+                <div className={styles.scopeList}>
+                  {scopes.map((scope) => (
+                    <label key={scope.name} className={styles.scopeItem}>
+                      <input
+                        type="checkbox"
+                        checked={selectedScopes.includes(scope.name)}
+                        onChange={() => toggleScope(scope.name)}
+                        disabled={creatingToken}
+                      />
+                      <span>
+                        <span className={styles.scopeName}>{scope.name}</span>
+                        <br />
+                        <span className={styles.scopeDescription}>{scope.description}</span>
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+
+              <div className={styles.tokenField}>
+                <label htmlFor="token-expiry" className={styles.tokenLabel}>
+                  Expires
+                </label>
+                <select
+                  id="token-expiry"
+                  className={styles.tokenSelect}
+                  value={tokenExpiry}
+                  onChange={(e) => setTokenExpiry(e.target.value)}
+                  disabled={creatingToken}
+                >
+                  <option value="7">7 days</option>
+                  <option value="30">30 days</option>
+                  <option value="90">90 days</option>
+                  <option value="">Never</option>
+                </select>
+              </div>
+
+              <button
+                type="button"
+                className={styles.backupButton}
+                disabled={creatingToken}
+                onClick={handleCreateToken}
+              >
+                {creatingToken ? "Creating..." : "Create token"}
+              </button>
+            </div>
           </div>
 
           <div className={styles.card}>

--- a/frontend/src/lib/api/tokens.ts
+++ b/frontend/src/lib/api/tokens.ts
@@ -1,0 +1,63 @@
+/**
+ * Scoped API token management (#300).
+ *
+ * Full admins mint, list, and revoke `mgd_`-prefixed bearer tokens for
+ * programmatic API use. The plaintext is returned exactly once, at creation.
+ */
+
+import { apiDelete, apiGet, apiPost } from "./client";
+
+export interface ApiScope {
+  name: string;
+  description: string;
+}
+
+export interface ApiTokenInfo {
+  token_id: string;
+  name: string;
+  scopes: string[];
+  created_at: number;
+  expires_at: number | null;
+  last_used_at: number | null;
+}
+
+export interface ApiTokenCreateResponse {
+  /** The plaintext bearer token - shown only at creation. */
+  token: string;
+  info: ApiTokenInfo;
+}
+
+interface ApiScopesResponse {
+  scopes: ApiScope[];
+}
+
+interface ApiTokensListResponse {
+  tokens: ApiTokenInfo[];
+  count: number;
+}
+
+export async function getApiScopes(): Promise<ApiScope[]> {
+  const response = await apiGet<ApiScopesResponse>("/api/admin/tokens/scopes");
+  return response.scopes;
+}
+
+export async function listApiTokens(): Promise<ApiTokenInfo[]> {
+  const response = await apiGet<ApiTokensListResponse>("/api/admin/tokens");
+  return response.tokens;
+}
+
+export async function createApiToken(
+  name: string,
+  scopes: string[],
+  expiresInDays: number | null
+): Promise<ApiTokenCreateResponse> {
+  return apiPost<ApiTokenCreateResponse>("/api/admin/tokens", {
+    name,
+    scopes,
+    expires_in_days: expiresInDays,
+  });
+}
+
+export async function deleteApiToken(tokenId: string): Promise<void> {
+  await apiDelete(`/api/admin/tokens/${encodeURIComponent(tokenId)}`);
+}


### PR DESCRIPTION
## Summary

Adds **scoped, revocable API bearer tokens** so we can script against the API (esp. prod) without exposing the unrevocable static `ADMIN_TOKEN`. Closes #300, and resolves #291 and #292 along the way.

Tokens are `mgd_`-prefixed random secrets, stored as SHA-256 **hashes** in Neo4j (plaintext shown once), minted/revoked from `/admin`. Endpoints declare a required scope via `require_scope(...)`:

- **passkey session** → satisfies every scope (full admin)
- **API token** → satisfies a granted scope (`admin:*` is a wildcard)
- Managing tokens themselves requires full admin, so a narrow token **cannot self-escalate**

Scopes: `notes:write`, `library:write`, `feature_flags:write`, `ai:use`, `admin:*`.

### #292 — break-glass LLM disable
`feature_flags:write` now gates both `GET`/`PUT /api/admin/feature-flags`, so the LLM kill-switch is reachable with a narrow token even when the passkey session is unhealthy.

### #291 — local dev without a passkey ceremony
New config `environment` (**fail-secure default `production`**) + `allow_token_auth`. The static token acts as full admin **only** when `is_development AND allow_token_auth` — two independent gates, unreachable in prod by construction. Uses a dedicated `ENVIRONMENT` signal, not the overloaded `debug`.

## Key files
- `backend/core/api_tokens.py` — pure hashing, scope matching, expiry, validation
- `backend/adapters/neo4j.py` — `ApiToken` CRUD + constraint/index
- `backend/auth.py` — `api_token` kind in `_authenticate`, `require_scope()` factory, `_authorize()`
- `backend/routers/tokens.py` — `/api/admin/tokens` (create/list/revoke/scopes)
- write endpoints (notes/library/ai/feature-flags/upload) re-gated onto scopes
- `frontend/src/app/admin/page.tsx` + `lib/api/tokens.ts` — admin UI (create form, scope checkboxes, one-time reveal, list+revoke)

## Deploy / rotation notes
- The deploy pipeline needs **no** token (backups over SSH, health checks are public/unauthenticated).
- A scripting/"deploy" token should be minted with the **tightest** scopes — e.g. `["library:write","notes:write"]` for the #297 importer + KB cleanups — **not** `admin:*`.
- API tokens are independent of `ADMIN_TOKEN`; prod sets `SESSION_SECRET` explicitly (#268), so rotating `ADMIN_TOKEN` is consequence-free.

## Verification
- Backend: **686** unit tests (41 new: pure core + integration incl. scope enforcement, expiry, revocation, dev-bypass on/off), mypy + ruff + bandit clean
- Frontend: **117** tests, `tsc` + `next lint` + prettier clean
- **Live end-to-end vs real Neo4j**: minted a `library:write` token via the dev bypass → library create `201`, notes create `403` (off-scope), revoke → `403`

Closes #300
Closes #291
Closes #292