### PR TITLE
feat(kb): color code blocks with Pygments monokai tokens (#298)

### DIFF
--- a/frontend/src/styles/_pygments-monokai.scss
+++ b/frontend/src/styles/_pygments-monokai.scss
@@ -1,0 +1,96 @@
+/**
+ * Monokai syntax-highlighting token colors for Pygments-rendered code blocks.
+ *
+ * GENERATED — do not hand-edit. The backend renders fenced code blocks with
+ * Pygments (HtmlFormatter style="monokai") in backend/core/markdown_renderer.py,
+ * emitting these token classes. This file colors them; without it every token
+ * renders in the flat container foreground (see #298).
+ *
+ * To regenerate after a renderer/Pygments change (drop the bare `.highlight`
+ * background and the `pre`/linenos rules — the container is styled in
+ * _rendered-markdown.scss and we don't render line numbers):
+ *   docker compose exec -T backend python -c \
+ *     "from core.markdown_renderer import get_pygments_css; print(get_pygments_css())"
+ */
+
+@mixin pygments-monokai {
+  .hll { background-color: #49483e; }
+  .c { color: #959077; } /* Comment */
+  .err { color: #ed007e; background-color: #1e0010; } /* Error */
+  .esc { color: #f8f8f2; } /* Escape */
+  .g { color: #f8f8f2; } /* Generic */
+  .k { color: #66d9ef; } /* Keyword */
+  .l { color: #ae81ff; } /* Literal */
+  .n { color: #f8f8f2; } /* Name */
+  .o { color: #ff4689; } /* Operator */
+  .x { color: #f8f8f2; } /* Other */
+  .p { color: #f8f8f2; } /* Punctuation */
+  .ch { color: #959077; } /* Comment.Hashbang */
+  .cm { color: #959077; } /* Comment.Multiline */
+  .cp { color: #959077; } /* Comment.Preproc */
+  .cpf { color: #959077; } /* Comment.PreprocFile */
+  .c1 { color: #959077; } /* Comment.Single */
+  .cs { color: #959077; } /* Comment.Special */
+  .gd { color: #ff4689; } /* Generic.Deleted */
+  .ge { color: #f8f8f2; font-style: italic; } /* Generic.Emph */
+  .ges { color: #f8f8f2; font-weight: bold; font-style: italic; } /* Generic.EmphStrong */
+  .gr { color: #f8f8f2; } /* Generic.Error */
+  .gh { color: #f8f8f2; } /* Generic.Heading */
+  .gi { color: #a6e22e; } /* Generic.Inserted */
+  .go { color: #66d9ef; } /* Generic.Output */
+  .gp { color: #ff4689; font-weight: bold; } /* Generic.Prompt */
+  .gs { color: #f8f8f2; font-weight: bold; } /* Generic.Strong */
+  .gu { color: #959077; } /* Generic.Subheading */
+  .gt { color: #f8f8f2; } /* Generic.Traceback */
+  .kc { color: #66d9ef; } /* Keyword.Constant */
+  .kd { color: #66d9ef; } /* Keyword.Declaration */
+  .kn { color: #ff4689; } /* Keyword.Namespace */
+  .kp { color: #66d9ef; } /* Keyword.Pseudo */
+  .kr { color: #66d9ef; } /* Keyword.Reserved */
+  .kt { color: #66d9ef; } /* Keyword.Type */
+  .ld { color: #e6db74; } /* Literal.Date */
+  .m { color: #ae81ff; } /* Literal.Number */
+  .s { color: #e6db74; } /* Literal.String */
+  .na { color: #a6e22e; } /* Name.Attribute */
+  .nb { color: #f8f8f2; } /* Name.Builtin */
+  .nc { color: #a6e22e; } /* Name.Class */
+  .no { color: #66d9ef; } /* Name.Constant */
+  .nd { color: #a6e22e; } /* Name.Decorator */
+  .ni { color: #f8f8f2; } /* Name.Entity */
+  .ne { color: #a6e22e; } /* Name.Exception */
+  .nf { color: #a6e22e; } /* Name.Function */
+  .nl { color: #f8f8f2; } /* Name.Label */
+  .nn { color: #f8f8f2; } /* Name.Namespace */
+  .nx { color: #a6e22e; } /* Name.Other */
+  .py { color: #f8f8f2; } /* Name.Property */
+  .nt { color: #ff4689; } /* Name.Tag */
+  .nv { color: #f8f8f2; } /* Name.Variable */
+  .ow { color: #ff4689; } /* Operator.Word */
+  .pm { color: #f8f8f2; } /* Punctuation.Marker */
+  .w { color: #f8f8f2; } /* Text.Whitespace */
+  .mb { color: #ae81ff; } /* Literal.Number.Bin */
+  .mf { color: #ae81ff; } /* Literal.Number.Float */
+  .mh { color: #ae81ff; } /* Literal.Number.Hex */
+  .mi { color: #ae81ff; } /* Literal.Number.Integer */
+  .mo { color: #ae81ff; } /* Literal.Number.Oct */
+  .sa { color: #e6db74; } /* Literal.String.Affix */
+  .sb { color: #e6db74; } /* Literal.String.Backtick */
+  .sc { color: #e6db74; } /* Literal.String.Char */
+  .dl { color: #e6db74; } /* Literal.String.Delimiter */
+  .sd { color: #e6db74; } /* Literal.String.Doc */
+  .s2 { color: #e6db74; } /* Literal.String.Double */
+  .se { color: #ae81ff; } /* Literal.String.Escape */
+  .sh { color: #e6db74; } /* Literal.String.Heredoc */
+  .si { color: #e6db74; } /* Literal.String.Interpol */
+  .sx { color: #e6db74; } /* Literal.String.Other */
+  .sr { color: #e6db74; } /* Literal.String.Regex */
+  .s1 { color: #e6db74; } /* Literal.String.Single */
+  .ss { color: #e6db74; } /* Literal.String.Symbol */
+  .bp { color: #f8f8f2; } /* Name.Builtin.Pseudo */
+  .fm { color: #a6e22e; } /* Name.Function.Magic */
+  .vc { color: #f8f8f2; } /* Name.Variable.Class */
+  .vg { color: #f8f8f2; } /* Name.Variable.Global */
+  .vi { color: #f8f8f2; } /* Name.Variable.Instance */
+  .vm { color: #f8f8f2; } /* Name.Variable.Magic */
+  .il { color: #ae81ff; } /* Literal.Number.Integer.Long */
+}

--- a/frontend/src/styles/_rendered-markdown.scss
+++ b/frontend/src/styles/_rendered-markdown.scss
@@ -8,6 +8,7 @@
 
 @use "@/styles/design-tokens" as *;
 @use "@/styles/mixins" as *;
+@use "@/styles/pygments-monokai" as *;
 
 @mixin rendered-markdown {
   @include text-secondary;
@@ -107,6 +108,10 @@
         line-height: 1.7;
       }
     }
+
+    // Pygments monokai token colors (#298). The container above is always
+    // dark, so these read in both light and dark site themes.
+    @include pygments-monokai;
   }
 
   // === TABLES ===


### PR DESCRIPTION
## Summary

Code blocks in articles/notes rendered monochrome, making them hard to read (#298). The backend already emitted Pygments token classes (`.k`, `.s`, `.nf`, …) in `html_content`, but the frontend only styled the `.highlight` container — nothing colored the tokens.

## Change

- Add `frontend/src/styles/_pygments-monokai.scss`, a generated partial with the monokai token colors (sourced from the backend's own `get_pygments_css()` so it can't drift from the renderer).
- `@include` it inside the `.highlight` block of the `rendered-markdown` mixin.

The code container is always dark (`$neutral-900`), so monokai reads correctly in both light and dark site themes.

## Verification

- Backend `GET /api/articles/13` `html_content` contains `<div class="highlight">` with token spans (`.c1`, `.k`, …).
- DOMPurify config already allows `class` on `span`/`div`/`pre`, so tokens survive sanitization.
- Monokai colors (`#66d9ef` etc.) confirmed present in the built article-page CSS bundle.

Fixes #298.